### PR TITLE
fix: 出撃開始時に疲労回復通知を消去する（疲労タイマーの積み直しはオプトイン設定で追加）

### DIFF
--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -79,6 +79,8 @@ export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDet
   const map = { area: data.api_maparea_id[0], info: data.api_mapinfo_no[0] };
   const fatigue = new Fatigue(parseInt(deck), map);
   Logbook.sortie.start(deck, map);
+  // 出撃した艦隊の表示中の疲労回復通知を消す（疲労通知はENDでのみ発行される）
+  await NotificationService.new().clear(fatigue.$n.id(TriggerType.END));
   await Queue.create({ type: EntryType.FATIGUE, params: fatigue, scheduled: Date.now() + fatigue.time });
 }
 

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -11,6 +11,7 @@ import { NotificationService } from "../../services/NotificationService";
 import { Launcher } from "../../services/Launcher";
 import { Logbook } from "../../models/Logbook";
 import { DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig";
+import { BehaviorConfig } from "../../models/configs/BehaviorConfig";
 
 const log = Logger.get("WebRequest");
 
@@ -81,6 +82,15 @@ export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDet
   Logbook.sortie.start(deck, map);
   // 出撃した艦隊の表示中の疲労回復通知を消す（疲労通知はENDでのみ発行される）
   await NotificationService.new().clear(fatigue.$n.id(TriggerType.END));
+  // 設定が有効な場合のみ、同じ艦隊の既存の疲労Queueを削除して最新の1本に積み直す。
+  // 既定では削除せず出撃ごとにタイマーが並ぶ（連続出撃の回数把握に使える）。
+  const behavior = await BehaviorConfig.user();
+  if (behavior.restackFatigueOnSortie) {
+    const queues = await Queue.list();
+    for (const q of queues) {
+      if (q.type === EntryType.FATIGUE && Number(q.entry<Fatigue>().deck) === fatigue.deck) await q.delete();
+    }
+  }
   await Queue.create({ type: EntryType.FATIGUE, params: fatigue, scheduled: Date.now() + fatigue.time });
 }
 

--- a/src/models/configs/BehaviorConfig.ts
+++ b/src/models/configs/BehaviorConfig.ts
@@ -1,0 +1,20 @@
+import { Model } from "jstorm/chrome/local";
+
+// 細かい挙動設定。独立したセクションを設けるほどではない挙動のトグルをまとめて持つ。
+export class BehaviorConfig extends Model {
+  static override _namespace_ = "BehaviorConfig";
+
+  static override default = {
+    "user": {
+      // 出撃時に同じ艦隊の疲労タイマー（FATIGUE の Queue）を削除して積み直すか。
+      // 既定 false（出撃ごとにタイマーが並ぶ。連続出撃の回数把握に使える）。
+      "restackFatigueOnSortie": false,
+    },
+  };
+
+  public restackFatigueOnSortie: boolean = false;
+
+  public static async user(): Promise<BehaviorConfig> {
+    return (await this.find("user"))!;
+  }
+}

