### PR TITLE
fix: 通知設定の保存キーを _namespace_ で明示し、ビルドを跨ぐ設定消失を修正する

### DIFF
--- a/src/controllers/Runtime.ts
+++ b/src/controllers/Runtime.ts
@@ -1,3 +1,82 @@
+import { Logger } from "../logger";
+import Queue from "../models/Queue";
+import { Frame } from "../models/Frame";
+import { SortieContext } from "../models/Logbook";
+import { DashboardConfig } from "../models/configs/DashboardConfig";
+import { DamageSnapshotConfig } from "../models/configs/DamageSnapshotConfig";
+import { FileSaveConfig } from "../models/configs/FileSaveConfig";
+import { GameWindowConfig } from "../models/configs/GameWindowConfig";
+import { NotificationConfig } from "../models/configs/NotificationConfig";
 
 export async function onInstalled() {
+  try {
+    await migrateNotificationConfig();
+  } catch (e) {
+    Logger.get("Runtime").warn("NotificationConfig の移行に失敗:", e);
+  }
+}
+
+// 正規の保存先として使用中の chrome.storage.local トップレベルキー。移行の対象外。
+const KNOWN_NAMESPACES: string[] = [
+  Queue._namespace_,
+  Frame._namespace_,
+  SortieContext._namespace_,
+  DashboardConfig._namespace_,
+  DamageSnapshotConfig._namespace_,
+  FileSaveConfig._namespace_,
+  GameWindowConfig._namespace_,
+  NotificationConfig._namespace_,
+];
+
+// 通知設定テーブルのレコードID形式（/{EntryType または default}/{TriggerType}）
+const NOTIFICATION_RECORD_ID_PATTERN = /^\/(default|mission|recovery|shipbuild|fatigue)\/(start|end)$/;
+
+/**
+ * _namespace_ 未指定だった過去ビルドの NotificationConfig は、minify で短縮された
+ * クラス名が chrome.storage.local のキーになっており、ビルドが変わるとキーも変わって
+ * 保存済みの通知設定が読めなくなっていた。そうした短縮名キーに残った通知設定テーブルを
+ * 正規キー（NotificationConfig._namespace_）へ移行する。
+ *
+ * - 短縮名キーはビルドごとに異なり特定できないため、キー名ではなく値の形で判定する:
+ *   正規 namespace 以外のトップレベルキーで、値がオブジェクトかつ全レコードIDが
+ *   NOTIFICATION_RECORD_ID_PATTERN にマッチするものだけを移行対象とみなす。
+ * - 正規キーに既に存在するレコードは正規側を優先し、無いレコードだけ取り込む。
+ * - 取り込み後、移行元のキーは削除する。
+ * - 少しでも形が合わない場合は何もしない（誤爆防止を最優先とする）。
+ */
+export async function migrateNotificationConfig(
+  area: chrome.storage.StorageArea = chrome.storage.local,
+): Promise<void> {
+  const all = await area.get(null);
+  const strayKeys = Object.keys(all).filter((key) => {
+    return !KNOWN_NAMESPACES.includes(key) && isNotificationConfigTable(all[key]);
+  });
+  if (strayKeys.length === 0) return;
+
+  const canonical = all[NotificationConfig._namespace_] ?? {};
+  if (!isPlainObject(canonical)) return;
+
+  const merged: { [id: string]: unknown } = { ...canonical };
+  for (const key of strayKeys) {
+    for (const [id, record] of Object.entries(all[key] as { [id: string]: unknown })) {
+      if (!(id in merged)) merged[id] = record;
+    }
+  }
+  await area.set({ [NotificationConfig._namespace_]: merged });
+  await area.remove(strayKeys);
+}
+
+function isPlainObject(value: unknown): value is { [key: string]: unknown } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * 値が通知設定テーブル（レコードIDをキーとするオブジェクト）とみなせるかを判定する。
+ * 空のテーブルは移行しても意味がないため対象外とする。
+ */
+function isNotificationConfigTable(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const ids = Object.keys(value);
+  if (ids.length === 0) return false;
+  return ids.every((id) => NOTIFICATION_RECORD_ID_PATTERN.test(id) && isPlainObject(value[id]));
 }

