### PR TITLE
海域名 (1-6, 7-2, 7-3) を追加

### DIFF
--- a/src/js/Applications/Models/Sortie/catalog.ts
+++ b/src/js/Applications/Models/Sortie/catalog.ts
@@ -32,6 +32,10 @@ const catalog: MapCatalog = {
         title: "鎮守府近海",
         extra: true,
       },
+      6: {
+        title: "鎮守府近海航路",
+        extra: true,
+      },
     },
   },
   2: {
@@ -143,6 +147,12 @@ const catalog: MapCatalog = {
     maps: {
       1: {
         title: "ブルネイ泊地沖",
+      },
+      2: {
+        title: "タウイタウイ泊地沖",
+      },
+      3: {
+        title: "ペナン島沖",
       },
     },
   },


### PR DESCRIPTION
海域名はwikiwikiから。

- 1-6 https://wikiwiki.jp/kancolle/%E9%8E%AE%E5%AE%88%E5%BA%9C%E6%B5%B7%E5%9F%9F#area6
- 7-2 https://wikiwiki.jp/kancolle/%E5%8D%97%E8%A5%BF%E6%B5%B7%E5%9F%9F#area2
- 7-3 https://wikiwiki.jp/kancolle/%E5%8D%97%E8%A5%BF%E6%B5%B7%E5%9F%9F#area3

## スクショ

### Before

<img width="1200" alt="7-3-before" src="https://user-images.githubusercontent.com/1213991/95167704-1c64a900-07eb-11eb-9031-30259737062f.png">

### After

<img width="1312" alt="7-3-after" src="https://user-images.githubusercontent.com/1213991/95167714-21c1f380-07eb-11eb-889b-de2341df62f9.png">
