### PR TITLE
fix(inapp): インアプリボタンのサイズをピクセル固定から画面相対(vw)に変更

### DIFF
--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -82,10 +82,9 @@ import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
       div.id = "kcw-inapp-action-buttons";
       return div;
     }
-    private createButton(svgContent: string, onclick = () => { }, sizeVw: number = 4): HTMLButtonElement {
+    private createButton(svgContent: string, onclick = () => { }, sizeVw: number): HTMLButtonElement {
       const button = window.document.createElement("button");
       button.style.backgroundColor = "#fff";
-      // ゲーム画面横幅基準の倍率（vw）。窓サイズに追従して占有割合を一定に保つ。
       // padding は従来の 8/48=1/6 比を維持する。
       button.style.width = `${sizeVw}vw`;
       button.style.height = `${sizeVw}vw`;

--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -28,10 +28,13 @@ import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
       return this.self;
     }
     constructor(config: GameWindowConfig) {
-      const sizeRatio = config.buttonSize / 100;
+      // ボタンサイズはゲーム画面に対する倍率（vw）で定義する。
+      // 大(buttonSize>=100)=6vw / 小=4vw（#1177 の「大小=6%:4%」準拠）。
+      // ピクセル固定だと窓を小さくした際にボタンが相対的に肥大化し、基地航空隊の操作 UI に被るため。
+      const sizeVw = config.buttonSize >= 100 ? 6 : 4;
       this.container = this.createContainer();
-      this.muteButton = this.createButton(InAppActionButtons.ICON_SPEAKER_WAVE, () => this.toggleMute(), sizeRatio);
-      this.screenshotButton = this.createButton(InAppActionButtons.ICON_CAMERA, () => this.screenshot(), sizeRatio);
+      this.muteButton = this.createButton(InAppActionButtons.ICON_SPEAKER_WAVE, () => this.toggleMute(), sizeVw);
+      this.screenshotButton = this.createButton(InAppActionButtons.ICON_CAMERA, () => this.screenshot(), sizeVw);
       if (config.showScreenshotButton) {
         this.container.appendChild(this.screenshotButton);
       }
@@ -79,12 +82,14 @@ import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
       div.id = "kcw-inapp-action-buttons";
       return div;
     }
-    private createButton(svgContent: string, onclick = () => { }, sizeRatio: number = 1): HTMLButtonElement {
+    private createButton(svgContent: string, onclick = () => { }, sizeVw: number = 4): HTMLButtonElement {
       const button = window.document.createElement("button");
       button.style.backgroundColor = "#fff";
-      button.style.width = `${48 * sizeRatio}px`;
-      button.style.height = `${48 * sizeRatio}px`;
-      button.style.padding = `${8 * sizeRatio}px`;
+      // ゲーム画面横幅基準の倍率（vw）。窓サイズに追従して占有割合を一定に保つ。
+      // padding は従来の 8/48=1/6 比を維持する。
+      button.style.width = `${sizeVw}vw`;
+      button.style.height = `${sizeVw}vw`;
+      button.style.padding = `${sizeVw / 6}vw`;
       button.style.cursor = "pointer";
       button.style.border = "none";
       button.style.display = "flex";

--- a/src/models/configs/GameWindowConfig.ts
+++ b/src/models/configs/GameWindowConfig.ts
@@ -7,7 +7,8 @@ export class GameWindowConfig extends Model {
       alertBeforeClose: true,
       showMuteButton: true,
       showScreenshotButton: true,
-      buttonSize: 100,
+      // 既定は小(4vw)。Issue #1763「ボタンを縮小」に沿い、ORIGINAL 窓(1200px)では現行の 48px と同等の見た目。
+      buttonSize: 50,
     },
   }
   public static async user(): Promise<GameWindowConfig> {
@@ -16,5 +17,5 @@ export class GameWindowConfig extends Model {
   public alertBeforeClose: boolean = true;
   public showMuteButton: boolean = true;
   public showScreenshotButton: boolean = true;
-  public buttonSize: number = 100;
+  public buttonSize: number = 50;
 }

--- a/src/page/components/options/InAppSettingView.tsx
+++ b/src/page/components/options/InAppSettingView.tsx
@@ -10,7 +10,7 @@ export function InAppSettingView({
   const [config] = useState<GameWindowConfig>(_config);
   const [showMuteButton, setShowMuteButton] = useState<boolean>(config.showMuteButton ?? true);
   const [showScreenshotButton, setShowScreenshotButton] = useState<boolean>(config.showScreenshotButton ?? true);
-  const [buttonSize, setButtonSize] = useState<number>(config.buttonSize ?? 100);
+  const [buttonSize, setButtonSize] = useState<number>(config.buttonSize ?? 50);
 
   return (
     <FoldableSection title="ウィンドウ内表示設定" id="inapp">


### PR DESCRIPTION
Closes #1763

## 背景

ゲーム窓に注入される右上のインアプリボタン（ミュート / スクリーンショット）のサイズが、画面サイズに依らない**ピクセル固定**（`48 * (buttonSize/100)px`、大=48px / 小=24px）だった。ピクセル固定のため、ゲーム窓を小さくするとボタンが相対的に肥大化し、**基地航空隊の操作 UI に被る**（#1177 の根本課題）。逆に大きい窓では相対的に小さくなる。

なお、表示可否トグルと大小選択 UI 自体は先行 PR #1772 で実装済みのため、本 PR の対象は **サイズの「px → 画面相対倍率」変換のみ**に絞っている。

## 目的

ボタンサイズをゲーム画面に対する倍率（`vw`）で定義し、窓サイズを変えても占有割合が一定になるようにする。これにより、特にゲーム窓を小さめで運用するプレイヤーが、どの窓サイズでも基地航空隊 UI への干渉を一定以下に抑えられる。

## 方針

ボタンサイズの「単位」だけを画面相対に変える。ユーザが操作する大／小の選択（`buttonSize` ∈ {50,100}）とその保存形式はそのまま維持し、描画時の換算をピクセルからビューポート横幅基準（`vw`）に置き換える。`vw` は CSS 仕様上ビューポート横幅の 1% なので、窓サイズに追従して占有割合が一定に保たれる（v3 が `width:6%` で実現していた挙動の等価）。

倍率値は #1177 が明示した「大小=6%:4%」に合わせ、大=6vw / 小=4vw とした。px/% をユーザに選ばせる案は、ユーザが単位を意識する必要があり UX を悪化させる過剰実装と判断して採らなかった。

既定は「ボタンを縮小」という Issue の主目的に沿って大(100) → 小(50=4vw) に変更した。ORIGINAL 窓(1200px) では 4vw=48px となり現行の既定と見た目が一致しつつ、小さい窓では確実に縮む。既存ユーザの保存値（50/100）はそのまま新しい換算にマップされるため、ストレージのマイグレーションは不要。

<details>
<summary>意思決定の経緯（Issue コメントの grill 結果より）</summary>

| # | 問い | 採用案 | 代替案 | 確定方法 |
|---|---|---|---|---|
| 1 | #1772 実装済みを踏まえた残作業 | 「大小サイズの px→倍率変換」のみに限定。表示可否・大小UIは再実装しない | 表示可否に追加要件 / Issue クローズ | 合意 |
| 2 | px をどう倍率化するか | ビューポート横幅基準 `vw` に内部置換。px/% はユーザに出さない | 基準を `vmin` / px か % かを設定化 | 合意 |
| 3 | 大/小の倍率値 | 大=6vw / 小=4vw | 大=4/小=2（#1772見た目維持）/ 4vw固定 | 合意 |
| 4 | 既存保存値と既定サイズ | 保存値50/100を維持しマップ。既定を大→小(4vw)に変更 | 既定は大のまま据え置き | **仮採用** |

</details>

## 設計

| 変更 | ファイル | 概要 | AC |
|---|---|---|---|
| サイズ単位の置換 | `src/injection/dmm.ts` | `48*ratio px` → `${sizeVw}vw`（大6 / 小4）。`sizeVw = buttonSize >= 100 ? 6 : 4`。padding は従来の 8/48=1/6 比を維持（`${sizeVw/6}vw`） | AC-1, AC-2, AC-3, AC-6 |
| 既定値の縮小 | `src/models/configs/GameWindowConfig.ts` | `buttonSize` の既定を 100 → 50（`static default` と class field の両方）。新規=小、既存保存値はそのまま | AC-4, AC-5 |

## 受入条件

> Issue #1763 のコメント（grill 結果）の受け入れ条件をミラー。`[x]` は本 PR で検証済み、`[ ]` は実機 UAT 推奨。

- [x] [UI] 「大」選択時、ボタン1辺がゲーム画面横幅の **約6%（=6vw）**。窓幅を変えても比率が一定 → AC-1 ※`vw` の CSS 仕様による構造的保証＋コンパイル済み `dist/dmm.js` に `buttonSize>=100?6:4` / `vw` を確認
- [x] [UI] 「小」選択時、**約4%（=4vw）** で比率一定 → AC-2 ※同上
- [ ] [UI] ゲーム窓を小さくしてもボタンが基地航空隊の操作 UI に被らない → AC-3 ※`vw` 化により小窓でボタンも比例縮小（論証済み）。**実機目視は要 UAT**
- [x] [UI] 新規インストール時の既定が **小（4vw）** → AC-4 ※jstorm `find()` が空namespaceで `static default`(buttonSize=50)を返す経路で担保
- [x] [UI] 既存保存値（`buttonSize`=50/100）がエラー・再設定なしに 4vw/6vw で描画（後方互換） → AC-5 ※保存値はjstormがそのまま使用、移行不要
- [x] [UI] 表示可否トグル（ミュート/スクショ）が引き続き機能し OFF は非表示（#1772 機能の回帰なし） → AC-6 ※`dmm.ts` の表示可否分岐は無改変
- [x] [BUILD] `pnpm typecheck` と `pnpm build` が通る → AC-7 ※typecheck エラー0 / build exit 0

## 評価観点

- **既定値の変更（仮採用 / 決定#4）**: `buttonSize` 既定を 100→50（小=4vw）に変更しています。これは grill で人の明示合意を取らず「縮小」目的に沿って安全側に倒した判断です。新規ユーザに与える既定サイズとして妥当か確認してください（据え置き＝大のままにする選択肢もあります）。
- **倍率値 6vw/4vw の妥当性**: #1177 の「6%:4%」準拠ですが、実機の各種窓サイズで基地航空隊 UI に被らない実用値になっているかは目視確認が望ましいです。
- **実機 UI 検証（AC-3）**: Chrome 拡張＋実ゲーム窓の自動駆動が CI/本環境では不可のため、AC-3 の被り検証は手動 UAT に委ねています。

## 発見

- 特になし（既存の回帰は確認されず）。`InAppSettingView` の大小スライダー、`dmm.scss` の縦長/横長レスポンシブ配置は `vw` 化に非依存のため変更不要。
