### PR TITLE
#426 fix windows size on customized Windows desktop dpi scaling

### DIFF
--- a/src/js/Util.js
+++ b/src/js/Util.js
@@ -451,8 +451,9 @@ var Util = Util || {};
      */
     Util.adjustSizeOfWindowsOSImmediately = function(win) {
         if (Util.system.isWindows()) {
-            var diffWidth = win.outerWidth - win.innerWidth;
-            var diffHeight = win.outerHeight - win.innerHeight;
+            var ratio = (win.devicePixelRatio || 1);
+            var diffWidth = win.outerWidth - Math.ceil(win.innerWidth * ratio);
+            var diffHeight = win.outerHeight - Math.ceil(win.innerHeight * ratio);
             win.resizeTo(win.outerWidth + diffWidth, win.outerHeight + diffHeight);
         }
     };

--- a/src/js/pages/ships_status.js
+++ b/src/js/pages/ships_status.js
@@ -16,6 +16,11 @@ $(function(){
         Util.focusKCWidgetWindow();
     });
 
+    var ratio = 1;
+    if (Util.system.isWindows()) {
+        ratio = (win.devicePixelRatio || 1);
+    }
+
     setInterval(function(){
         chrome.runtime.sendMessage({
             purpose  : 'statusWindowPositionTracking',
@@ -24,8 +29,8 @@ $(function(){
                 left : window.screenLeft
             },
             size: {
-                width: window.innerWidth,
-                height: window.innerHeight
+                width: Math.ceil(window.innerWidth * ratio),
+                height: Math.ceil(window.innerHeight * ratio)
             }
         });
     }, 1 * 1000);


### PR DESCRIPTION
Windows のデスクトップ設定で DPI 設定が通常（100%）以外の時に，Chrome が window.innerWidth と window.outerWidth に異なる体系の値を設定してしまうため，ウィンドウサイズが色々と変になるのを修正しました．

Mac は Mac で，Retina 対応のために Chrome が window.devicePixelRatio を 2倍の率で扱っているくせに innner/outer が同じ値になるという変態実装なので，ひとまずこれらの変更は isWindows() の時しか発動しないようにしてます．
