### PR TITLE
fix window resize timing

### DIFF
--- a/src/js/Util.js
+++ b/src/js/Util.js
@@ -440,7 +440,7 @@ var Util = Util || {};
             return function() {
                 setTimeout(function() {
                     Util.adjustSizeOfWindowsOSImmediately(_win);
-                }, 100);
+                }, 250);
             };
         })(win);
     };


### PR DESCRIPTION
adjustSizeOfWindowsOSImmediately() のタイミングがディレイ 100ms だと，Chrome 37 において devicePixelRatio = 2.0 の時に係数の掛かっていない位置・サイズで情報取得されてしまうという（おそらく Chrome 側の）不具合があり，もう少しだけ余分にディレイすると現象の発生率が激減するので，ここ 250ms にしてみていただけませんか……？
