### PR TITLE
連合艦隊の編成キャプチャが生成されない件の修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "description": "「艦これ」をほどよく快適にたのしく遊べるようにするやつです",
   "permissions": [
     "tabs",
+    "storage",
     "downloads",
     "<all_urls>",
     "webRequest",

--- a/src/js/Applications/Background/Controllers/Message/Capture.ts
+++ b/src/js/Applications/Background/Controllers/Message/Capture.ts
@@ -27,8 +27,8 @@ export async function Screenshot(
   const area = message.rect ? rect.reframe(message.rect) : rect.game();
   const trimmed = ts.trim(area);
   if (message.open) {
-    const storage = new TempStorage();
-    WindowService.getInstance().openCapturePage({ key: storage.store("capture", trimmed) });
+    const key = await TempStorage.new().store(`capture_${Date.now()}`, trimmed);
+    WindowService.getInstance().openCapturePage({ key });
   }
   return {status: 202, uri: trimmed};
 }

--- a/src/js/Applications/Background/Controllers/Message/DamageSnapshot.ts
+++ b/src/js/Applications/Background/Controllers/Message/DamageSnapshot.ts
@@ -24,7 +24,7 @@ export async function DamageSnapshotCapture(message: {after: number; key: string
     Client.for(chrome.tabs, tab.id, false).message("/snapshot/show", { uri: trimmed, height: 25 });
     break;
   case DamageSnapshotType.Separate:
-    (new TempStorage()).store(`damagesnapshot_${key}`, trimmed);
+    TempStorage.new().store(`damagesnapshot_${key}`, trimmed);
     break;
   }
   return {status: 202, tabId: tab.id};

--- a/src/js/Applications/Background/Controllers/Request/Shipbuilding.ts
+++ b/src/js/Applications/Background/Controllers/Request/Shipbuilding.ts
@@ -68,7 +68,10 @@ export async function OnShipbuildingStartCompleted(req: DebuggableResponse) {
   const shipbuilding = Shipbuilding.new<Shipbuilding>({dock, time, text});
   shipbuilding.register(Date.now() + time);
 
-  if (DebugSetting.user().on) ws.openCapturePage({ key: TempStorage.new().store("debug", base64), info: JSON.stringify(shipbuilding) });
+  if (DebugSetting.user().on) {
+    const key = await TempStorage.new().store(`debug_${Date.now()}`, base64);
+    ws.openCapturePage({ key, info: JSON.stringify(shipbuilding) });
+  }
 
   const setting = NotificationSetting.find<NotificationSetting>(shipbuilding.kind());
   if (!setting.enabled) return { status: 202, shipbuilding };

--- a/src/js/Applications/Components/Capture/index.tsx
+++ b/src/js/Applications/Components/Capture/index.tsx
@@ -24,7 +24,7 @@ export default class CapturePage extends Component<{}, {
     };
     this.canvas = createRef<HTMLCanvasElement>();
   }
-  componentDidMount() {
+  async componentDidMount() {
     /**
      * 当初は、capture.htmlで chrome.runtime.onMessage を listen しようとしたが、
      * Chrome拡張ドメイン（chrome-extension://{ext_id}）において複数 runtime.onMessage
@@ -38,8 +38,7 @@ export default class CapturePage extends Component<{}, {
     // chrome.runtime.onMessage.addListener(router.listener());
     const search = new URLSearchParams(location.search);
     const key = search.get("key");
-    const temp = new TempStorage();
-    const uri = temp.draw(key);
+    const uri = await TempStorage.new().draw(key);
     // this.setState({ uri });
     this.drawImageURI(uri);
   }

--- a/src/js/Applications/Components/DamageSnapshot/index.tsx
+++ b/src/js/Applications/Components/DamageSnapshot/index.tsx
@@ -29,9 +29,8 @@ export default class DamageSnapshot extends Component<{}, {
    * それを引き出して表示する。
    * 初期化で使われた "count" に至れば、もうこれ以上同じことはしない。
    */
-  private renderImage() {
-    const temp = new TempStorage();
-    const uri = temp.draw(`damagesnapshot_${this.key}`);
+  private async renderImage() {
+    const uri = await TempStorage.new().draw(`damagesnapshot_${this.key}`);
     if (!uri) {
       return;
     }

--- a/src/js/Applications/Components/DeckCapture/index.tsx
+++ b/src/js/Applications/Components/DeckCapture/index.tsx
@@ -113,9 +113,7 @@ export default class DeckCaptureView extends Component<{}, {
     const { stack, selected: deckcapture } = this.state;
     const service = ComposeImageService.withStrategyFor(deckcapture);
     const composed = await service.compose(stack);
-    const storage = new TempStorage();
-    WindowService.getInstance().openCapturePage({
-      key: storage.store("capture", composed),
-    });
+    const key = await TempStorage.new().store(`deckcapture_${Date.now()}`, composed);
+    WindowService.getInstance().openCapturePage({ key });
   }
 }

--- a/src/js/Services/TempStorage.ts
+++ b/src/js/Services/TempStorage.ts
@@ -1,33 +1,49 @@
 
+/**
+ * TempStorage
+ * 大きめの画像URIなんかを一時的に保存、取り出しと同時に削除することを目的としたもの.
+ * とくにスクショ編集画面に画像URIを伝えるケースで使う.
+ * 当初はlocalStorageを使っていたが、localStorageでは"unlimitedStorage"の恩恵を受けないので、
+ * chrome.storage.localを使っている.
+ */
 export default class TempStorage {
 
-  constructor(private storage: Storage = localStorage) {}
+  constructor(private storage = chrome.storage.local) {}
 
   static new(): TempStorage {
     return new this();
   }
 
-  private get(key: string): string {
-    return this.storage.getItem(key);
+  private get(key: string): Promise<string> {
+    return new Promise(resolve => {
+      this.storage.get(items => {
+        resolve(items[key]);
+      });
+    });
   }
 
   private delete(key: string) {
-    return this.storage.removeItem(key);
+    return new Promise(resolve => {
+      this.storage.remove(key, () => resolve());
+    });
   }
 
-  store(prefix: string, value: string, expires = 60 * 1000): string {
-    const key = prefix + "_" + Date.now();
-    this.storage.setItem(key, value);
+  store(key: string, value: string, expires = 60 * 1000): Promise<string> {
     setTimeout(() => this.delete(key), expires);
-    return key;
+    return new Promise(resolve => {
+      this.storage.get(items => {
+        items[key] = value;
+        this.storage.set(items, () => resolve(key));
+      });
+    });
   }
 
   /**
    * 取得し、消す。
    */
-  draw(key: string): string {
-    const value: string = this.get(key);
-    if (value) {
+  async draw(key: string, clean = true): Promise<string> {
+    const value: string = await this.get(key);
+    if (!!value && clean) {
       this.delete(key);
     }
     return value;

--- a/tests/Applications/Background/Controllers/Message/Capture.spec.ts
+++ b/tests/Applications/Background/Controllers/Message/Capture.spec.ts
@@ -6,6 +6,8 @@ describe("CaptureControllers", () => {
   describe("ScreenshotController", () => {
     fake(chrome.tabs.query).callbacks([{}]);
     fake(chrome.tabs.captureVisibleTab).callbacks("data:image/png;base64,xxx");
+    fake(chrome.storage.local.get).callbacks({});
+    fake(chrome.storage.local.set).callbacks({});
     it("TODO: なんかアサーションする", async () => {
       const res = await Screenshot();
       expect(res.status).toBe(202);

--- a/tests/Services/TempStorage.spec.ts
+++ b/tests/Services/TempStorage.spec.ts
@@ -1,13 +1,18 @@
 import TempStorage from "../../src/js/Services/TempStorage";
+import { fake } from "../tools";
 
 describe("TempStorage", () => {
   describe("ひととおり", () => {
-    it("なんかする", () => {
+    it("なんかする", async () => {
+      const key = "my_key_123";
+      const val = "my_val_456";
+      fake(chrome.storage.local.get).callbacks({ [key]: val });
+      fake(chrome.storage.local.set).callbacks({ [key]: val });
       const storage = new TempStorage();
-      const key = storage.store("my_prefix", "THIS IS VALUE");
-      expect(key).toMatch(/^my_prefix_.+$/);
-      const value = storage.draw(key);
-      expect(value).toBe("THIS IS VALUE");
+      const genkey = await storage.store(key, val);
+      expect(genkey).toBe(key);
+      const value = await storage.draw(key);
+      expect(value).toBe(val);
     });
   });
 });


### PR DESCRIPTION
# 問題

- 連合艦隊の編成キャプチャをcomposeしてもcaptureが開かない

# 原因

- localStorageのquota exceeded

# 解決

- `chrome.storage.local`を使い、`unlimitedStorage`の効果を得る

# 参照

Fix #1126 