### PR TITLE
fix(dashboard): 疲労タイマーの残り秒をゼロ埋め2桁で表示する

### DIFF
--- a/src/page/components/dashboard/FatigueQueueView.tsx
+++ b/src/page/components/dashboard/FatigueQueueView.tsx
@@ -17,7 +17,7 @@ export function FatigueQueueView({ queues, edit }: { queues: Queue[], edit: (q: 
           <div>{fatigue.seamap?.area}-{fatigue.seamap?.info}</div>
           <div className="flex-1 bg-gray-100">
             <div className={`pl-1 text-gray-400 ${color}`} style={{width: `${Math.floor(r.progress * 100)}%`}}>
-              {r.minutes}:{r.seconds}
+              {r.minutes}:{r.seconds.toString().padStart(2, "0")}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 背景

ダッシュボードの疲労回復タイマーは残り時間を `分:秒` で表示するが、秒が1桁のとき `9:4` のように表示され、残り時間として読み取りにくい。

## 方針

`Queue.remain()` が数値を返す設計はそのままに、表示側（`FatigueQueueView`）で秒のみ `padStart(2, "0")` でゼロ埋めする（`9:04` 形式。分はカウントダウン表示として自然な1桁のままとする）。ゼロ埋めの書き方は同ディレクトリ `ClockView.tsx` の既存イディオムに合わせた。

`remain()` の結果をほかに文字列として生表示している箇所がないことは確認済み（`CustomQueueModal` は number input の初期値としての数値利用のみ）。

## 確認

- `pnpm typecheck` / `pnpm lint` パス
- 実機（dev ビルド）で、秒が1桁になる瞬間の表示が `9:04` となることを目視および DOM テキストで確認
