### PR TITLE
fix(damage-snapshot): 連合艦隊キャプチャの連打を最小間隔デバウンスで防止

### DIFF
--- a/src/injection/osapi.ts
+++ b/src/injection/osapi.ts
@@ -71,8 +71,17 @@
     private count: number = 1; // 何回クリックされたらリセットするか
     private timestamp: number = 0; // drawする画像のkey
     private clicked: number = 0; // 何回クリックされたか
+    private lastClickedAt: number = 0; // 直近で capture を登録した時刻（連打デバウンス用 #1262）
+    private ignoreMillisecBetweenClicks = 800; // この間隔内の連打クリックは capture を無視する（#1262）
     private listener: (a: unknown) => unknown = () => { };
     private onClickNext() {
+      // 素早い連打（ダブルクリック相当）だと、画面が第二艦隊へ進む前に2発目が走り、同じ第一艦隊を
+      // 二重キャプチャして連合艦隊の第二艦隊を取りこぼす（#1262）。直近の登録クリックから一定時間内の
+      // クリックは capture 送信をスキップして防ぐ。ゲーム画面へのクリック自体は阻害しない（mousedown は
+      // 観測のみで preventDefault しない）ため、画面進行後の正規の再クリックは第二艦隊として通る。
+      const now = Date.now();
+      if (now - this.lastClickedAt < this.ignoreMillisecBetweenClicks) return;
+      this.lastClickedAt = now;
       chrome.runtime.sendMessage(chrome.runtime.id, {
         action: "/damage-snapshot/capture", after: 1000 + (800 * this.clicked), timestamp: this.timestamp,
       })
@@ -83,6 +92,7 @@
     }
     private reset() {
       this.clicked = 0;
+      this.lastClickedAt = 0;
       this.canvas?.removeEventListener("mousedown", this.listener);
     }
     private createContainer(label?: string | null): HTMLDivElement {


### PR DESCRIPTION
Closes #1262

## 背景

連合艦隊編成時、戦闘終了後に大破進撃防止窓（damage-snapshot）へ艦隊状況を取り込む際、ゲーム画面を**素早く2連打**すると第二艦隊が撮影されず、第一艦隊だけが取り込まれる（実質「第一艦隊しかキャプチャできなかった」）ことがしばしば発生していた。

## 目的

連合艦隊でも、素早い連打（ダブルクリック相当）によって第二艦隊が取りこぼされないようにする。通常艦隊（1枚取り）の動作には影響を与えない。

## 原因

- 戦闘終了時に `dsnapshot:prepare({count, timestamp})` を送る。通常艦隊は `count:1`（`src/controllers/WebRequest/index.ts:72`）、連合艦隊は `count:2`（`src/controllers/WebRequest/index.ts:79`）。
- `src/injection/osapi.ts` の `onClickNext()` が click ごとに `/damage-snapshot/capture` を送信して `clicked++`、`count <= clicked` でリスナ解除する。連合艦隊は「1クリック目=第一艦隊／画面進行後の2クリック目=第二艦隊」を撮る2段取り。
- 既存ガード `ignoreMillisecFromBattleResulted = 7800`（`osapi.ts:67`）は「戦闘終了〜"次"出現」までの待ち用で、**クリック間隔（連打）のガードが無かった**。
- そのため、画面が第二艦隊へ進む前に2連打すると両クリックとも第一艦隊を撮り、`clicked` が `count(2)` に達してリスナ解除され、第二艦隊が撮れなかった。

## 方針

`src/injection/osapi.ts` の `onClickNext()` に**最小間隔デバウンス**を導入。直近で capture を登録した時刻 `lastClickedAt` を保持し、`ignoreMillisecBetweenClicks`（=800ms）以内のクリックは capture 送信をスキップ（`clicked` も進めない）。修正の責務はクリック源である content script に置く（Service Worker は idle で状態が揮発しグローバル変数を持てない / CLAUDE.md）。

- ゲーム画面へのクリック自体は阻害しない（`mousedown` は観測のみで `preventDefault` しない）。抑制するのは capture 送信だけなので、画面進行後の意図的な再クリックは第二艦隊として正しく通る。
- `clicked` を進める全クリックに一律適用（`count:1` の通常艦隊でも無害、実質効くのは連合艦隊）。
- `reset()` で `lastClickedAt` も初期化し、次戦闘へ状態を持ち越さない。

## 設計

| 変更 | ファイル | 概要 | AC |
|---|---|---|---|
| 連打デバウンス | `src/injection/osapi.ts` | `lastClickedAt` / `ignoreMillisecBetweenClicks(=800)` を追加。`onClickNext()` 冒頭で `Date.now() - lastClickedAt < 800` なら即 return。`reset()` で `lastClickedAt` を初期化 | AC-1〜AC-4 |

<details>
<summary>意思決定の経緯（Issue #1262 の grill 結果より）</summary>

| # | 問い | 採用案 | 代替案 | 確定方法 |
|---|---|---|---|---|
| 1 | 連打時の機構 | 最小間隔デバウンス | 報告者案「窓表示まで2枚目を完全拒否」（連合艦隊の第二艦隊が永久に撮れず機能後退） | 合意 |
| 2 | デバウンス閾値 | 800ms | 1000ms / 1500ms | 合意 |
| 3 | 実装箇所 | `osapi.ts`（content script） | `Message.ts`（SWは状態揮発） | 合意 |
| 4 | 適用範囲 | 全クリック一律 | count>=2 時のみ | 合意 |

</details>

## 受入条件

> Issue #1262 の受け入れ条件をミラー。`[x]` は本 PR で検証済み、`[ ]` は実機 UAT 推奨。

- [x] [BUILD] `pnpm typecheck` と `pnpm build` が通る → AC-1 ※typecheck exit 0 / build exit 0、`dist/osapi.js` に `lastClickedAt`/`ignoreMillisecBetweenClicks`/`800` を確認
- [ ] [MANUAL] 6-5 ボスマスで戦闘終了後、画面を**素早く2連打**しても第二艦隊が取りこぼされない → AC-2 ※Chrome拡張＋実ゲームの自動駆動不可のため**要 実機 UAT**
- [ ] [MANUAL] 連合艦隊で**間隔を空けて**（800ms 以上）2回クリックすれば従来どおり第一・第二艦隊が1枚ずつ取り込まれる → AC-3 ※**要 実機 UAT**
- [ ] [MANUAL] 通常艦隊（1枚取り）が従来どおり動作する（一律適用による退行が無い） → AC-4 ※**要 実機 UAT**

## 評価観点

- **デバウンス閾値 800ms の妥当性**: 人間のダブルクリック/連打を吸収しつつ、画面進行後の正規の再クリック（連合艦隊の第二艦隊）を弾かない値として 800ms を採用。実機の画面進行タイミングに対して短すぎ（取りこぼし）/長すぎ（正規操作を弾く）でないかは実機 UAT で確認推奨。
- **検証経路（AC-2〜4）**: 自軍連合艦隊出撃はイベント海域限定だが、6-5 ボスマスは敵連合艦隊判定により防止窓が連合艦隊処理（`count:2`）になるため擬似検証可能（Issue コメント情報）。Chrome 拡張＋実ゲームのため UAT は手動。

## 発見

- 特になし（既存の回帰は確認されず）。修正はクリック源のため表示モード（INAPP / SEPARATE）双方に効く。