--- a/src/models/configs/NotificationConfig.ts
+++ b/src/models/configs/NotificationConfig.ts
@@ -9,7 +9,7 @@ export interface NotificationConfigData {
 }
 
 export class NotificationConfig extends Model {
-  static tableName = "NotificationConfig";
+  static override _namespace_ = "NotificationConfig";
   static override default = {
     "/default/start": {
       enabled: true,

--- a/tests/model-namespace.spec.ts
+++ b/tests/model-namespace.spec.ts
@@ -1,0 +1,44 @@
+import { expect, describe, it, vi } from "vitest";
+
+// NotificationConfig は static default の初期化で chrome.runtime.getURL を参照するため、
+// import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+});
+
+import Queue from "../src/models/Queue";
+import { Frame } from "../src/models/Frame";
+import { SortieContext } from "../src/models/Logbook";
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+import { DamageSnapshotConfig } from "../src/models/configs/DamageSnapshotConfig";
+import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
+import { GameWindowConfig } from "../src/models/configs/GameWindowConfig";
+import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+
+// jstorm の Model は _namespace_ が未指定だとクラス名を chrome.storage.local のキーに使う。
+// minify でクラス名はビルドごとに変わる短縮名になるため、_namespace_ を明示しないモデルは
+// ビルドのたびに保存キーが変わり、保存済みデータが黙って初期値に戻る。
+// ここでは全モデルが _namespace_ を非空文字列で明示していることを検証する。
+const models = [
+  Queue,
+  Frame,
+  SortieContext,
+  DashboardConfig,
+  DamageSnapshotConfig,
+  FileSaveConfig,
+  GameWindowConfig,
+  NotificationConfig,
+] as const;
+
+describe("jstorm モデルの _namespace_", () => {
+  it.each(models.map((model) => [model.name, model] as const))(
+    "%s は _namespace_ を非空文字列で明示している",
+    (_name, model) => {
+      expect(model._namespace_).toBeTypeOf("string");
+      expect(model._namespace_).not.toBe("");
+    },
+  );
+});

--- a/tests/notification-config-migration.spec.ts
+++ b/tests/notification-config-migration.spec.ts
@@ -1,0 +1,91 @@
+import { expect, describe, it, vi } from "vitest";
+
+// NotificationConfig は static default の初期化で chrome.runtime.getURL を参照するため、
+// import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+});
+
+import { Model } from "jstorm/chrome/local";
+import { installMemoryStorage } from "jstorm/testing";
+
+import { migrateNotificationConfig } from "../src/controllers/Runtime";
+import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+
+// _namespace_ 未指定だった過去ビルドでは、NotificationConfig のテーブルが minify 後の
+// 短縮クラス名（"G" や "Z" 等、ビルドごとに異なる）のキーに保存されていた。
+// migrateNotificationConfig がそれらを正規キー "NotificationConfig" へ移行することを検証する。
+describe("migrateNotificationConfig", () => {
+  const record = (props: { [key: string]: unknown } = {}) => ({
+    enabled: false,
+    sound: null,
+    icon: null,
+    stay: false,
+    ...props,
+  });
+
+  it("短縮名キーの通知設定テーブルを正規キーへ移行し、移行元を削除する", async () => {
+    const area = installMemoryStorage({
+      "Z": {
+        "/mission/end": record({ _id: "/mission/end" }),
+        "/default/start": record({ sound: "beep.mp3", _id: "/default/start" }),
+      },
+      "Queue": { "1": { type: "mission" } },
+    });
+    Model.useStorage(area);
+
+    await migrateNotificationConfig(area);
+
+    const all = await area.get(null);
+    expect(all["Z"]).toBeUndefined();
+    expect(all["NotificationConfig"]).toEqual({
+      "/mission/end": record({ _id: "/mission/end" }),
+      "/default/start": record({ sound: "beep.mp3", _id: "/default/start" }),
+    });
+    // 移行後はモデル経由でも保存済みの設定が読める
+    const config = await NotificationConfig.find("/mission/end");
+    expect(config?.enabled).toBe(false);
+    // 通知設定と無関係のテーブルには触れない
+    expect(all["Queue"]).toEqual({ "1": { type: "mission" } });
+  });
+
+  it("移行対象がなければ何もしない", async () => {
+    const area = installMemoryStorage({
+      "NotificationConfig": { "/mission/end": record() },
+      "Queue": { "1": { type: "mission" } },
+      // レコードIDの形式が一部でも合わないテーブルは通知設定とみなさない
+      "X": { "/mission/end": record(), "user": { enabled: true } },
+      // オブジェクト以外の値も対象外
+      "Y": "not-a-table",
+    });
+    const before = await area.get(null);
+
+    await migrateNotificationConfig(area);
+
+    expect(await area.get(null)).toEqual(before);
+  });
+
+  it("正規キーに既にあるレコードは正規側を優先し、無いレコードだけ取り込む", async () => {
+    const area = installMemoryStorage({
+      "NotificationConfig": {
+        "/mission/end": record({ enabled: true, _id: "/mission/end" }),
+      },
+      "G": {
+        "/mission/end": record({ enabled: false, _id: "/mission/end" }),
+        "/fatigue/end": record({ stay: true, _id: "/fatigue/end" }),
+      },
+    });
+
+    await migrateNotificationConfig(area);
+
+    const all = await area.get(null);
+    expect(all["G"]).toBeUndefined();
+    expect(all["NotificationConfig"]).toEqual({
+      "/mission/end": record({ enabled: true, _id: "/mission/end" }),
+      "/fatigue/end": record({ stay: true, _id: "/fatigue/end" }),
+    });
+  });
+});


### PR DESCRIPTION
Closes #1818

## 方針

詳細な原因分析は #1818 のとおり。`NotificationConfig` が jstorm に存在しない `static tableName` を定義していたため、実行時のストレージキーが minify 後のクラス名（ビルド依存の短縮識別子）になっていた。本 PR は以下の2コミットで構成する。

| コミット | 内容 |
|---|---|
| 1 | `static tableName` を他モデルと同じ `static override _namespace_ = "NotificationConfig"` に置換。あわせて再発防止として、jstorm Model 継承クラス全8個が `_namespace_` を非空文字列で明示していることを検証する単体テスト（`tests/model-namespace.spec.ts`）を追加 |
| 2 | 過去ビルドの短縮名キーに残された通知設定を、install/update 時に一度だけ正規キーへ移行する処理（`Runtime.ts` の `onInstalled`）とその単体テストを追加 |

## 移行処理の設計

- 短縮名キーはビルドごとに異なり特定できないため、**キー名ではなく値の形で判定**する: 正規 namespace 以外のトップレベルキーのうち、値が非空オブジェクトで、全レコードIDが `/^\/(default|mission|recovery|shipbuild|fatigue)\/(start|end)$/` にマッチするものだけを移行対象とする。
- 正規キーに既存のレコードは正規側を優先し、無いIDだけ取り込む。取り込み後、移行元キーは削除する。
- 少しでも形が合わない場合は何もしない（誤爆防止優先）。全体を try-catch で包み、失敗しても拡張の起動は妨げない。

## 確認

- `pnpm typecheck` / `pnpm lint` / `vitest run tests`（13ファイル58テスト、新規11テスト含む）すべてパス
- 実機（dev ビルド・デバッグ用プロファイル）で以下を確認:
  - 修正前ビルドで options UI から保存した設定（短縮名 `Z` キーに保存されていたもの）が、修正後ビルドへのリロード時に `NotificationConfig` キーへ移行され、元キーが削除されること
  - 移行後、SW が正規キーの設定（`/fatigue/end` の stay=true）を実際に読み、通知が自動クローズせず常駐すること

## 評価観点

- 移行処理（コミット2）は独立コミットにしてあるので、救済不要（設定の一度きりの初期化を許容）という判断であればコミット2だけ落とせます。
- 形ベース判定の誤爆（通知設定と同形の無関係データを取り込む）は、レコードIDパターンの特異性から実質起こらないと考えていますが、懸念があればご指摘ください。
