### PR TITLE
回収操作時に遠征・建造の通知を消去する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,13 +232,13 @@ DMM popup window (www.dmm.com)
 通知IDにメタデータをエンコード：
 
 ```
-/{type}/{deck_or_dock}/{trigger}
+/{type}/{trigger}/{deck_or_dock}
 
 例:
-/mission/2/end     // 艦隊2の遠征完了
-/recovery/1/start  // ドック1の修復開始
-/shipbuild/3/end   // ドック3の建造完了
-/fatigue/4/end     // 艦隊4の疲労回復
+/mission/end/2     // 艦隊2の遠征完了
+/recovery/start/1  // ドック1の修復開始
+/shipbuild/end/3   // ドック3の建造完了
+/fatigue/end/4     // 艦隊4の疲労回復
 ```
 
 ### Sequential API処理

--- a/src/controllers/WebRequest/datatypes.ts
+++ b/src/controllers/WebRequest/datatypes.ts
@@ -9,6 +9,10 @@ export interface MissionStartFormData {
     // api_verno: string[];
 }
 
+export interface MissionResultFormData {
+    api_deck_id: string[];
+}
+
 export interface RecoveryStartFormData {
     api_highspeed: string[];
     api_ndock_id: string[];
@@ -37,4 +41,8 @@ export interface CreateShipFormData {
     // api_item5: string[];
     // api_token: string[];
     // api_verno: string[];
+}
+
+export interface GetShipFormData {
+    api_kdock_id: string[];
 }

--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -13,6 +13,7 @@ import {
   onBattleStarted,
   onCombinedBattleStarted,
   onCreateShip,
+  onGetShip,
   onBattleResulted,
   onMapNext,
   onMidnightBattleStarted,
@@ -48,6 +49,7 @@ onBeforeRequest.on([
   '/kcsapi/api_req_kousyou/createship',
   '/kcsapi/api_get_member/kdock',
 ], onCreateShip); // 新造艦を作成しようとしたとき
+onBeforeRequest.on(["/kcsapi/api_req_kousyou/getship"], onGetShip); // 建造した艦を受け取ったとき
 
 onBeforeRequest.onNotFound(async (details) => {
   requestLogger.debug("-", details);

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -2,7 +2,7 @@ import { Logger } from "../../logger";
 import { missions } from "../../catalog";
 import { sleep, WorkerImage } from "../../utils";
 import Queue from "../../models/Queue";
-import { CreateShipFormData, MapStartFormData, MissionStartFormData, RecoveryStartFormData } from "./datatypes";
+import { CreateShipFormData, GetShipFormData, MapStartFormData, MissionResultFormData, MissionStartFormData, RecoveryStartFormData } from "./datatypes";
 import { EntryType, Fatigue, Mission } from "../../models/entry";
 import { TriggerType } from "../../models/entry";
 import { TabService } from "../../services/TabService";
@@ -48,14 +48,20 @@ export async function onMissionReturnInstruction([details]: chrome.webRequest.On
   log.debug("onMissionReturnInstruction", details);
 }
 
+// 指定タイプ・指定艦隊(ドック)の通知を全トリガー分消す。
+// 通知IDは /{type}/{trigger}/{deck|dock} 形式（各 entry の $n.id 参照）。
+async function clearNotificationsOf(type: EntryType, target: string) {
+  const service = NotificationService.new();
+  const notifications = await service.getAll();
+  for (const id of Object.keys(notifications)) {
+    if (id.startsWith(`/${type}/`) && id.endsWith(`/${target}`)) await service.clear(id);
+  }
+}
+
+// 遠征結果を回収したとき、その艦隊の遠征通知（開始・完了）を消す
 export async function onMissionResult([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_deck_id: [api_deck_id] } = details.requestBody?.formData as unknown as { api_deck_id: string[], api_mission_id: string[] };
-  // TODO: @types/chrome の chrome.notifications.getAll が Promise を返すようになったら修正
-  await chrome.notifications.getAll((notifications) => {
-    for (const id in notifications) {
-      if (id.match(`/${EntryType.MISSION}/${api_deck_id}`)) chrome.notifications.clear(id);
-    }
-  });
+  const { api_deck_id: [deck] } = details.requestBody?.formData as unknown as MissionResultFormData;
+  await clearNotificationsOf(EntryType.MISSION, deck);
 }
 
 export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
@@ -155,6 +161,12 @@ export async function onCombinedSpMidnightBattleStarted([details]: chrome.webReq
 export async function onBattleResulted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   log.debug("onBattleResulted", details);
   Logbook.sortie.battle.result();
+}
+
+// 建造した艦を受け取ったとき、そのドックの建造通知（開始・完了）を消す
+export async function onGetShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as GetShipFormData;
+  await clearNotificationsOf(EntryType.SHIPBUILD, dock);
 }
 
 export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {

--- a/tests/notification-clear-on-collection.spec.ts
+++ b/tests/notification-clear-on-collection.spec.ts
@@ -1,0 +1,78 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// NotificationService が chrome.notifications を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: {
+      id: "test",
+      onMessage: { addListener: () => {} },
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    notifications: {
+      getAll: vi.fn(),
+      clear: vi.fn(),
+    },
+  };
+});
+
+import { onMissionResult, onGetShip } from "../src/controllers/WebRequest/kcsapi";
+
+const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
+const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
+
+// 表示中の通知IDを与えてスタブを構成する（コールバック形式のAPI）
+const displaying = (ids: string[]) => {
+  getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
+    cb(Object.fromEntries(ids.map((id) => [id, true])));
+  });
+  clear.mockImplementation((_id: string, cb: (wasCleared: boolean) => void) => cb(true));
+};
+
+// ハンドラに渡す webRequest details の最小構成
+const details = (formData: Record<string, string[]>) =>
+  [{ requestBody: { formData } }] as unknown as chrome.webRequest.OnBeforeRequestDetails[];
+
+const clearedIds = () => clear.mock.calls.map(([id]) => id);
+
+// 回収操作（遠征結果回収・建造艦受取）で、対象の艦隊/ドックの通知だけが消えることを検証する。
+// 通知IDは /{type}/{trigger}/{deck|dock} 形式（tests/notification-id.spec.ts 参照）。
+describe("onMissionResult", () => {
+  beforeEach(() => {
+    getAll.mockReset();
+    clear.mockReset();
+  });
+
+  it("回収した艦隊の遠征通知（開始・完了）を消す", async () => {
+    displaying(["/mission/start/2", "/mission/end/2"]);
+    await onMissionResult(details({ api_deck_id: ["2"] }));
+    expect(clearedIds()).toEqual(expect.arrayContaining(["/mission/start/2", "/mission/end/2"]));
+    expect(clearedIds()).toHaveLength(2);
+  });
+
+  it("他艦隊の遠征通知や、同じ艦隊番号の他タイプの通知は消さない", async () => {
+    displaying(["/mission/end/2", "/mission/end/3", "/fatigue/end/2", "/recovery/end/2"]);
+    await onMissionResult(details({ api_deck_id: ["2"] }));
+    expect(clearedIds()).toEqual(["/mission/end/2"]);
+  });
+});
+
+describe("onGetShip", () => {
+  beforeEach(() => {
+    getAll.mockReset();
+    clear.mockReset();
+  });
+
+  it("受け取ったドックの建造通知（開始・完了）を消す", async () => {
+    displaying(["/shipbuild/start/3", "/shipbuild/end/3"]);
+    await onGetShip(details({ api_kdock_id: ["3"] }));
+    expect(clearedIds()).toEqual(expect.arrayContaining(["/shipbuild/start/3", "/shipbuild/end/3"]));
+    expect(clearedIds()).toHaveLength(2);
+  });
+
+  it("他ドックの建造通知は消さない", async () => {
+    displaying(["/shipbuild/end/3", "/shipbuild/end/1", "/recovery/end/3"]);
+    await onGetShip(details({ api_kdock_id: ["3"] }));
+    expect(clearedIds()).toEqual(["/shipbuild/end/3"]);
+  });
+});

