### PR TITLE
fix: 通知クリックで既存窓をリサイズせずアクティブ化する (#1810)

### DIFF
--- a/src/controllers/Notifications.ts
+++ b/src/controllers/Notifications.ts
@@ -7,9 +7,11 @@ const onClicked = new Router<typeof chrome.notifications.onClicked>(async (id) =
 });
 
 onClicked.onNotFound(async (id) => {
+  // 通知クリックは「ゲーム窓をアクティブ化する」だけが目的なので、
+  // 既存窓へのサイズ調整（retouch）は行わない。非アクティブ窓を retouch すると
+  // Windows で上下に黒帯が累積する不具合があったため focusOrLaunch を使う（#1810）。
   const launcher = new Launcher();
-  const frame = await Frame.memory();
-  launcher.launch(frame);
+  await launcher.focusOrLaunch(await Frame.memory());
   chrome.notifications.clear(id);
 })
 

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -107,29 +107,54 @@ export class Launcher {
   }
 
   /**
-   * 指定されたフレーム設定でゲーム別窓を起動する。
-   * 既存別窓があればフォーカスのみ行い、無ければ新規作成して活性化する。
+   * ゲーム窓を開く。既存があれば retouch（サイズ調整＋focus）し、無ければ新規作成して activate する。
    * @param frame 起動対象のフレーム設定
-   */
-  /**
-   * ゲーム窓を開く。既存があれば retouch して focus し、無ければ新規作成して activate する。
    * @returns ゲーム窓を新規作成したとき true、既存窓を再フォーカスしたとき false（#1216）
    */
   public async launch(frame: Frame): Promise<boolean> {
-    // すでに存在する場合、retouchして終わる
+    return this.findOrOpen(frame, (win) => this.retouch(win, frame));
+  }
+
+  /**
+   * 既存のゲーム窓があれば focus のみ、無ければ新規作成する。
+   * retouch と違いサイズ調整を行わないため、通知クリックなど
+   * 「単にアクティブ化したいだけ」の用途に使う（#1810）。
+   * @param frame 窓が無いとき新規作成に使うフレーム設定
+   * @returns ゲーム窓を新規作成したとき true、既存窓を再フォーカスしたとき false
+   */
+  public async focusOrLaunch(frame: Frame): Promise<boolean> {
+    return this.findOrOpen(frame, (win) => this.focus(win.id!));
+  }
+
+  /**
+   * 既存のゲーム別窓を探し、あれば onExists で再利用、無ければ新規作成する。
+   * 「既存窓に対する振る舞い」だけが launch と focusOrLaunch の差なので、
+   * find→存在判定→open の共通骨格をここに集約する。
+   * @param frame 検索・新規作成に使うフレーム設定
+   * @param onExists 既存窓が見つかったときの再利用処理
+   * @returns ゲーム窓を新規作成したとき true、既存窓を再利用したとき false
+   */
+  private async findOrOpen(frame: Frame, onExists: (win: chrome.windows.Window) => Promise<unknown>): Promise<boolean> {
     const exists = await this.find(frame);
     if (exists && exists.id) {
-      await this.retouch(exists, frame);
+      await onExists(exists);
       return false;
     }
-    // ない場合、新規作成してactivateする
+    await this.open(frame);
+    return true;
+  }
+
+  /**
+   * フレーム設定からゲーム別窓を新規作成し、注入・ミュート・活性化まで行う。
+   * @param frame 起動対象のフレーム設定
+   */
+  private async open(frame: Frame): Promise<void> {
     const win = await this.windows.create(frame.toWindowCreateData());
     if (!win) throw new Error("Failed to create game window");
     const innerIframe = await this.waitForInnerIframeLoaded(win.tabs![0].id!);
     this.anchor(win, frame);
     this.mute(win.tabs![0].id!, frame.muted);
     await this.activate(win, innerIframe);
-    return true;
   }
 
   /**

--- a/tests/launcher-focus-or-launch.spec.ts
+++ b/tests/launcher-focus-or-launch.spec.ts
@@ -1,0 +1,98 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// Launcher のメソッドは chrome.tabs.sendMessage / chrome.webNavigation などを参照するため、
+// import より前にグローバル chrome をスタブする。
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} } },
+    tabs: { sendMessage: vi.fn() },
+    // open() 内の waitForInnerIframeLoaded が内側 iframe を即座に見つけられるようにする
+    webNavigation: {
+      getAllFrames: vi.fn().mockResolvedValue([
+        { frameId: 1, url: "https://osapi.dmm.com/gadgets/ifr?game" },
+      ]),
+    },
+  };
+});
+
+import { Launcher } from "../src/services/Launcher";
+import { Frame } from "../src/models/Frame";
+import { WindowService } from "../src/services/WindowService";
+import { TabService } from "../src/services/TabService";
+import { ScriptingService } from "../src/services/ScriptingService";
+import { KanColleURL } from "../src/constants";
+
+// find() が既存ゲーム窓を見つけられる状態のフェイク群を組み立てる。
+// existingTabs を空にすると「ゲーム窓なし」を表現できる。
+function build(existingTabs: chrome.tabs.Tab[]) {
+  const windows = {
+    create: vi.fn().mockResolvedValue({ id: 20, tabs: [{ id: 2 }] }),
+    update: vi.fn().mockResolvedValue({}),
+    remove: vi.fn(),
+    get: vi.fn().mockResolvedValue({ id: 10, tabs: [{ id: 1 }] }),
+  };
+  const tabs = {
+    query: vi.fn().mockResolvedValue(existingTabs),
+    update: vi.fn().mockResolvedValue({}),
+  };
+  const scriptings = { func: vi.fn(), js: vi.fn(), css: vi.fn() };
+  const launcher = new Launcher(
+    windows as unknown as WindowService,
+    tabs as unknown as TabService,
+    scriptings as unknown as ScriptingService,
+  );
+  return { launcher, windows, tabs, scriptings };
+}
+
+const existingGameTab = [
+  { url: KanColleURL, windowId: 10 },
+] as unknown as chrome.tabs.Tab[];
+
+describe("Launcher.focusOrLaunch（#1810）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("既存窓があるときは focus のみで、サイズ調整（resize）を行わない", async () => {
+    const { launcher, windows } = build(existingGameTab);
+
+    const created = await launcher.focusOrLaunch(new Frame());
+
+    expect(created).toBe(false);
+    // windows.update は focus 用の1回だけ。サイズ指定では呼ばれない。
+    expect(windows.update).toHaveBeenCalledTimes(1);
+    expect(windows.update).toHaveBeenCalledWith(10, { focused: true });
+    expect(windows.create).not.toHaveBeenCalled();
+    // retouch 経由のサイズ調整メッセージも飛ばない
+    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("既存窓が無いときは新規作成する", async () => {
+    const { launcher, windows } = build([]);
+
+    const created = await launcher.focusOrLaunch(new Frame());
+
+    expect(created).toBe(true);
+    expect(windows.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Launcher.launch（既存窓では従来通り retouch する）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("既存窓があるときはサイズ調整（resize）と focus を行う", async () => {
+    const { launcher, windows } = build(existingGameTab);
+
+    const created = await launcher.launch(new Frame());
+
+    expect(created).toBe(false);
+    // サイズ指定の update と focus の update の2回呼ばれる
+    expect(windows.update).toHaveBeenCalledWith(10, expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }));
+    expect(windows.update).toHaveBeenCalledWith(10, { focused: true });
+    // retouch のサイズ調整メッセージが飛ぶ
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { __action__: "/injected/dmm/retouch" });
+  });
+});

--- a/tests/notification-click-activate.spec.ts
+++ b/tests/notification-click-activate.spec.ts
@@ -1,0 +1,52 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// chromite はモジュール読み込み時に chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} } },
+    notifications: { clear: vi.fn() },
+  };
+});
+
+// Launcher をモックし、通知クリックがどのメソッドを呼ぶかだけを検証する（#1810）。
+const { focusOrLaunch, launch } = vi.hoisted(() => ({
+  focusOrLaunch: vi.fn(),
+  launch: vi.fn(),
+}));
+vi.mock("../src/services/Launcher", () => ({
+  Launcher: vi.fn(() => ({ focusOrLaunch, launch })),
+}));
+vi.mock("../src/models/Frame", () => ({
+  Frame: { memory: vi.fn().mockResolvedValue({ url: "https://example.test" }) },
+}));
+
+import { onClicked } from "../src/controllers/Notifications";
+
+const fire = (id: string) => {
+  const listener = onClicked.listener();
+  // chromite の listener は同期的に呼び出され、ハンドラは Promise 内で実行される
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (listener as any)(id);
+};
+
+describe("Notifications onClicked（#1810）", () => {
+  beforeEach(() => {
+    focusOrLaunch.mockReset();
+    launch.mockReset();
+    (chrome.notifications.clear as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("通知クリックは focusOrLaunch でアクティブ化し、launch（retouch）は呼ばない", async () => {
+    focusOrLaunch.mockResolvedValue(false);
+    fire("/mission/2/end");
+    await vi.waitFor(() => expect(focusOrLaunch).toHaveBeenCalledTimes(1));
+    expect(launch).not.toHaveBeenCalled();
+  });
+
+  it("処理後に通知をクリアする", async () => {
+    focusOrLaunch.mockResolvedValue(false);
+    fire("/recovery/1/end");
+    await vi.waitFor(() => expect(chrome.notifications.clear).toHaveBeenCalledWith("/recovery/1/end"));
+  });
+});


### PR DESCRIPTION
## 概要

#1810 の修正です。非アクティブなゲーム窓に来た通知（遠征・入渠・建造・疲労）をクリックすると、ゲーム窓の上下に黒帯が入り、クリックのたびにウィンドウサイズが累積して増えていく不具合を修正します。

## 原因

通知クリックは `Notifications` コントローラの `onNotFound` → `launcher.launch(frame)` を通っており、既存窓がある場合は `retouch()`（`windows.update` でサイズ指定 ＋ `dmm.ts` の `resize()` 呼び出し）が走っていました。この `resize()` は枠（タイトルバー/ボーダー）分を `window.resizeBy(outerW - innerW, outerH - innerH)` で補正する処理ですが、非アクティブな popup 窓に対しては Windows 環境で枠サイズの補正が誤って効き、クリックのたびに高さが枠分ずつ増加します。ゲーム画面はアスペクト比を保って描画されるため、増えた縦方向の余白が黒帯として現れ、累積していました。

通知クリックは本来「ゲーム窓をアクティブ化する」だけが目的であり、サイズ調整（retouch）は不要かつ有害です。

## 変更内容

- `Launcher` に **`focusOrLaunch(frame)`** を新設。既存窓があれば `focus` のみ行い（サイズ調整しない）、無ければ従来通り新規作成する。
- `Notifications` の通知クリック経路を `launch()` から `focusOrLaunch()` に変更。
- リファクタ（/simplify）: `launch` と `focusOrLaunch` で共通する「find → 存在判定 → 新規作成」の骨格を private な **`findOrOpen(frame, onExists)`** に集約し、窓の新規作成処理を **`open(frame)`** に抽出。公開APIは2メソッドのまま、振る舞いの差（既存窓に `retouch` か `focus` か）だけを明示する形にした。

明示的なゲーム起動（オプション画面のプリセット選択 = `/frame/open-or-focus`）は引き続き `launch()` を使い、サイズ同期（retouch）が行われます。

## 挙動

| 通知クリック時 | 変更後の挙動 |
|---|---|
| 既存のゲーム窓が**ある** | focus のみ（黒帯が出ない・サイズ不変） |
| ゲーム窓が**無い** | 従来通り `__memory__` のサイズで新規作成 |

## 確認

- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRUMbL1yWYHV4kG94XJbaY)_