### PR TITLE
chore(deps): jstorm 0.18.1 に更新しテストの chrome モックを jstorm/testing へ置換

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@heroicons/react": "2.1.5",
     "@tesseract.js-data/eng": "1.0.0",
     "chromite": "^0.3.3",
-    "jstorm": "^0.17.0",
+    "jstorm": "^0.18.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3
       jstorm:
-        specifier: ^0.17.0
-        version: 0.17.0
+        specifier: ^0.18.1
+        version: 0.18.1
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1654,8 +1654,8 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jstorm@0.17.0:
-    resolution: {integrity: sha512-vNRsiB47b5MZjHWJUaj970SHYIbHrNb5L4x6z1unI4AumAzGE1FJhHXpW7zZaYFMz5TBz476AsKQTpp6QP+sSw==}
+  jstorm@0.18.1:
+    resolution: {integrity: sha512-gHA15lmyQfIDmG1vIzAQJujtT/DoVgc2gHY5xXIxDpuZODPM6QTypkLHFh/9I7tfptNmnn26mFkZgyGLonuJOw==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3682,7 +3682,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  jstorm@0.17.0: {}
+  jstorm@0.18.1: {}
 
   keyv@4.5.4:
     dependencies:

--- a/tests/popup-default-frame.spec.ts
+++ b/tests/popup-default-frame.spec.ts
@@ -33,3 +33,17 @@ describe("GameWindowConfig.lastSelectedFrameId", () => {
     expect(GameWindowConfig.default.user.lastSelectedFrameId).toBe(MEMORY_FRAME_ID);
   });
 });
+
+// jstorm/testing の installMemoryStorage（tests/setup.ts で各テスト前に注入）を実際に
+// 経由した storage round-trip。Model 層が拡張外でも動くことを検証する。
+describe("GameWindowConfig storage round-trip (jstorm/testing)", () => {
+  it("user() は既定で __memory__ を返し、update が in-memory storage に永続化される", async () => {
+    const before = await GameWindowConfig.user();
+    expect(before.lastSelectedFrameId).toBe(MEMORY_FRAME_ID);
+
+    await before.update({ lastSelectedFrameId: "__classic__" });
+
+    const after = await GameWindowConfig.user();
+    expect(after.lastSelectedFrameId).toBe("__classic__");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,35 +1,16 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, beforeEach } from 'vitest'
+import { Model } from 'jstorm/chrome/local'
+import { installMemoryStorage } from 'jstorm/testing'
 
-// jstorm (chrome/local) は import 時に chrome.storage.local を参照するため、jsdom 環境では
-// chrome が未定義だと Model を import しただけで ReferenceError になる。Model 層をテスト可能に
-// するための最小限の in-memory モックをグローバルに用意する（実 chrome は無いので副作用なし）。
-if (typeof (globalThis as { chrome?: unknown }).chrome === "undefined") {
-  const store: Record<string, unknown> = {};
-  const local = {
-    get: (keys?: string | string[] | null) => {
-      if (keys == null) return Promise.resolve({ ...store });
-      const list = Array.isArray(keys) ? keys : [keys];
-      const out: Record<string, unknown> = {};
-      for (const k of list) if (k in store) out[k] = store[k];
-      return Promise.resolve(out);
-    },
-    set: (items: Record<string, unknown>) => {
-      Object.assign(store, items);
-      return Promise.resolve();
-    },
-    remove: (keys: string | string[]) => {
-      for (const k of (Array.isArray(keys) ? keys : [keys])) delete store[k];
-      return Promise.resolve();
-    },
-    clear: () => {
-      for (const k of Object.keys(store)) delete store[k];
-      return Promise.resolve();
-    },
-  };
-  (globalThis as { chrome?: unknown }).chrome = { storage: { local } };
-}
+// jstorm の Model 層を拡張外(node/jsdom)でテストするためのストレージ。各テスト前に新しい
+// in-memory StorageArea を割り当て、テスト間で状態が漏れないようにする（jstorm/testing）。
+// jstorm@0.18.1 で chrome/local は import 時に chrome を無ガード参照しなくなったため、
+// 以前ここに置いていた手書きの chrome.storage モックは不要になった。
+beforeEach(() => {
+  Model.useStorage(installMemoryStorage())
+})
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## 背景

#1806 で model 層（`GameWindowConfig`）の単体テストを追加した際、`jstorm@0.17.0` の `chrome/local` が **import 時に無ガードで `chrome.storage.local` を参照**していたため、jsdom 環境では Model を import しただけで `ReferenceError: chrome is not defined` になっていた。暫定対応として `tests/setup.ts` に手書きの in-memory `chrome.storage` モックを置いていた。

`jstorm@0.18.1` で以下が入ったため、この借金を返す。
- `chrome/local` の import 時 area 束縛が `typeof chrome` ガード付きになり、拡張外でも import で落ちない
- `jstorm/testing`（`MemoryStorageArea` / `installMemoryStorage` / `withStorage`）が追加。`chrome.storage.StorageArea` と同じ **async** な面を持つ in-memory テストダブル

## 変更

| ファイル | 概要 |
|---|---|
| `package.json` / `pnpm-lock.yaml` | `jstorm` を `^0.17.0` → `^0.18.1` |
| `tests/setup.ts` | 手書き chrome モック(29行)を撤去し、各テスト前に `Model.useStorage(installMemoryStorage())` で fresh な in-memory StorageArea を注入 |
| `tests/popup-default-frame.spec.ts` | `GameWindowConfig` の storage round-trip テストを追加（`user()` → `update()` → 再 `user()` が in-memory storage を経由して永続化されることを検証＝新 API の実証） |

## 確認

- `pnpm exec vitest run` → 36 passed
- `pnpm typecheck` → exit 0
- `pnpm build` → exit 0
- `require.resolve('jstorm/chrome/local')` / `require.resolve('jstorm/testing')` ともに解決OK（0.18.0 の publish 不具合は 0.18.1 で解消済み）

## 補足（jstorm 側の別件・本PRの対象外）

storage が空のとき jstorm の `__rawdict__()` が static `default` を**参照で**返し、`save()` が `dict[id]=…` でそれを破壊的に書き換えるため、一度 write すると static `default` が汚染される（テスト間でフォールバック値が漏れる）挙動を確認。本PRでは该当を踏むテストは入れていない。jstorm リポジトリ側へ共有予定。