--- a/tests/notification-id.spec.ts
+++ b/tests/notification-id.spec.ts
@@ -1,0 +1,31 @@
+import { expect, describe, it } from "vitest";
+
+import { missions } from "../src/catalog";
+import { Fatigue, Mission, Recovery, Shipbuild, TriggerType } from "../src/models/entry";
+
+// 通知IDは /{type}/{trigger}/{deck|dock} 形式（CLAUDE.md「通知ID規約」）。
+// WebRequest 側の消去処理はこの形式への prefix/suffix 照合に依存しているため、形式を契約として固定する。
+describe("通知IDの形式", () => {
+  it("Mission は /mission/{trigger}/{deck}", () => {
+    const mission = new Mission("2", 5, missions["5"]);
+    expect(mission.$n.id(TriggerType.START)).toBe("/mission/start/2");
+    expect(mission.$n.id(TriggerType.END)).toBe("/mission/end/2");
+  });
+
+  it("Recovery は /recovery/{trigger}/{dock}", () => {
+    const recovery = new Recovery(1, 30 * 60 * 1000);
+    expect(recovery.$n.id(TriggerType.START)).toBe("/recovery/start/1");
+    expect(recovery.$n.id(TriggerType.END)).toBe("/recovery/end/1");
+  });
+
+  it("Shipbuild は /shipbuild/{trigger}/{dock}", () => {
+    const shipbuild = new Shipbuild(3, 60 * 60 * 1000);
+    expect(shipbuild.$n.id(TriggerType.START)).toBe("/shipbuild/start/3");
+    expect(shipbuild.$n.id(TriggerType.END)).toBe("/shipbuild/end/3");
+  });
+
+  it("Fatigue は /fatigue/{trigger}/{deck}", () => {
+    const fatigue = new Fatigue(4, { area: 1, info: 1 });
+    expect(fatigue.$n.id(TriggerType.END)).toBe("/fatigue/end/4");
+  });
+});


### PR DESCRIPTION
## 問題

- 遠征結果を回収しても、その艦隊の遠征通知が消えない。通知消去処理が通知IDを `/{type}/{deck}` の形で照合していたが、実際の通知IDは `/{type}/{trigger}/{deck}` 形式（例: `/mission/end/2`）のため一度もマッチしていなかった。
- 建造した艦を受け取っても建造通知が消えない。v3 にあった `api_req_kousyou/getship` をトリガーとする消去処理が v4 には存在しなかった。

## 変更内容

- 遠征結果回収時（`api_req_mission/result`）に、回収した艦隊の遠征通知（開始・完了）を消すよう照合を修正
- 建造艦受取時（`api_req_kousyou/getship`）に、該当ドックの建造通知（開始・完了）を消す `onGetShip` を追加
- 両者の消去処理を `clearNotificationsOf(type, target)` ヘルパーに集約し、通知IDの手組みによる形式不一致が再発しにくい構成にした
- CLAUDE.md の通知ID規約の記載が実装と逆順（`/{type}/{deck_or_dock}/{trigger}`）だったため、実装どおり `/{type}/{trigger}/{deck_or_dock}` に修正
- 通知ID形式を契約として固定する `tests/notification-id.spec.ts` を追加

## 動作確認

- `pnpm typecheck` / `pnpm lint` / vitest（tests/ 配下 16 ファイル 70 件）通過
