### PR TITLE
feat: スクショの保存フォーマットを png/jpeg から選択できるようにする

### DIFF
--- a/src/controllers/Commands.ts
+++ b/src/controllers/Commands.ts
@@ -13,9 +13,7 @@ onCommand.on("/screenshot", async () => {
   }
   const config = await FileSaveConfig.user();
   const service = new DownloadService(config);
-  // TODO: formatもconfigから取得できるようにする
-  const format = "png"; 
-  const uri = await launcher.capture(win.id, { format });
+  const uri = await launcher.capture(win.id, { format: config.format });
   return await service.download(uri);
 });
 

--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -61,8 +61,7 @@ onMessage.on("/screenshot", async (_, sender) => {
   const launcher = new Launcher();
   const config = await FileSaveConfig.user();
   const s = new DownloadService(config);
-  const format = "png";
-  const uri = await launcher.capture(sender.tab.windowId, { format });
+  const uri = await launcher.capture(sender.tab.windowId, { format: config.format });
   return await s.download(uri);
 });
 

--- a/src/models/configs/FileSaveConfig.ts
+++ b/src/models/configs/FileSaveConfig.ts
@@ -1,5 +1,9 @@
 import { Model } from "jstorm/chrome/local";
 
+// スクリーンショットの保存画像フォーマット
+// chrome.tabs.captureVisibleTab の format に渡せる値と一致させる
+export type ImageFormat = "png" | "jpeg";
+
 export class FileSaveConfig extends Model {
   public static readonly _namespace_ = "FileSaveConfig";
 
@@ -7,12 +11,14 @@ export class FileSaveConfig extends Model {
     "user": {
       askAlways: false,
       folder: "艦これ",
-      filenameTemplate: "%Y%m%d_%H%M%S.png",
+      filenameTemplate: "%Y%m%d_%H%M%S",
+      format: "png" as ImageFormat,
     }
   };
 
   static async user(): Promise<FileSaveConfig> {
-    return (await this.find("user"))!;
+    const config = (await this.find("user"))!;
+    return await config.migrateFilenameExtension();
   }
 
   // 保存前に毎回ファイル保存先を指定すべきか
@@ -23,13 +29,31 @@ export class FileSaveConfig extends Model {
   // デフォルト: "艦これ" (= "~/Downloads/艦これ")
   public folder: string = "艦これ";
 
-  // 保存ファイル名テンプレート
+  // 保存ファイル名テンプレート（拡張子なし、拡張子は format から付与される）
   // %Y: 年(4桁), %m: 月(2桁), %d: 日(2桁), %H: 時(2桁), %M: 分(2桁), %S: 秒(2桁)
-  // デフォルト: "%Y%m%d_%H%M%S.png" (例: "20240615_134501.png")
-  public filenameTemplate: string = "%Y%m%d_%H%M%S.png";
+  // デフォルト: "%Y%m%d_%H%M%S" (例: "20240615_134501.png")
+  public filenameTemplate: string = "%Y%m%d_%H%M%S";
+
+  // 保存画像フォーマット。ファイル名の拡張子もこれに従う
+  public format: ImageFormat = "png";
 
   /**
-   * ファイル名を生成する
+   * filenameTemplate 末尾に拡張子を含む設定を、拡張子なしテンプレートと format の組に
+   * 移行して保存し直す。format 導入以前の設定は拡張子込みテンプレートだったため、その互換処理。
+   * @returns 移行後（または移行不要ならそのまま）の設定
+   */
+  private async migrateFilenameExtension(): Promise<FileSaveConfig> {
+    const matched = this.filenameTemplate.match(/\.(png|jpe?g)$/i);
+    if (!matched) return this;
+    const format: ImageFormat = matched[1].toLowerCase() === "png" ? "png" : "jpeg";
+    return await this.update({
+      filenameTemplate: this.filenameTemplate.slice(0, -matched[0].length),
+      format,
+    });
+  }
+
+  /**
+   * ファイル名を生成する（拡張子込み）
    * @param date 日付オブジェクト
    * @returns 生成されたファイル名
    */
@@ -47,6 +71,6 @@ export class FileSaveConfig extends Model {
     filename = filename.replace(/%H/g, H);
     filename = filename.replace(/%M/g, M);
     filename = filename.replace(/%S/g, S);
-    return filename;
+    return `${filename}.${this.format}`;
   }
 }

--- a/src/page/components/dashboard/ActionsView.tsx
+++ b/src/page/components/dashboard/ActionsView.tsx
@@ -21,8 +21,7 @@ function CaptureControlButton({ tab, launcher }: { tab?: chrome.tabs.Tab, launch
   return (
     <div onClick={async () => {
       const config = await FileSaveConfig.user();
-      const format = "png";
-      const uri = await launcher.capture(tab.windowId, { format });
+      const uri = await launcher.capture(tab.windowId, { format: config.format });
       const s = new DownloadService(config);
       /* const downloadId = */ await s.download(uri);
       // await s.show(downloadId);

--- a/src/page/components/options/FileSaveSettingView.tsx
+++ b/src/page/components/options/FileSaveSettingView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileSaveConfig } from "../../../models/configs/FileSaveConfig";
+import { FileSaveConfig, type ImageFormat } from "../../../models/configs/FileSaveConfig";
 import { FoldableSection } from "../FoldableSection";
 
 export function FileSaveSettingView({
@@ -61,17 +61,31 @@ export function FileSaveSettingView({
         <div className="mb-4">
           <label className="block mb-2">
             <span className="font-bold">ファイル名テンプレート</span>
+            <span className="text-sm text-gray-600 ml-2">(拡張子は保存フォーマットに従う)</span>
           </label>
-          <input
-            type="text"
-            defaultValue={config.filenameTemplate || ""}
-            onChange={async (e) => {
-              await config.update({ filenameTemplate: e.target.value });
-              setPreview(config!.getFilename(new Date()));
-            }}
-            className="border rounded p-2 w-full max-w-md font-mono"
-            placeholder="%Y%m%d_%H%M%S.png"
-          />
+          <div className="flex items-center gap-2 w-full max-w-md">
+            <input
+              type="text"
+              defaultValue={config.filenameTemplate || ""}
+              onChange={async (e) => {
+                await config.update({ filenameTemplate: e.target.value });
+                setPreview(config!.getFilename(new Date()));
+              }}
+              className="border rounded p-2 flex-1 font-mono"
+              placeholder="%Y%m%d_%H%M%S"
+            />
+            <select
+              defaultValue={config.format}
+              onChange={async (e) => {
+                await config.update({ format: e.target.value as ImageFormat });
+                setPreview(config!.getFilename(new Date()));
+              }}
+              className="border rounded p-2 font-mono"
+            >
+              <option value="png">.png</option>
+              <option value="jpeg">.jpeg</option>
+            </select>
+          </div>
           <div className="text-sm text-gray-600 mt-1">
             <div>使用可能な変数 ( %Y: 年(4桁), %m: 月(2桁), %d: 日(2桁) %H: 時(2桁), %M: 分(2桁), %S: 秒(2桁))</div>
             <div className="mt-2">

--- a/src/page/fleet-capture/useFleetCapture.ts
+++ b/src/page/fleet-capture/useFleetCapture.ts
@@ -77,7 +77,7 @@ export function useFleetCapture({
       });
       const config = await FileSaveConfig.user();
       const downloadService = new DownloadService(config);
-      const dataUrl = canvas.toDataURL("image/png");
+      const dataUrl = canvas.toDataURL(`image/${config.format}`);
       await downloadService.download(dataUrl);
     } catch (error) {
       log.error("exportResults failed", error);

--- a/tests/file-save-config.spec.ts
+++ b/tests/file-save-config.spec.ts
@@ -1,0 +1,53 @@
+import { expect, describe, it } from "vitest";
+
+import { Model } from "jstorm/chrome/local";
+import { installMemoryStorage } from "jstorm/testing";
+
+import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
+
+// スクショ保存設定（FileSaveConfig）の既定値と、拡張子込みテンプレート
+// （format 導入以前の旧形式）から拡張子なしテンプレート + format への移行を検証する。
+describe("FileSaveConfig", () => {
+  it("既定はテンプレート拡張子なし + format png で、getFilename が .png を付ける", async () => {
+    const config = await FileSaveConfig.user();
+    expect(config.filenameTemplate).toBe("%Y%m%d_%H%M%S");
+    expect(config.format).toBe("png");
+    expect(config.getFilename(new Date(2024, 5, 15, 13, 45, 1))).toBe("20240615_134501.png");
+  });
+
+  it.each([
+    ["%Y%m%d_%H%M%S.png", "%Y%m%d_%H%M%S", "png"],
+    ["kancolle_%H%M%S.jpg", "kancolle_%H%M%S", "jpeg"],
+    ["kancolle_%H%M%S.jpeg", "kancolle_%H%M%S", "jpeg"],
+  ])("旧形式テンプレート %s を拡張子なしテンプレート + format=%s に移行して保存し直す", async (legacy, template, format) => {
+    const area = installMemoryStorage({
+      "FileSaveConfig": {
+        "user": { _id: "user", askAlways: false, folder: "艦これ", filenameTemplate: legacy },
+      },
+    });
+    Model.useStorage(area);
+
+    const config = await FileSaveConfig.user();
+
+    expect(config.filenameTemplate).toBe(template);
+    expect(config.format).toBe(format);
+    // 移行結果が storage にも永続化されている
+    const all = await area.get(null);
+    expect(all["FileSaveConfig"]["user"]).toMatchObject({ filenameTemplate: template, format });
+  });
+
+  it("拡張子なしテンプレートは移行対象外で、設定済みの format を上書きしない", async () => {
+    const area = installMemoryStorage({
+      "FileSaveConfig": {
+        "user": { _id: "user", askAlways: false, folder: "艦これ", filenameTemplate: "%Y%m%d_%H%M%S", format: "jpeg" },
+      },
+    });
+    Model.useStorage(area);
+
+    const config = await FileSaveConfig.user();
+
+    expect(config.filenameTemplate).toBe("%Y%m%d_%H%M%S");
+    expect(config.format).toBe("jpeg");
+    expect(config.getFilename(new Date(2024, 5, 15, 13, 45, 1))).toBe("20240615_134501.jpeg");
+  });
+});


### PR DESCRIPTION
## 背景

v4 のスクリーンショット保存は PNG 固定で、すべてのキャプチャ経路で format が直書きされていた（`Commands.ts` には「TODO: formatもconfigから取得できるようにする」が残っていた）。一方でファイル名テンプレート（`FileSaveConfig.filenameTemplate`）は拡張子込みの自由文字列のため、テンプレートに `.jpg` と書くと「拡張子は .jpg だが中身は PNG」というファイルが生成される不整合があった。v3 には png/jpeg の選択機能があった（`ScreenshotSetting.format`）ため、同等の選択式を v4 に実装する。

## 変更内容

- `FileSaveConfig` に `format`（`"png" | "jpeg"`、既定 png）を追加し、`filenameTemplate` を拡張子なしに変更。`getFilename()` が `"." + format` を付与する
- すべてのキャプチャ経路で `config.format` を参照する
  - ゲーム画面のカメラボタン（`Message.ts`）/ キーボードショートカット（`Commands.ts`）/ ダッシュボード（`ActionsView`）/ 編成キャプチャ（`useFleetCapture`）
- options の「スクショ保存の設定」に、テンプレート入力欄の隣へ `.png` / `.jpeg` の選択ボックスを追加（v3 と同じ配置）。プレビューは拡張子込みで表示

## 互換性（既存設定の移行）

既存の `filenameTemplate` は拡張子込み（例: `"%Y%m%d_%H%M%S.png"`）で保存されている。`FileSaveConfig.user()` での読み込み時、テンプレート末尾が `.png` / `.jpg` / `.jpeg` の場合は拡張子を剥がして `format` に反映し保存し直す（一度きりの移行）。移行後の保存ファイル名は従来と同一になる。

なお、従来テンプレートに `.jpg` と書いていた場合、「名前だけ .jpg で中身 PNG」だったファイルが移行後は実際に JPEG で保存されるようになる（拡張子に書いた意図へ実体を合わせる方向の変化）。

## 確認

- `pnpm typecheck` / `pnpm lint` / `vitest run --dir tests`（15ファイル66テスト、新規5テスト含む）すべてパス
- 実機（dev ビルド・デバッグ用プロファイル）で確認:
  - 旧形式 `"%Y%m%d_%H%M%S.png"` が拡張子なし template + `format: png` に移行されること
  - 旧形式 `"kancolle_%H%M%S.jpg"` が `format: jpeg` に移行されること
  - options の選択ボックスで format を切り替えて保存・プレビュー反映されること
  - JPEG 選択時に実際に JPEG ファイルがダウンロードされること
