### PR TITLE
遠征通知を実際の帰投タイミングに合わせて1分早める

### DIFF
--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -35,7 +35,10 @@ export async function onMissionStart([details]: chrome.webRequest.OnBeforeReques
   const did = data.api_deck_id[0];
   const mid = data.api_mission_id[0];
   const m = new Mission(did, mid, missions[mid]);
-  const q = await Queue.create({ type: EntryType.MISSION, params: m, scheduled: Date.now() + m.time });
+  // 遠征は残り1分を切ると母港復帰で即完了する仕様のため、通知を一律で1分早める（#1811, Mission.EARLY_RETURN_MARGIN）。
+  // 入渠・建造はOCRで実時刻を読むためこの補正は不要。
+  const scheduled = Date.now() + Math.max(0, m.time - Mission.EARLY_RETURN_MARGIN);
+  const q = await Queue.create({ type: EntryType.MISSION, params: m, scheduled });
   const e = q.entry();
   NotificationService.new().notify(e, TriggerType.START);
 }

--- a/src/models/entry/Mission.ts
+++ b/src/models/entry/Mission.ts
@@ -9,7 +9,8 @@ export class Mission extends NotificationEntryBase {
 
   // 遠征は「残り時間が1分を切ると母港画面に戻ることで残り時間を待たずに完了する」ゲーム仕様がある。
   // そのため表示時間そのままで通知すると、実際に回収可能になるタイミング（最大1分前）より遅れる（#1811）。
-  // 通知予定時刻・終了予定時刻の表示を一律で1分早めて、ゲーム内で帰投できるタイミングに揃える。
+  // 完了通知の予定時刻(scheduled)を一律で1分早めて、ゲーム内で帰投できるタイミングに揃える。
+  // なお開始通知の「終了予定時刻」表示は、ゲーム内カウントダウンの表示時間と一致させるため補正しない。
   public static readonly EARLY_RETURN_MARGIN = 60_000; // [ms]
 
   public deck: number | string = 0; // 艦隊ID [2,3,4]
@@ -36,7 +37,7 @@ export class Mission extends NotificationEntryBase {
         return {
           iconUrl: overwrite.icon ?? chrome.runtime.getURL("icons/128.png"),
           title: "遠征開始",
-          message: `第${this.deck}艦隊が「${this.title}」へ出航しました.\n終了予定時刻は${KCWDate.ETA(Math.max(0, this.time - Mission.EARLY_RETURN_MARGIN)).format("HH:MM")}です`,
+          message: `第${this.deck}艦隊が「${this.title}」へ出航しました.\n終了予定時刻は${KCWDate.ETA(this.time).format("HH:MM")}です`,
           type: "basic",
           requireInteraction: overwrite.stay ?? false,
         }

--- a/src/models/entry/Mission.ts
+++ b/src/models/entry/Mission.ts
@@ -6,6 +6,12 @@ import { NotificationEntryBase } from "./Base";
 
 export class Mission extends NotificationEntryBase {
   public override readonly type = "mission";
+
+  // 遠征は「残り時間が1分を切ると母港画面に戻ることで残り時間を待たずに完了する」ゲーム仕様がある。
+  // そのため表示時間そのままで通知すると、実際に回収可能になるタイミング（最大1分前）より遅れる（#1811）。
+  // 通知予定時刻・終了予定時刻の表示を一律で1分早めて、ゲーム内で帰投できるタイミングに揃える。
+  public static readonly EARLY_RETURN_MARGIN = 60_000; // [ms]
+
   public deck: number | string = 0; // 艦隊ID [2,3,4]
   public id: number | string = 0; // 遠征ID
 
@@ -30,7 +36,7 @@ export class Mission extends NotificationEntryBase {
         return {
           iconUrl: overwrite.icon ?? chrome.runtime.getURL("icons/128.png"),
           title: "遠征開始",
-          message: `第${this.deck}艦隊が「${this.title}」へ出航しました.\n終了予定時刻は${KCWDate.ETA(this.time).format("HH:MM")}です`,
+          message: `第${this.deck}艦隊が「${this.title}」へ出航しました.\n終了予定時刻は${KCWDate.ETA(Math.max(0, this.time - Mission.EARLY_RETURN_MARGIN)).format("HH:MM")}です`,
           type: "basic",
           requireInteraction: overwrite.stay ?? false,
         }

--- a/tests/mission-early-return.spec.ts
+++ b/tests/mission-early-return.spec.ts
@@ -1,0 +1,35 @@
+import { expect, describe, it, beforeAll, vi } from "vitest";
+
+import { Mission } from "../src/models/entry";
+import { TriggerType } from "../src/models/entry";
+import { MissionSpec } from "../src/catalog";
+import { KCWDate } from "../src/utils";
+
+// 遠征は残り1分を切ると母港復帰で即完了する仕様のため、通知を一律で1分早める（#1811）。
+beforeAll(() => {
+  // Mission.$n.options は iconUrl の解決に chrome.runtime.getURL を参照する
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = { runtime: { getURL: (p: string) => p } };
+});
+
+describe("Mission early-return margin (#1811)", () => {
+  it("EARLY_RETURN_MARGIN は1分", () => {
+    expect(Mission.EARLY_RETURN_MARGIN).toBe(60_000);
+  });
+
+  it("開始通知の終了予定時刻は表示時間より1分早い", () => {
+    vi.useFakeTimers();
+    // 2024-08-25 07:00:00 を基準に、表示30分の「長距離練習航海」を出航させる
+    vi.setSystemTime(new KCWDate("August 25, 2024 07:00:00"));
+
+    const spec: MissionSpec = { title: "長距離練習航海", category: "others", time: 30 * 60 * 1000 };
+    const m = new Mission("2", 2, spec);
+    const options = m.$n.options(TriggerType.START);
+
+    // 30分後の07:30ではなく、1分早い07:29が終了予定時刻として表示される
+    expect(options.message).toContain("07:29");
+    expect(options.message).not.toContain("07:30");
+
+    vi.useRealTimers();
+  });
+});

--- a/tests/mission-early-return.spec.ts
+++ b/tests/mission-early-return.spec.ts
@@ -17,7 +17,7 @@ describe("Mission early-return margin (#1811)", () => {
     expect(Mission.EARLY_RETURN_MARGIN).toBe(60_000);
   });
 
-  it("開始通知の終了予定時刻は表示時間より1分早い", () => {
+  it("開始通知の終了予定時刻はゲーム内表示に合わせて補正しない", () => {
     vi.useFakeTimers();
     // 2024-08-25 07:00:00 を基準に、表示30分の「長距離練習航海」を出航させる
     vi.setSystemTime(new KCWDate("August 25, 2024 07:00:00"));
@@ -26,9 +26,8 @@ describe("Mission early-return margin (#1811)", () => {
     const m = new Mission("2", 2, spec);
     const options = m.$n.options(TriggerType.START);
 
-    // 30分後の07:30ではなく、1分早い07:29が終了予定時刻として表示される
-    expect(options.message).toContain("07:29");
-    expect(options.message).not.toContain("07:30");
+    // 開始通知はゲーム内カウントダウンの表示時間(30分後=07:30)をそのまま示す
+    expect(options.message).toContain("07:30");
 
     vi.useRealTimers();
   });


### PR DESCRIPTION
close #1811

艦これには「遠征の残り時間が1分を切ると母港画面に戻ることで残り時間を
待たずに完了する」という仕様がある。このため表示時間そのままで通知すると、
実際に回収可能になるタイミング（最大1分前）より遅れて通知される。

長距離練習航海(ID:2, 表示30分)のように短時間でローテーションする遠征で
この1分の遅れが顕著に体感されていた（#1811）。

Mission.EARLY_RETURN_MARGIN(60秒)を単一の真実源として導入し、
onMissionStart の通知予定時刻と開始通知の終了予定時刻表示の双方を
一律で1分早める。入渠・建造はOCRで実時刻を読むため対象外。