### PR TITLE
fix(scss): osapi.scss の unquote() を string.unquote() に移行

### DIFF
--- a/src/injection/osapi.scss
+++ b/src/injection/osapi.scss
@@ -1,4 +1,6 @@
 /* This CSS is injected by KanColleWidget */
+@use "sass:string";
+
 html {
   overflow: hidden;
 }
@@ -33,13 +35,13 @@ body {
 // 縦長の場合
 @media (max-aspect-ratio: 1200/720) {
   #flashWrap {
-    transform: scale(unquote("calc(100vw / 1200px)")) !important;
+    transform: scale(string.unquote("calc(100vw / 1200px)")) !important;
   }
 }
 
 // 横長の場合
 @media (min-aspect-ratio: 1200/720) {
   #flashWrap {
-    transform: scale(unquote("calc(100vh / 720px)")) !important;
+    transform: scale(string.unquote("calc(100vh / 720px)")) !important;
   }
 }


### PR DESCRIPTION
## Summary

`src/injection/osapi.scss` で使われているグローバル `unquote()` が Dart Sass で非推奨（`global-builtin`、Dart Sass 3.0.0 で削除予定）になっており、ビルド時に deprecation 警告が出ていた。`@use "sass:string"` を追加し `string.unquote()` に移行して解消する。

挙動は不変（アスペクト比に応じた `#flashWrap` の `scale()`）。

## Changes

- `src/injection/osapi.scss`:
  - 先頭に `@use "sass:string";` を追加
  - `scale(unquote("calc(100vw / 1200px)"))` → `scale(string.unquote(...))`
  - `scale(unquote("calc(100vh / 720px)"))` → `scale(string.unquote(...))`

## Test Plan

- [x] [BUILD] `pnpm build` がエラーなく完了すること
- [x] [BUILD] ビルドログから `global-builtin`（unquote）の deprecation 警告が消えていること（修正前: 2件 → 修正後: 0件）
- [x] [LOGIC] コンパイル後の `dist/assets/osapi.css` に `transform:scale(calc(100vw/1200px))` / `transform:scale(calc(100vh/720px))` が出力され、挙動が変わっていないこと

## Verification

- `pnpm build` exit 0。
- `global-builtin` 警告: 修正後 **0 件**（`grep -c global-builtin` で確認）。
- 出力 CSS: `scale(calc(100vw/1200px))` / `scale(calc(100vh/720px))` を確認。

> 注: ログに残る `[import]`（Sass `@import` 非推奨）系の警告は別件の既存課題で、本 PR のスコープ外。