### PR TITLE
運営電文仕様変更に合わせパディング値を修正

### DIFF
--- a/src/js/Applications/Context/DMM.ts
+++ b/src/js/Applications/Context/DMM.ts
@@ -81,7 +81,7 @@ export default class DMM {
     wrapper.style.justifyContent = "center";
     wrapper.style.zIndex = "1";
     // 動的なものはこれだけなので、これ以外はinjectに持っていってもいいかもしれない
-    wrapper.style.paddingTop = `${54 * zoom}px`;
+    wrapper.style.paddingTop = `${204 * zoom}px`;
   }
 
   private injectStyles() {


### PR DESCRIPTION
運営電文仕様変更に合わせパディング値を修正．

54 → 204 で現状大丈夫そうですがそもそもこの 54 がどこから来てるのかわからなかったので今後の仕様再変更やメッセージ枠サイズ変更でどうなるかは不明です．
変更が繰り返されるようなら設定から調節できるようにしたいですね．