--- a/src/page/components/options/BehaviorSettingView.tsx
+++ b/src/page/components/options/BehaviorSettingView.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { BehaviorConfig } from "../../../models/configs/BehaviorConfig";
+import { FoldableSection } from "../FoldableSection";
+
+export function BehaviorSettingView({
+  config: _config,
+}: {
+  config: BehaviorConfig;
+}) {
+  const [config] = useState<BehaviorConfig>(_config);
+  const [restackFatigueOnSortie, setRestackFatigueOnSortie] = useState<boolean>(config.restackFatigueOnSortie ?? false);
+
+  return (
+    <FoldableSection title="細かい挙動設定" id="behavior">
+      <div className="mb-4">
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={restackFatigueOnSortie}
+            onChange={async (e) => {
+              const next = e.target.checked;
+              await config.update({ restackFatigueOnSortie: next });
+              setRestackFatigueOnSortie(next);
+            }}
+            className="w-4 h-4"
+          />
+          <span className="font-bold">出撃時に同じ艦隊の疲労タイマーを積み直す</span>
+        </label>
+        <div className="text-sm text-gray-600 mt-1">
+          オフ（既定）では出撃するたびに疲労タイマーが並びます（連続出撃の回数把握に使えます）。オンでは同じ艦隊の古いタイマーを削除して最新の1本だけにします。
+        </div>
+      </div>
+    </FoldableSection>
+  );
+}

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -7,6 +7,7 @@ import { Launcher } from "../../services/Launcher";
 import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
 import { DashboardConfig } from "../../models/configs/DashboardConfig";
 import { DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig";
+import { BehaviorConfig } from "../../models/configs/BehaviorConfig";
 import { GameWindowConfig } from "../../models/configs/GameWindowConfig";
 import { NotificationConfig } from "../../models/configs/NotificationConfig";
 import { EntryType, TriggerType } from "../../models/entry";
@@ -18,6 +19,7 @@ export async function options() {
   const filesave = await FileSaveConfig.user();
   const dashboard = await DashboardConfig.user();
   const damagesnapshot = await DamageSnapshotConfig.user();
+  const behavior = await BehaviorConfig.user();
   const notificationDefaults = {
     [TriggerType.START]: (await NotificationConfig.find("/default/start"))!,
     [TriggerType.END]: (await NotificationConfig.find("/default/end"))!,
@@ -52,6 +54,7 @@ export async function options() {
     filesave,
     dashboard,
     damagesnapshot,
+    behavior,
     notification: {
       defaults: notificationDefaults,
       entries: notificationEntries,

--- a/src/page/options/OptionsPage.tsx
+++ b/src/page/options/OptionsPage.tsx
@@ -3,6 +3,7 @@ import { FrameSettingView } from "../components/options/FrameSettingView";
 import { FileSaveSettingView } from "../components/options/FileSaveSettingView";
 import { DashboardSettingView } from "../components/options/DashboardSettingView";
 import { DamageSnapshotSettingView } from "../components/options/DamageSnapshotSettingView";
+import { BehaviorSettingView } from "../components/options/BehaviorSettingView";
 import { NotificationSettingView } from "../components/options/NotificationSettingView";
 import { InAppSettingView } from "../components/options/InAppSettingView";
 
@@ -10,6 +11,7 @@ import { type Frame } from "../../models/Frame";
 import { type FileSaveConfig } from "../../models/configs/FileSaveConfig";
 import { type DashboardConfig } from "../../models/configs/DashboardConfig";
 import { type DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig";
+import { type BehaviorConfig } from "../../models/configs/BehaviorConfig";
 import { DevelopmentInfoView, type ReleaseNoteObject } from "../components/options/DevelopmentInfoView";
 import { VersionView } from "../components/options/VersionView";
 import { type GameWindowConfig } from "../../models/configs/GameWindowConfig";
@@ -26,6 +28,7 @@ export function OptionsPage() {
     filesave,
     dashboard,
     damagesnapshot,
+    behavior,
     notification,
   } = useLoaderData() as {
     frames: Frame[];
@@ -34,6 +37,7 @@ export function OptionsPage() {
     filesave: FileSaveConfig;
     dashboard: DashboardConfig;
     damagesnapshot: DamageSnapshotConfig;
+    behavior: BehaviorConfig;
     notification: {
       defaults: Record<TriggerType.START | TriggerType.END, NotificationConfig>;
       entries: Record<EntryType, Record<TriggerType.START | TriggerType.END, NotificationConfig>>;
@@ -59,6 +63,8 @@ export function OptionsPage() {
       <FileSaveSettingView config={filesave} />
       <Divider />
       <DamageSnapshotSettingView config={damagesnapshot} />
+      <Divider />
+      <BehaviorSettingView config={behavior} />
       <Divider />
       <DevelopmentInfoView releasenote={releasenote} />
     </div>

--- a/tests/behavior-config.spec.ts
+++ b/tests/behavior-config.spec.ts
@@ -1,0 +1,22 @@
+import { expect, describe, it } from "vitest";
+
+import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+
+// 細かい挙動設定（BehaviorConfig）の既定値と保存・読み出し。
+describe("BehaviorConfig", () => {
+  it("既定では restackFatigueOnSortie は false（疲労タイマーは出撃ごとに積み上がる）", async () => {
+    const config = await BehaviorConfig.user();
+    expect(config.restackFatigueOnSortie).toBe(false);
+  });
+
+  it("static default の restackFatigueOnSortie も false", () => {
+    expect(BehaviorConfig.default.user.restackFatigueOnSortie).toBe(false);
+  });
+
+  it("update で保存した値を読み出せる", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ restackFatigueOnSortie: true });
+    const reloaded = await BehaviorConfig.user();
+    expect(reloaded.restackFatigueOnSortie).toBe(true);
+  });
+});


### PR DESCRIPTION
## 背景

疲労回復通知が、その艦隊で出撃した後も表示されたまま残る。v3 は出撃開始時に疲労通知を消去していた（`OnMapStart` の `clearAll(/^Tiredness/)`）が、v4 の `onMapStart` には対応する処理がない。

## 方針

| コミット | 内容 |
|---|---|
| 1 | `onMapStart` で出撃した艦隊の疲労回復通知（`/fatigue/end/{deck}`）を消去する。v3 は全艦隊分を消していたが、通知が艦隊単位の情報であることから出撃した艦隊の分のみ消す。疲労通知は `QueueWatcher` が END トリガーでのみ発行するため、消去対象も END のみ |
| 2 | 「出撃時に同じ艦隊の疲労タイマーを積み直す（古い Queue を削除して最新の1本にする）」を**オプトイン設定**として追加。既定はオフで、従来どおり出撃ごとにタイマーが並ぶ。積み上がるタイマーを連続出撃の回数把握（キラ付け等）に使う運用が実在するため、既定挙動は変えない。設定の受け皿として設定画面に「細かい挙動設定」セクションと `BehaviorConfig` モデル（`_namespace_` 明示）を新設 |

## 確認

- `pnpm typecheck` / `pnpm lint` / `vitest run tests`（50テスト、`BehaviorConfig` の既定値・保存のテスト含む）すべてパス
- 実機（dev ビルド）で確認:
  - 疲労回復通知が常駐した状態から該当艦隊で出撃 → 通知が消去される
  - 既定（設定オフ）では出撃ごとに疲労タイマーが積み上がる（従来挙動の維持）
  - 設定オンでは既存タイマーが削除され最新の1本に積み直される
- 「通知が常駐する」状態の再現には通知の「消えない」設定が必要で、これは #1819 の修正で初めて実際に機能する。本修正は #1819 とコード上の依存はないが、効果が最も見えるのは併用時
