### PR TITLE
大破進撃防止窓撮影前の入力不検出ディレイを 8200ms → 8000ms に短縮

### DIFF
--- a/src/js/Applications/Context/Features/DamageSnapshot.ts
+++ b/src/js/Applications/Context/Features/DamageSnapshot.ts
@@ -12,7 +12,7 @@ export default class DamageSnapshot {
   private text: string; // なんか付随して表示する情報。おもにSortie.context()
   private clicked = 0;
 
-  private deactivatedMillisecFromBattleResulted = 8200; // 戦闘終了から「次」が登場するまでのミリ秒
+  private deactivatedMillisecFromBattleResulted = 8000; // 戦闘終了から「次」が登場するまでのミリ秒
 
   constructor(private scope: Window) {
     this.client = new Client(chrome.runtime);


### PR DESCRIPTION
fix #1213 