### PR TITLE
feat(popup): 前回選択した画面サイズ(Frame)を初期選択として記憶する

### DIFF
--- a/src/models/configs/GameWindowConfig.ts
+++ b/src/models/configs/GameWindowConfig.ts
@@ -9,6 +9,9 @@ export class GameWindowConfig extends Model {
       showScreenshotButton: true,
       // 既定は小(4vw)。Issue #1763「ボタンを縮小」に沿い、ORIGINAL 窓(1200px)では現行の 48px と同等の見た目。
       buttonSize: 50,
+      // ポップアップで最後に選択（起動）した Frame の id を記憶し、次回の初期選択にする（#1236）。
+      // 既定は "__memory__"（従来挙動）。指定 Frame が存在しない場合は表示側で MEMORY にフォールバックする。
+      lastSelectedFrameId: "__memory__",
     },
   }
   public static async user(): Promise<GameWindowConfig> {
@@ -18,4 +21,5 @@ export class GameWindowConfig extends Model {
   public showMuteButton: boolean = true;
   public showScreenshotButton: boolean = true;
   public buttonSize: number = 50;
+  public lastSelectedFrameId: string = "__memory__";
 }

--- a/src/models/popupDefaultFrame.ts
+++ b/src/models/popupDefaultFrame.ts
@@ -1,0 +1,17 @@
+// ポップアップの初期選択 Frame を解決するロジック（#1236）。
+// 「最後に選択（起動）した Frame を次回の初期選択にする」を実現するが、保存していた Frame が
+// 削除されている等で現在の一覧に無い場合は MEMORY にフォールバックする。
+// loader (src/page/**) は coverage 除外なので、テスト可能な純粋関数としてここに切り出している。
+
+export const MEMORY_FRAME_ID = "__memory__";
+
+/**
+ * 保存された既定 Frame id が現在の Frame 一覧に存在すればそれを返し、
+ * 存在しなければ MEMORY（`__memory__`）にフォールバックする。
+ *
+ * @param frameIds 現在選択肢として並ぶ Frame の id 一覧
+ * @param savedId  前回ポップアップで選択（起動）した Frame の id
+ */
+export function resolveDefaultFrameId(frameIds: string[], savedId: string): string {
+  return frameIds.includes(savedId) ? savedId : MEMORY_FRAME_ID;
+}

--- a/src/page/PopupPage.tsx
+++ b/src/page/PopupPage.tsx
@@ -1,6 +1,7 @@
 import { useLoaderData } from "react-router-dom"
 import { Launcher } from "../services/Launcher"
 import { type Frame } from "../models/Frame"
+import { GameWindowConfig } from "../models/configs/GameWindowConfig"
 
 import { useState, type ReactNode } from "react";
 import { ClockIcon, SquaresPlusIcon, Cog6ToothIcon, BookOpenIcon } from "@heroicons/react/24/outline";
@@ -18,11 +19,20 @@ function ShortCutIcon({icon, title, action}: {
 }
 
 export function PopupPage() {
-  const { frames } = useLoaderData() as { frames: Frame[] }
-  const [selectedId, selectId] = useState<string>("__memory__");
+  const { frames, defaultFrameId } = useLoaderData() as { frames: Frame[]; defaultFrameId: string }
+  // 前回起動した Frame を初期選択として復元する（#1236）。
+  const [selectedId, selectId] = useState<string>(defaultFrameId);
 
   const openFrame = async (frameId?: string) => {
     if (typeof chrome === "undefined" || !chrome.runtime?.id) return;
+    // 起動した Frame を次回ポップアップの初期選択として記憶する（#1236）。
+    if (frameId) {
+      try {
+        await (await GameWindowConfig.user()).update({ lastSelectedFrameId: frameId });
+      } catch (error) {
+        console.error("lastSelectedFrameId の保存に失敗しました", error);
+      }
+    }
     try {
       await chrome.runtime.sendMessage<
         { action: string; frame_id?: string },

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -59,8 +59,16 @@ export async function options() {
 }
 
 export async function popup() {
+  const frames = await Frame.list();
+  // 前回ポップアップで選択（起動）した Frame を初期選択として復元する（#1236）。
+  // 保存IDが現在の Frame 一覧に無い（削除済み等）場合は MEMORY にフォールバックする。
+  const game = await GameWindowConfig.user();
+  const defaultFrameId = frames.some((f) => f._id === game.lastSelectedFrameId)
+    ? game.lastSelectedFrameId
+    : "__memory__";
   return {
-    frames: await Frame.list(),
+    frames,
+    defaultFrameId,
   };
 }
 

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -1,4 +1,5 @@
 import { Frame } from "../../models/Frame";
+import { resolveDefaultFrameId } from "../../models/popupDefaultFrame";
 import Queue from "../../models/Queue";
 import note from "../../release-note.json"
 import { ReleaseNoteObject } from "../components/options/DevelopmentInfoView";
@@ -61,11 +62,9 @@ export async function options() {
 export async function popup() {
   const frames = await Frame.list();
   // 前回ポップアップで選択（起動）した Frame を初期選択として復元する（#1236）。
-  // 保存IDが現在の Frame 一覧に無い（削除済み等）場合は MEMORY にフォールバックする。
+  // 解決ロジック（削除済みIDのフォールバック含む）は resolveDefaultFrameId に切り出してテストしている。
   const game = await GameWindowConfig.user();
-  const defaultFrameId = frames.some((f) => f._id === game.lastSelectedFrameId)
-    ? game.lastSelectedFrameId
-    : "__memory__";
+  const defaultFrameId = resolveDefaultFrameId(frames.map((f) => f._id!), game.lastSelectedFrameId);
   return {
     frames,
     defaultFrameId,

--- a/tests/popup-default-frame.spec.ts
+++ b/tests/popup-default-frame.spec.ts
@@ -1,0 +1,35 @@
+import { expect, describe, it } from "vitest";
+
+import { resolveDefaultFrameId, MEMORY_FRAME_ID } from "../src/models/popupDefaultFrame";
+import { GameWindowConfig } from "../src/models/configs/GameWindowConfig";
+
+describe("resolveDefaultFrameId", () => {
+  const frameIds = ["__memory__", "__original__", "__classic__", "user-1234"];
+
+  it("保存IDが一覧に存在すればそれを返す", () => {
+    expect(resolveDefaultFrameId(frameIds, "__classic__")).toBe("__classic__");
+    expect(resolveDefaultFrameId(frameIds, "user-1234")).toBe("user-1234");
+  });
+
+  it("保存IDが一覧に無ければ MEMORY にフォールバックする（削除済みID対策）", () => {
+    expect(resolveDefaultFrameId(frameIds, "user-deleted")).toBe("__memory__");
+  });
+
+  it("既定の __memory__ はそのまま MEMORY を返す（後方互換）", () => {
+    expect(resolveDefaultFrameId(frameIds, MEMORY_FRAME_ID)).toBe("__memory__");
+  });
+
+  it("Frame 一覧が空でも MEMORY にフォールバックする", () => {
+    expect(resolveDefaultFrameId([], "__classic__")).toBe("__memory__");
+  });
+});
+
+describe("GameWindowConfig.lastSelectedFrameId", () => {
+  it("インスタンスの既定は __memory__", () => {
+    expect(new GameWindowConfig().lastSelectedFrameId).toBe(MEMORY_FRAME_ID);
+  });
+
+  it("static default も __memory__", () => {
+    expect(GameWindowConfig.default.user.lastSelectedFrameId).toBe(MEMORY_FRAME_ID);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,35 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
 
+// jstorm (chrome/local) は import 時に chrome.storage.local を参照するため、jsdom 環境では
+// chrome が未定義だと Model を import しただけで ReferenceError になる。Model 層をテスト可能に
+// するための最小限の in-memory モックをグローバルに用意する（実 chrome は無いので副作用なし）。
+if (typeof (globalThis as { chrome?: unknown }).chrome === "undefined") {
+  const store: Record<string, unknown> = {};
+  const local = {
+    get: (keys?: string | string[] | null) => {
+      if (keys == null) return Promise.resolve({ ...store });
+      const list = Array.isArray(keys) ? keys : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of list) if (k in store) out[k] = store[k];
+      return Promise.resolve(out);
+    },
+    set: (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+      return Promise.resolve();
+    },
+    remove: (keys: string | string[]) => {
+      for (const k of (Array.isArray(keys) ? keys : [keys])) delete store[k];
+      return Promise.resolve();
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+      return Promise.resolve();
+    },
+  };
+  (globalThis as { chrome?: unknown }).chrome = { storage: { local } };
+}
+
 afterEach(() => {
   cleanup()
 })


### PR DESCRIPTION
Closes #1236

## 背景

ポップアップの Frame（画面サイズ）選択プルダウンは初期選択が常に MEMORY 固定（`src/page/PopupPage.tsx` の `useState("__memory__")`）で、選択は永続化されていなかった。そのため、よく使うサイズ（例: CLASSIC）で遊びたいユーザは、誤リサイズからの復帰などのたびにプルダウンから選び直す必要があった。

Issue コメントでの議論は最終的に **「プルダウン→option選択の2クリックを、錨マークの1クリックにしたい（よく使うサイズをすぐ再起動したい）」** で報告者・メンテナ双方が合意している。

## 目的

ユーザが最後に起動した Frame をポップアップが記憶し、次回の初期選択として復元する。これにより現行の錨アイコン（1クリック起動）が「好みのサイズの1クリック再起動」として機能する。MEMORY 利用者の従来挙動は壊さない。

## 方針

設定 UI は追加せず（メンテナの「UIを追加するほどではない」意向に沿う）、**最後に選択（起動）した Frame を暗黙の既定として記憶**する最小実装とした。

## 設計

| 変更 | ファイル | 概要 | AC |
|---|---|---|---|
| 記憶領域の追加 | `src/models/configs/GameWindowConfig.ts` | `lastSelectedFrameId`（既定 `"__memory__"`）を追加 | AC-1, AC-4 |
| 初期選択の復元＋フォールバック | `src/page/loader/index.ts` | `popup()` で保存IDを読み、frames に存在すれば `defaultFrameId` に採用、無ければ `"__memory__"`（削除済みID対策） | AC-2, AC-5 |
| 復元と保存 | `src/page/PopupPage.tsx` | 初期選択を `defaultFrameId` から復元。Frame 起動の全経路（onChange / 錨クリック）で `GameWindowConfig.update({ lastSelectedFrameId })` 保存 | AC-2, AC-3 |

<details>
<summary>意思決定の経緯（Issue #1236 の grill 結果より）</summary>

| # | 問い | 採用案 | 代替案 | 確定方法 |
|---|---|---|---|---|
| 1 | 解釈の選択 | 最後に選択した Frame を記憶（設定UIなし） | 設定画面に明示的な既定Frame選択UI / MEMORY更新挙動の変更 | **仮採用** |
| 2 | 永続化先 | `GameWindowConfig` に `lastSelectedFrameId` | 新規 config | **仮採用** |
| 3 | 保存タイミング | 起動の全経路（onChange/錨） | 片方のみ | **仮採用** |
| 4 | 保存IDが無い場合 | `__memory__` フォールバック | エラー/先頭選択 | **仮採用** |

</details>

## 受入条件

> Issue #1236 の受け入れ条件をミラー。`[x]` は本 PR で検証済み、`[ ]` は手動 UAT 推奨（ブラウザ拡張のポップアップUIで検証可能・実ゲーム不要）。

- [x] [BUILD] `pnpm typecheck` と `pnpm build` が通る → AC-1 ※typecheck exit 0 / build exit 0
- [ ] [MANUAL] プルダウンで CLASSIC を起動 → ポップアップを開き直すと初期選択が CLASSIC → AC-2
- [ ] [MANUAL] その状態で錨アイコン1クリックで CLASSIC が起動 → AC-3
- [ ] [MANUAL] 初回/既存ユーザは初期選択が MEMORY（後方互換） → AC-4
- [ ] [MANUAL] 既定に記憶したユーザ作成 Frame を削除後にポップアップを開くと MEMORY にフォールバックしエラーにならない → AC-5

## 評価観点

- **「明示設定」ではなく「暗黙の記憶」を選んだ点**: Issue タイトルは「指定できるようにしたい」だが、スレッド合意（錨1クリック）とメンテナの no-UI 意向を優先し、設定UIを足さず「最後に使った Frame を記憶」する実装にした。明示的な既定Frame選択UI（設定画面）を望む場合は方針転換が必要。
- **暗黙記憶の副作用**: たまたま SMALL を一度起動すると次回の既定が SMALL になる。「主に使うサイズの固定指定」が必要なら明示設定案の方が適切。

## 発見

- 現行 v4 ポップアップには既に錨アイコン（1クリック起動）が存在していた（`PopupPage.tsx`）。本 PR は「その1クリックが好みのサイズを開く」状態を初期選択の永続化で実現する形になっている。
