### PR TITLE
feat(dashboard): ゲーム起動と同時にダッシュボードを開く設定を追加

### DIFF
--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -22,15 +22,14 @@ onMessage.on("/frame/open-or-focus", async (req) => {
   const launcher = new Launcher();
   const id = req.frame_id;
   const frame = (await Frame.find(id)) ?? (await Frame.memory());
-  // ゲーム窓が新規作成かどうかを launch 前に判定する（#1216）
-  const existed = !!(await launcher.find(frame));
-  const result = await launcher.launch(frame);
+  // launch() はゲーム窓を新規作成したとき true を返す（#1216）
+  const created = await launcher.launch(frame);
   // 設定 ON かつ新規作成時のみ、ダッシュボードも同時に開く（#1216）。
   // Launcher.dashboard() は open-or-focus なので、既にDBが開いていれば focus されるだけ。
-  if ((await DashboardConfig.user()).shouldOpenOnLaunch(existed)) {
+  if ((await DashboardConfig.user()).shouldOpenOnLaunch(created)) {
     await Launcher.dashboard();
   }
-  return result;
+  return created;
 });
 
 onMessage.on("/frame/memory:track", async (req) => {

--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -22,7 +22,15 @@ onMessage.on("/frame/open-or-focus", async (req) => {
   const launcher = new Launcher();
   const id = req.frame_id;
   const frame = (await Frame.find(id)) ?? (await Frame.memory());
-  return await launcher.launch(frame);
+  // ゲーム窓が新規作成かどうかを launch 前に判定する（#1216）
+  const existed = !!(await launcher.find(frame));
+  const result = await launcher.launch(frame);
+  // 設定 ON かつ新規作成時のみ、ダッシュボードも同時に開く（#1216）。
+  // Launcher.dashboard() は open-or-focus なので、既にDBが開いていれば focus されるだけ。
+  if ((await DashboardConfig.user()).shouldOpenOnLaunch(existed)) {
+    await Launcher.dashboard();
+  }
+  return result;
 });
 
 onMessage.on("/frame/memory:track", async (req) => {

--- a/src/models/configs/DashboardConfig.ts
+++ b/src/models/configs/DashboardConfig.ts
@@ -9,6 +9,8 @@ export class DashboardConfig extends Model {
       "height": 220,
       "left": 10,
       "top": 10,
+      // ゲーム窓を新規に開いたとき、ダッシュボードも同時に開くか（#1216）。既定は false（従来どおり手動）。
+      "openWithGame": false,
     },
   };
 
@@ -16,9 +18,19 @@ export class DashboardConfig extends Model {
   public height: number = 220;
   public left: number = 100;
   public top: number = 100;
+  public openWithGame: boolean = false;
 
   static async user(): Promise<DashboardConfig> {
     return (await this.find("user"))!;
+  }
+
+  /**
+   * ゲーム窓の起動に合わせてダッシュボードを自動で開くべきかを判定する（#1216）。
+   * 設定 ON かつ「新規作成時のみ」が条件。既存ゲーム窓の再フォーカスでは開かない。
+   * @param gameWindowExisted launch 前に既にゲーム窓が存在したか
+   */
+  public shouldOpenOnLaunch(gameWindowExisted: boolean): boolean {
+    return !gameWindowExisted && this.openWithGame;
   }
 
   public toWindowCreateData(): chrome.windows.CreateData {

--- a/src/models/configs/DashboardConfig.ts
+++ b/src/models/configs/DashboardConfig.ts
@@ -27,10 +27,10 @@ export class DashboardConfig extends Model {
   /**
    * ゲーム窓の起動に合わせてダッシュボードを自動で開くべきかを判定する（#1216）。
    * 設定 ON かつ「新規作成時のみ」が条件。既存ゲーム窓の再フォーカスでは開かない。
-   * @param gameWindowExisted launch 前に既にゲーム窓が存在したか
+   * @param gameWindowCreated launch でゲーム窓を新規作成したか（既存窓の再フォーカスは false）
    */
-  public shouldOpenOnLaunch(gameWindowExisted: boolean): boolean {
-    return !gameWindowExisted && this.openWithGame;
+  public shouldOpenOnLaunch(gameWindowCreated: boolean): boolean {
+    return gameWindowCreated && this.openWithGame;
   }
 
   public toWindowCreateData(): chrome.windows.CreateData {

--- a/src/page/components/options/DashboardSettingView.tsx
+++ b/src/page/components/options/DashboardSettingView.tsx
@@ -8,11 +8,28 @@ export function DashboardSettingView({
   config: DashboardConfig;
 }) {
   const [config] = useState<DashboardConfig>(_config);
+  const [openWithGame, setOpenWithGame] = useState<boolean>(config.openWithGame ?? false);
 
   return (
     <FoldableSection title="ダッシュボードの設定" id="dashboard">
       <div className="mb-4">
         <p>ダッシュボード窓を開く際のサイズと位置を設定できます.</p>
+      </div>
+
+      <div className="mb-4">
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={openWithGame}
+            onChange={async (e) => {
+              const next = e.target.checked;
+              await config.update({ openWithGame: next });
+              setOpenWithGame(next);
+            }}
+            className="w-4 h-4"
+          />
+          <span className="font-bold">ゲーム起動と同時にダッシュボードを開く</span>
+        </label>
       </div>
 
       <div className="mb-4 grid grid-cols-2 gap-4 max-w-md">

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -111,10 +111,17 @@ export class Launcher {
    * 既存別窓があればフォーカスのみ行い、無ければ新規作成して活性化する。
    * @param frame 起動対象のフレーム設定
    */
-  public async launch(frame: Frame) {
+  /**
+   * ゲーム窓を開く。既存があれば retouch して focus し、無ければ新規作成して activate する。
+   * @returns ゲーム窓を新規作成したとき true、既存窓を再フォーカスしたとき false（#1216）
+   */
+  public async launch(frame: Frame): Promise<boolean> {
     // すでに存在する場合、retouchして終わる
     const exists = await this.find(frame);
-    if (exists && exists.id) return this.retouch(exists, frame);
+    if (exists && exists.id) {
+      await this.retouch(exists, frame);
+      return false;
+    }
     // ない場合、新規作成してactivateする
     const win = await this.windows.create(frame.toWindowCreateData());
     if (!win) throw new Error("Failed to create game window");
@@ -122,6 +129,7 @@ export class Launcher {
     this.anchor(win, frame);
     this.mute(win.tabs![0].id!, frame.muted);
     await this.activate(win, innerIframe);
+    return true;
   }
 
   /**

--- a/tests/dashboard-open-with-game.spec.ts
+++ b/tests/dashboard-open-with-game.spec.ts
@@ -1,0 +1,29 @@
+import { expect, describe, it } from "vitest";
+
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+
+// #1216: ゲーム窓の起動に合わせてダッシュボードを自動で開くかの判定ルール。
+describe("DashboardConfig.shouldOpenOnLaunch", () => {
+  it("既定（openWithGame=false）では新規/既存どちらでも開かない", () => {
+    const config = new DashboardConfig();
+    expect(config.openWithGame).toBe(false); // 既定は OFF（後方互換）
+    expect(config.shouldOpenOnLaunch(false)).toBe(false);
+    expect(config.shouldOpenOnLaunch(true)).toBe(false);
+  });
+
+  it("openWithGame=true かつ 新規作成（existed=false）のときだけ開く", () => {
+    const config = new DashboardConfig();
+    config.openWithGame = true;
+    expect(config.shouldOpenOnLaunch(false)).toBe(true);
+  });
+
+  it("openWithGame=true でも既存ゲーム窓の再フォーカス（existed=true）では開かない", () => {
+    const config = new DashboardConfig();
+    config.openWithGame = true;
+    expect(config.shouldOpenOnLaunch(true)).toBe(false);
+  });
+
+  it("static default の openWithGame も false", () => {
+    expect(DashboardConfig.default.user.openWithGame).toBe(false);
+  });
+});

--- a/tests/dashboard-open-with-game.spec.ts
+++ b/tests/dashboard-open-with-game.spec.ts
@@ -4,23 +4,23 @@ import { DashboardConfig } from "../src/models/configs/DashboardConfig";
 
 // #1216: ゲーム窓の起動に合わせてダッシュボードを自動で開くかの判定ルール。
 describe("DashboardConfig.shouldOpenOnLaunch", () => {
-  it("既定（openWithGame=false）では新規/既存どちらでも開かない", () => {
+  it("既定（openWithGame=false）では新規作成でも再フォーカスでも開かない", () => {
     const config = new DashboardConfig();
     expect(config.openWithGame).toBe(false); // 既定は OFF（後方互換）
+    expect(config.shouldOpenOnLaunch(true)).toBe(false);
     expect(config.shouldOpenOnLaunch(false)).toBe(false);
-    expect(config.shouldOpenOnLaunch(true)).toBe(false);
   });
 
-  it("openWithGame=true かつ 新規作成（existed=false）のときだけ開く", () => {
+  it("openWithGame=true かつ 新規作成（created=true）のときだけ開く", () => {
     const config = new DashboardConfig();
     config.openWithGame = true;
-    expect(config.shouldOpenOnLaunch(false)).toBe(true);
+    expect(config.shouldOpenOnLaunch(true)).toBe(true);
   });
 
-  it("openWithGame=true でも既存ゲーム窓の再フォーカス（existed=true）では開かない", () => {
+  it("openWithGame=true でも既存ゲーム窓の再フォーカス（created=false）では開かない", () => {
     const config = new DashboardConfig();
     config.openWithGame = true;
-    expect(config.shouldOpenOnLaunch(true)).toBe(false);
+    expect(config.shouldOpenOnLaunch(false)).toBe(false);
   });
 
   it("static default の openWithGame も false", () => {


### PR DESCRIPTION
Closes #1216

## 背景

ダッシュボード窓はポップアップのアイコンから手動でのみ起動し、ゲーム窓を開いても自動では開かなかった。毎回ゲーム窓とダッシュボードを別々に開く必要があり、「艦これと同時にダッシュボードが立ち上がる設定が欲しい」という複数ユーザ（@xia-sava 氏も 👍）からの要望があった。

## 目的

設定 ON 時、ゲーム窓を**新規に**開いたときだけダッシュボードも同時に開く。既定 OFF で従来挙動を維持する。

## 方針

「新規作成時のみ開く（既存ゲーム窓の再フォーカスでは開かない）」という判定ルールを `DashboardConfig` の純粋メソッド `shouldOpenOnLaunch()` に同居させ、ゲーム起動の単一経路 `/frame/open-or-focus`（`Message.ts`）からそれを参照する。`Launcher.launch()` はゲーム窓専任のまま（関心の分離）。

## 設計

| 変更 | ファイル | 概要 | AC |
|---|---|---|---|
| 設定＋判定ルール | `src/models/configs/DashboardConfig.ts` | `openWithGame`(既定 false) と `shouldOpenOnLaunch(gameWindowExisted)` を追加 | AC-1〜AC-4 |
| 設定UI | `src/page/components/options/DashboardSettingView.tsx` | チェックボックス「ゲーム起動と同時にダッシュボードを開く」を追加（toggle パターン） | AC-2, AC-3 |
| 起動時の連動 | `src/controllers/Message.ts` | `/frame/open-or-focus` で launch 前に `launcher.find()` で既存判定し、`shouldOpenOnLaunch` が真なら `Launcher.dashboard()`（open-or-focus）を呼ぶ | AC-2, AC-4, AC-5 |
| テスト | `tests/dashboard-open-with-game.spec.ts` | 判定ルール（OFF/新規/既存）と既定値を検証 | AC-1 |

<details>
<summary>意思決定の経緯（Issue #1216 の grill 結果より）</summary>

| # | 問い | 採用案 | 代替案 | 確定方法 |
|---|---|---|---|---|
| 1 | 設定の既定値 | OFF（opt-in・後方互換） | 既定 ON | 合意 |
| 2 | 自動オープンのトリガー | ゲーム窓の新規作成時のみ | open-or-focus 実行毎回 | 合意 |
| 3 | 設定の置き場所 | DashboardConfig | GameWindowConfig | 合意 |
| 4 | 実装箇所 | /frame/open-or-focus ハンドラ | Launcher.launch() 内 | 合意 |

</details>

## 受入条件

> Issue #1216 の受け入れ条件をミラー。`[x]` は本 PR で検証済み、`[ ]` は手動 UAT 推奨（拡張のポップアップUIで検証可能・実ゲーム不要）。

- [x] [BUILD] `pnpm typecheck` と `pnpm build` が通る → AC-1 ※exit 0 / 0。判定ルールは `tests/dashboard-open-with-game.spec.ts` で検証（40 tests pass）
- [ ] [MANUAL] 設定 ON で新規にゲーム窓を開くとダッシュボードも開く → AC-2
- [ ] [MANUAL] 設定 OFF（既定）ではゲーム窓を開いてもダッシュボードは開かない → AC-3
- [ ] [MANUAL] 設定 ON で既存ゲーム窓を再フォーカスしてもダッシュボードは新たに開かない（新規作成時のみ） → AC-4
- [ ] [MANUAL] 設定 ON でダッシュボード既存時は二重に開かず focus されるだけ → AC-5

## 評価観点

- **フォーカス順**: `Launcher.dashboard()` を `launch()` の後に呼ぶため、環境によってはダッシュボードが最前面に来てゲーム窓が背面に回る可能性がある。実機目視で許容範囲か確認推奨（必要なら起動順 / focus 制御を追加）。
- **検証経路**: Chrome 拡張＋実ゲーム窓の自動駆動が不可のため AC-2〜5 は手動 UAT に委ねている。判定ロジック（新規作成時のみ）は単体テスト済み。

## 発見

- 現行の `/frame/open-or-focus` ハンドラは launch 内部でも `find()` を呼ぶため、本変更で `find()` が二度走る（読み取りのみで冪等・影響軽微）。気になる場合は launch() が新規/既存を返す形へリファクタする余地あり。
