### PR TITLE
fix(damage-snapshot): 出撃開始時に連戦数をリセットし窓の交戦数+1を防止

### DIFF
--- a/src/models/Logbook.ts
+++ b/src/models/Logbook.ts
@@ -42,6 +42,12 @@ export class SortieContext extends Model {
     this.started = Date.now();
     this.deck = deck;
     this.map = map;
+    // 新規出撃は必ず連戦数 0 から始める。通常は onPort→Logbook.record() が _context を
+    // null 化するので不要だが、母港(/api_port/port)を挟まず onMapStart が再度走る異常系
+    // （Service Worker のライフサイクル境界・port イベント取りこぼし等）で前出撃の battles/
+    // cells が持ち越されて連戦数が +1 されるのを防ぐ二重防御（#1367）。
+    this.cells = [];
+    this.battles = [];
   }
 
   public next(cell: string) {

--- a/tests/sortie-counting.spec.ts
+++ b/tests/sortie-counting.spec.ts
@@ -56,4 +56,21 @@ describe("SortieContext 連戦数カウント", () => {
     expect(ctx.battles.length).toBe(4);
     expect(ctx.battles.filter((b) => b.midnight).length).toBe(2);
   });
+
+  it("前出撃の戦闘が残った状態で start() すると連戦数が 0 にリセットされる(#1367)", () => {
+    const ctx = new SortieContext();
+    // 前の出撃で戦闘・マス移動が記録された状態を作る
+    ctx.next("1");
+    ctx.battle.start("1");
+    ctx.battle.start("1");
+    expect(ctx.battles.length).toBe(2);
+    expect(ctx.cells.length).toBe(1);
+    // 母港(/api_port/port)を挟まず次の出撃が始まっても、新規出撃は連戦数 0 から始まる
+    ctx.start("2", { area: "2", info: "2" });
+    expect(ctx.battles.length).toBe(0);
+    expect(ctx.cells.length).toBe(0);
+    // 初手の戦闘で連戦数は 1 から始まる
+    ctx.battle.start("1");
+    expect(ctx.battles.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #1367

## 背景

「大破進撃防止窓」の進撃中海域情報に表示される連戦数（交戦数）が、実際より +1 されることがある——という 2021 年（v3.2.40）からの報告。当時の主症状は「初手が非戦闘マス（空襲・渦潮・戦闘なし）の海域に出撃すると連戦数が 2 から始まる」で、4-5 等で 100% 再現していた。連戦数を頼りに進撃／撤退を判断するプレイヤーが、誤った戦数表示で判断を誤る。

連戦数機能は `#1764`（PR #1796）でゼロから再設計され、連戦数は「マス進行」ではなく「実戦闘回数（`battles[]` の長さ）」で数えるようになった。非戦闘マスは `cells[]` にしか積まれないため、**元の主症状は構造的に解消済み**（回帰テスト `tests/sortie-counting.spec.ts` が担保）。

しかし、最後のコメント（2021-06-14）が示す「初手が戦闘マスなのに間欠的に +1（再現せず）」は別系統の潜在ギャップに由来する。`SortieContext.start()` が `cells[]`/`battles[]` をリセットせず、母港（`/api_port/port`）を挟まず `onMapStart` が再度走る異常系で前出撃の戦闘が持ち越されると、新規出撃の連戦数が >1 から始まりうる。

## 目的

連戦数を進撃判断に使う全プレイヤーが、いかなる出撃遷移でも「実際の戦闘回数と一致する連戦数（初回戦闘で必ず `(1)`）」を得られるようにする。

## 方針

「新規出撃は必ず連戦数 0 から始まる」を、`onPort`→`Logbook.record()` の context null 化に**暗黙に依存する**現状から、`SortieContext.start()` 自身が**明示的に保証する不変条件**へ格上げする（二重防御）。通常フローでは無害な変更だが、Service Worker のライフサイクル境界や port イベント取りこぼしといった「母港を挟まない異常系」での stale state 持ち越しを根本から塞ぐ。元の主症状そのものは再設計済みで再現しないため、本 PR は最小の防御 + 回帰テストに留める。

<details>
<summary>意思決定（grill の監査証跡）</summary>

| # | 問い | 採用案 | 代替案 | 根拠 | 確定方法 |
|---|---|---|---|---|---|
| 1 | 原因が消えた #1367 の決着 | #1764 で主症状は解消済みと判定し、潜在ギャップを塞ぐ防御＋回帰テストを入れて close | 即 close / 実機追加調査 | 非戦闘マスは `battles[]` を触らず回帰テスト済。2-1 間欠 over-count は潜在ギャップで説明可 | 合意 |
| 2 | `start()` 未リセットを塞ぐか | `cells`/`battles` の空配列リセットを追加し不変条件を明示化 | `onPort` の null リセットに依存し続ける | 異常系で stale battles 持ち越し +1、修正は最小＋安全側 | 合意 |
| 3 | 検証方法 | ユニットテスト（`[LOGIC]`）で固定 | 実機 UAT（`[UI]`） | 実機は海域/イベント依存でフレーキー、ロジックは決定的に固定可 | 合意 |

</details>

## 設計

| 種別 | 変更 | 充足 AC |
|---|---|---|
| 修正 | `src/models/Logbook.ts` — `SortieContext.start()` に `this.cells = []; this.battles = [];` を追加（背景コメント付き） | AC-1 |
| 追加 | `tests/sortie-counting.spec.ts` — 前出撃の戦闘が残った状態で `start()` すると連戦数が 0 に戻る回帰テスト | AC-1 / AC-2 |

## 受入条件

- [x] [LOGIC] 前出撃の戦闘が残った `SortieContext` で `start()` を呼ぶと `battles.length===0` かつ `cells.length===0` に戻る → AC-1 ✅
- [x] [LOGIC] 初手が非戦闘マスでも連戦数は 1 から始まる（既存 `sortie-counting.spec.ts` の回帰として維持）→ AC-2 ✅
- [x] [BUILD] `pnpm typecheck` と `pnpm test` が通過する → AC-3 ✅（typecheck OK・test 29 passed・lint clean）

## 評価観点

- `start()` での配列リセットは「同一 `SortieContext` インスタンスが port を挟まず再 start される」異常系を想定した二重防御。通常フローでは `onPort`→`record()` が context を null 化するため到達しないが、この防御位置（`start()` 内）が最も素直か、それとも `onMapStart` 側で明示的に新 context を作る方が良いか、レビュー観点として提示する。
- 連合艦隊の開幕夜戦（`onCombinedSpMidnightBattleStarted`）は実データ未観測の予防実装（#1764 の TODO）。本 PR のリセットとは独立だが、連戦数カウント全体の正しさはイベント期間中の実機観測で最終確認が必要。

## 発見

特になし（既存テスト 29 件は全て pass、回帰なし）。
