### PR TITLE
Fixes #409 black out on dev chrome

### DIFF
--- a/src/js/pages/proxy2.js
+++ b/src/js/pages/proxy2.js
@@ -57,7 +57,9 @@ $(function() {
         $('div').remove();
 
         // 背景を黒に
-        $('body').css('background-color', 'black');
+        $('body').css('background-color', 'black')
+            .css('width', '100%')
+            .css('height', '100%');
 
         // リサイズ周りの挙動
         $embedElement.css('position', 'absolute');


### PR DESCRIPTION
#409 について、私の環境でも同様の現象に悩まされていたので修正しました。

原因としては、embed 要素が absolute なので body が 0 x 0 になっているため描画されないようです。

Linux で、 version 37.0.2017.2 について動作確認をしています。
