### PR TITLE
chore(recorder): live feed のログ形式を [ext:xxxxxxxx] 前置に変更

### DIFF
--- a/scripts/request-recorder-server.mjs
+++ b/scripts/request-recorder-server.mjs
@@ -52,7 +52,9 @@ const server = http.createServer((req, res) => {
       const record = JSON.parse(body);
       out.write(`${JSON.stringify(record)}\n`);
       // live feed: 受信を 1 行で stdout に出す（too の出力に流れる）。
-      process.stdout.write(`[recorder] ${record.method ?? "?"} ${record.path ?? "?"}${record.extId ? ` (ext:${record.extId.slice(0, 8)})` : ""}\n`);
+      // 送信元拡張を頭にラベル表示して grep しやすくする: `[ext:xxxxxxxx] POST /kcsapi/...`
+      const label = record.extId ? `[ext:${record.extId.slice(0, 8)}]` : "[recorder]";
+      process.stdout.write(`${label} ${record.method ?? "?"} ${record.path ?? "?"}\n`);
       res.writeHead(204).end();
     } catch (err) {
       process.stderr.write(`[recorder] failed to parse body: ${err}\n`);


### PR DESCRIPTION
## Summary

recorder サーバ（`scripts/request-recorder-server.mjs`）の live feed ログを、送信元拡張を頭にラベル表示する形式に変更する。実機ドッグフーディング（#1793 / PR #1794）でのフィードバック。

- 変更前: `[recorder] POST /kcsapi/api_start2/get_option_setting (ext:lbmaokgj)`
- 変更後: `[ext:lbmaokgj] POST /kcsapi/api_start2/get_option_setting`

ext を頭に出すことで `too` の `[node]` ラベルと合わせて `[node] [ext:xxxxxxxx] ...` となり、送信元での grep がしやすくなる。`extId` が無い場合は従来どおり `[recorder]` をラベルにフォールバック。

## Changes

- `scripts/request-recorder-server.mjs`: stdout の live feed 1 行を `${label} ${method} ${path}`（`label = [ext:<id8>]` or `[recorder]`）に変更。JSONL 出力・HTTP 挙動は不変。

## Test Plan

- [x] [LOGIC] `POST /record` 受信時の stdout 行が `[ext:lbmaokgj] POST /kcsapi/api_start2/get_option_setting` 形式になること（サーバ smoke で確認）
- [x] [BUILD] `pnpm typecheck` が通ること
- [ ] [MANUAL] `pnpm start` 実プレイで `[node] [ext:xxxxxxxx] POST /kcsapi/...` が live 表示されること

## Verification

- サーバ smoke: ダミー POST → stdout 行が期待形式と完全一致を確認。
- JSONL 追記・HTTP 204 は従来どおり（ログ表示のみの変更）。