### PR TITLE
ゲーム窓サイズ設定の＋ボタンが反応しないことのある不具合の修正

### DIFF
--- a/src/js/Applications/Components/Options/Frames/index.tsx
+++ b/src/js/Applications/Components/Options/Frames/index.tsx
@@ -117,8 +117,8 @@ export default class FrameSettingView extends React.Component<{}, {
           />: <div className="columns add-btn-wrapper">
             <div className="column"></div>
             <div className="column col-auto">
-              <button className="btn btn-sm add-btn">
-                <FontAwesomeIcon icon={faPlus} onClick={() => this.setState({ addMode: true })} />
+              <button className="btn btn-sm add-btn" onClick={() => this.setState({ addMode: true })}>
+                <FontAwesomeIcon icon={faPlus} />
               </button>
             </div>
           </div>}


### PR DESCRIPTION
fix #1229

## 不具合の原因
button要素の下にあるiconのclickイベントに引っ掛けていたので、buttonの判定に吸われて発火しないことがあったと思われる

## 確認内容
 - [x] +ボタンが反応すること
![t](https://user-images.githubusercontent.com/8841932/95039560-15b33480-070c-11eb-9a38-7f23a002ac25.gif)
