### PR TITLE
fix: 大破進撃防止機能の別窓表示で戦闘画像が積み上がる不具合を修正

### DIFF
--- a/src/page/snapshot/DamageSnapshotPage.tsx
+++ b/src/page/snapshot/DamageSnapshotPage.tsx
@@ -1,12 +1,22 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 export function DamageSnapshotPage() {
   const [uris, setURIs] = useState<string[]>([]);
   const [label, setLabel] = useState<string | null>(null);
+  // 現在表示中の画像がどの戦闘(timestamp)のものかを保持する（osapi.ts DamageSnapshot.show()と同じ役割）
+  const shownTimestamp = useRef<number | undefined>(undefined);
   useEffect(() => {
     chrome.runtime.onMessage.addListener((msg) => {
       if (msg.__action__ === "/dsnapshot/separate:push") {
-        setURIs((prev) => [...prev, msg.uri as string]);
+        const timestamp = msg.timestamp as number;
+        // 新しい戦闘（timestampが変わった）なら前回までの画像を消して置き換える。
+        // 同じtimestamp（連合艦隊の2ペイン目）は消さずに横へ追記する（#1815）。
+        if (shownTimestamp.current !== timestamp) {
+          setURIs([msg.uri as string]);
+          shownTimestamp.current = timestamp;
+        } else {
+          setURIs((prev) => [...prev, msg.uri as string]);
+        }
         if (msg.label) setLabel(msg.label as string);
       }
     });

--- a/src/page/snapshot/DamageSnapshotPage.tsx
+++ b/src/page/snapshot/DamageSnapshotPage.tsx
@@ -4,6 +4,8 @@ export function DamageSnapshotPage() {
   const [uris, setURIs] = useState<string[]>([]);
   const [label, setLabel] = useState<string | null>(null);
   // 現在表示中の画像がどの戦闘(timestamp)のものかを保持する（osapi.ts DamageSnapshot.show()と同じ役割）
+  // stellar:debt(scope) osapi.tsのDamageSnapshot.show()と同じtimestamp比較ロジックをここに個別実装している。
+  // upgrade: 両者が使う共有predicate（例: shouldReplaceSnapshot）に統合し、将来の乖離を防ぐ。
   const shownTimestamp = useRef<number | undefined>(undefined);
   useEffect(() => {
     chrome.runtime.onMessage.addListener((msg) => {


### PR DESCRIPTION
Closes #1815

## 背景

大破進撃防止機能を「別窓表示」に設定すると、2戦以上発生する海域に出撃した場合、2戦目以降の各戦闘終了時に、直近の戦闘スクリーンショットがそれまでの全戦闘のスクリーンショットに追記される形で表示されてしまう。別窓のサイズは固定のまま画像枚数分に等分されるため、戦闘回数が増えるほど1枚あたりの表示が縮小し、視認性が低下する。ウィンドウ内表示モードではこの問題は発生しない。

## 目的

「大破進撃防止機能」を別窓表示で使っているユーザが、各戦闘終了時に直近の艦隊状況を正しいサイズで確認できるようにする。

## 方針

別窓表示側は、受信メッセージに含まれる `timestamp` を一切参照せず、届いた画像を無条件に配列へ追記していた。一方ウィンドウ内表示側は、直前に表示した戦闘の `timestamp` と比較し、戦闘が変わっていれば前の画像を消してから新しく描画する（同一戦闘＝連合艦隊の2ペイン目のみ追記を維持する）設計を既に持っている。今回はこのロジックを別窓表示側にも移植し、両表示モードの挙動を揃えることを優先した。別窓の「使い回して開く」設計（多重起動防止）自体は意図的なものなので変更していない。

<details>
<summary>Issue の意思決定テーブル（仮採用ログ）</summary>

| # | 対象 | 問い | 採用案 | 代替案 | 根拠・優先価値 | 確定方法 |
|---|---|---|---|---|---|---|
| 1 | 修正提案 | 別窓表示の追記ロジックをどう直すか | `osapi.ts` の `DamageSnapshot.show()` と同じtimestamp比較を `DamageSnapshotPage.tsx` に移植し、timestamp変化時は `uris` をクリアして置換、同一timestampは追記 | 別窓を戦闘ごとに毎回新規に開き直す（`Launcher.damagesnapshot()` の使い回し設計自体を変更） | 既存のINAPP側に実装済みの設計をそのまま踏襲でき、Launcherの「窓使い回し」という意図的な設計（多重起動防止）を変えずに済む。最小スコープ | 仮採用 |
| 2 | 修正提案 + 受け入れ条件 | `keepUntilNextShow` 設定（戦闘開始時に前画像を即座に消す/消さない）を別窓表示にも適用するか | 今回は対象外とする（timestampベースの置換ロジックのみ実装） | `clearSnapshotOnBattleStart`（kcsapi.ts）を拡張し、別窓にも `/dsnapshot:remove` 相当のメッセージを送る | 報告されたバグはtimestamp置換のみで解消する。scope拡大を避ける | 仮採用 |
| 3 | 受け入れ条件 | 3戦目以降の挙動をどう規定するか（Issue内で未確認と明記） | timestamp比較ロジックは戦闘回数に依存しないため、3戦目以降も同じロジックで「直近の戦闘結果のみ表示」が成立する | 3戦目以降は別途検証・別Issue化 | 実装ロジックがtimestampの差分検知である以上、N戦目に対して特別扱いする理由がない | 仮採用 |
| 4 | 受け入れ条件 | 連合艦隊（同一timestampで2枚生成）の既存挙動を維持するか | 維持する | 連合艦隊時も1枚だけに制限する（仕様変更） | INAPP側の既存コメントに「同一timestampは横並び維持が仕様」と明記されている | 仮採用 |

</details>

## 設計

| 変更 | ファイル | 内容 | 対応AC |
|---|---|---|---|
| 修正 | `src/page/snapshot/DamageSnapshotPage.tsx` | 受信した `timestamp` を `useRef` で直前の値と比較。異なれば `uris` を新規1枚の配列に置き換え、同一なら従来通り追記する | AC-1, AC-2, AC-3 |

## 受入条件

- [ ] AC-1 [UI] 別窓表示モードで2戦以上の海域に出撃したとき、2戦目以降の各戦闘終了時に表示される画像は直近の戦闘結果のみであり、前の戦闘の画像と横並びにならないこと。
- [ ] AC-2 [UI] 3戦目以降も同様に、常に直近の戦闘結果のみが表示され続けること（戦闘回数に応じて画像が積み上がらないこと）。
- [ ] AC-3 [UI] 連合艦隊で単一戦闘（同一timestamp）から2枚の画像が生成される場合は、従来通り2枚横並び表示を維持すること（回帰なきこと）。
- [x] AC-4 [BUILD] `pnpm build` および `pnpm typecheck` が通ること。 → `pnpm typecheck` / `pnpm lint` / `pnpm build` すべて成功、既存 `pnpm exec vitest run`（47件）も回帰なしで全パス。

AC-1〜AC-3 は実機の艦これでの複数戦闘の海域出撃が必要なため、この開発環境では自動検証できていません。`/uat` またはレビュアーによる実機確認をお願いします。

## 評価観点

- Issue 意思決定 #2 の通り、`keepUntilNextShow`（戦闘開始時に前画像をproactiveに消す設定）は別窓表示に対して未対応のまま残しています。ウィンドウ内表示と完全に同じ「消えるタイミング」までは揃っておらず、「新しい画像が来るまで前の画像が見え続ける」点は仕様として許容するかご確認ください。
- `shownTimestamp` を `useState` ではなく `useRef` にしています（比較のためだけの値で再レンダリングは不要なため）。Reactの作法として問題ないか一応ご確認ください。
- 連合艦隊の2ペイン目が「同一timestamp」で送られてくる前提を、`osapi.ts` 側の実装から踏襲していますが、実機での動作未確認です。

## 発見

なし
