### PR TITLE
タイマーの監視間隔を設定可能にする

### DIFF
--- a/src/controllers/Alarm.ts
+++ b/src/controllers/Alarm.ts
@@ -1,13 +1,22 @@
 import { Router } from "chromite";
 import * as QueueWatcher from "./Cron/QueueWatcher";
+import { BehaviorConfig } from "../models/configs/BehaviorConfig";
+import { sleep } from "../utils";
 
 const r = new Router<typeof chrome.alarms.onAlarm>(async (alarm) => ({ __action__: alarm.name }));
 
+// chrome.alarms の周期は下限が30秒のため、それより短い監視間隔は
+// アラーム発火で起きた Service Worker の生存中に、間隔ごとに複数回チェックすることで実現する。
+// 例: 監視間隔10秒なら、0秒・10秒・20秒後の3回チェックし、残りは次のアラーム発火が引き継ぐ。
 r.on("/cron/queues", async (/* alarm */) => {
-  QueueWatcher.Once();
+  const config = await BehaviorConfig.user();
+  const interval = config.normalizedQueueWatchIntervalSeconds();
+  for (let elapsed = 0; elapsed < BehaviorConfig.ALARM_PERIOD_SECONDS; elapsed += interval) {
+    if (elapsed > 0) await sleep(interval * 1000);
+    await QueueWatcher.Once();
+  }
 });
 
 setTimeout(() => QueueWatcher.Once(), 10);
 
 export default r;
-

--- a/src/controllers/Cron/QueueWatcher.ts
+++ b/src/controllers/Cron/QueueWatcher.ts
@@ -2,7 +2,17 @@ import { Logger } from "../../logger";
 import Queue from "../../models/Queue";
 import { NotificationService } from "../../services/NotificationService";
 
-export async function Once() {
+// Once の実行を直列化するための Promise チェーン。
+// 多重起動で同一 Queue を並行チェックすると二重通知の恐れがあるため、前回の実行完了を待ってから次を実行する。
+let serial: Promise<void> = Promise.resolve();
+
+export function Once(): Promise<void> {
+  const result = serial.then(() => check());
+  serial = result.catch((e) => Logger.get("QueueWatcher").warn("Once:", e));
+  return result;
+}
+
+async function check() {
   const log = Logger.get("QueueWatcher");
   const queues = await Queue.list();
   const notification = new NotificationService();

--- a/src/models/configs/BehaviorConfig.ts
+++ b/src/models/configs/BehaviorConfig.ts
@@ -1,20 +1,41 @@
 import { Model } from "jstorm/chrome/local";
 
-// 細かい挙動設定。独立したセクションを設けるほどではない挙動のトグルをまとめて持つ。
+// タイマー監視間隔（秒）の選択肢
+export const QueueWatchIntervalOptions = [5, 10, 20, 30] as const;
+export type QueueWatchIntervalSeconds = (typeof QueueWatchIntervalOptions)[number];
+
+const DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS: QueueWatchIntervalSeconds = 30;
+
+// 細かい挙動設定。独立したセクションを設けるほどではない挙動の設定をまとめて持つ。
 export class BehaviorConfig extends Model {
   static override _namespace_ = "BehaviorConfig";
+
+  // /cron/queues アラームの周期（秒）。chrome.alarms の periodInMinutes 下限 0.5 に相当する。
+  public static readonly ALARM_PERIOD_SECONDS = 30;
 
   static override default = {
     "user": {
       // 出撃時に同じ艦隊の疲労タイマー（FATIGUE の Queue）を削除して積み直すか。
       // 既定 false（出撃ごとにタイマーが並ぶ。連続出撃の回数把握に使える）。
       "restackFatigueOnSortie": false,
+      // Queue の期限を確認する間隔（秒）。短いほど予定時刻に近いタイミングで通知される。
+      "queueWatchIntervalSeconds": DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS,
     },
   };
 
   public restackFatigueOnSortie: boolean = false;
+  public queueWatchIntervalSeconds: number = DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS;
 
   public static async user(): Promise<BehaviorConfig> {
     return (await this.find("user"))!;
+  }
+
+  /**
+   * タイマー監視間隔（秒）を選択肢のいずれかに正規化して返す。
+   * 保存値が選択肢にない場合は既定の30秒として扱う。
+   */
+  public normalizedQueueWatchIntervalSeconds(): QueueWatchIntervalSeconds {
+    const found = QueueWatchIntervalOptions.find((v) => v === this.queueWatchIntervalSeconds);
+    return found ?? DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS;
   }
 }

--- a/src/page/components/options/BehaviorSettingView.tsx
+++ b/src/page/components/options/BehaviorSettingView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BehaviorConfig } from "../../../models/configs/BehaviorConfig";
+import { BehaviorConfig, QueueWatchIntervalOptions, QueueWatchIntervalSeconds } from "../../../models/configs/BehaviorConfig";
 import { FoldableSection } from "../FoldableSection";
 
 export function BehaviorSettingView({
@@ -9,6 +9,7 @@ export function BehaviorSettingView({
 }) {
   const [config] = useState<BehaviorConfig>(_config);
   const [restackFatigueOnSortie, setRestackFatigueOnSortie] = useState<boolean>(config.restackFatigueOnSortie ?? false);
+  const [queueWatchIntervalSeconds, setQueueWatchIntervalSeconds] = useState<QueueWatchIntervalSeconds>(config.normalizedQueueWatchIntervalSeconds());
 
   return (
     <FoldableSection title="細かい挙動設定" id="behavior">
@@ -28,6 +29,29 @@ export function BehaviorSettingView({
         </label>
         <div className="text-sm text-gray-600 mt-1">
           オフ（既定）では出撃するたびに疲労タイマーが並びます（連続出撃の回数把握に使えます）。オンでは同じ艦隊の古いタイマーを削除して最新の1本だけにします。
+        </div>
+      </div>
+      <div className="mb-4">
+        <label className="block mb-2">
+          <span className="font-bold">タイマーの監視間隔</span>
+        </label>
+        <select
+          value={queueWatchIntervalSeconds}
+          onChange={async (e) => {
+            const next = Number(e.target.value) as QueueWatchIntervalSeconds;
+            await config.update({ queueWatchIntervalSeconds: next });
+            setQueueWatchIntervalSeconds(next);
+          }}
+          className="border rounded p-2"
+        >
+          {QueueWatchIntervalOptions.map((seconds) => (
+            <option key={seconds} value={seconds}>
+              {seconds}秒
+            </option>
+          ))}
+        </select>
+        <div className="text-sm text-gray-600 mt-1">
+          遠征・入渠・建造などのタイマーの期限を確認する間隔です。短くするほど予定時刻に近いタイミングで通知されますが、30秒より短い間隔では拡張機能が休止できなくなるため、バッテリー消費がわずかに増えます。ノートPCなど電力が気になる環境では既定の30秒のままをおすすめします。
         </div>
       </div>
     </FoldableSection>

--- a/tests/behavior-config.spec.ts
+++ b/tests/behavior-config.spec.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from "vitest";
 
-import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+import { BehaviorConfig, QueueWatchIntervalOptions } from "../src/models/configs/BehaviorConfig";
 
 // 細かい挙動設定（BehaviorConfig）の既定値と保存・読み出し。
 describe("BehaviorConfig", () => {
@@ -18,5 +18,39 @@ describe("BehaviorConfig", () => {
     await config.update({ restackFatigueOnSortie: true });
     const reloaded = await BehaviorConfig.user();
     expect(reloaded.restackFatigueOnSortie).toBe(true);
+  });
+});
+
+// タイマー監視間隔（Queue の期限確認間隔）の既定値・保存・正規化のルール。
+describe("BehaviorConfig.queueWatchIntervalSeconds", () => {
+  it("未保存のときは既定の30秒が返る", async () => {
+    const config = await BehaviorConfig.user();
+    expect(config.queueWatchIntervalSeconds).toBe(30);
+    expect(config.normalizedQueueWatchIntervalSeconds()).toBe(30);
+  });
+
+  it("保存した監視間隔を読み出せる", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ queueWatchIntervalSeconds: 5 });
+    const reloaded = await BehaviorConfig.user();
+    expect(reloaded.queueWatchIntervalSeconds).toBe(5);
+  });
+
+  it.each([...QueueWatchIntervalOptions])("選択肢の値 %d はそのまま正規化結果になる", (seconds) => {
+    const config = new BehaviorConfig();
+    config.queueWatchIntervalSeconds = seconds;
+    expect(config.normalizedQueueWatchIntervalSeconds()).toBe(seconds);
+  });
+
+  it("選択肢にない保存値は既定の30秒に正規化される", () => {
+    const config = new BehaviorConfig();
+    config.queueWatchIntervalSeconds = 7;
+    expect(config.normalizedQueueWatchIntervalSeconds()).toBe(30);
+  });
+
+  it("選択肢はいずれもアラーム周期（30秒）以下", () => {
+    for (const seconds of QueueWatchIntervalOptions) {
+      expect(seconds).toBeLessThanOrEqual(BehaviorConfig.ALARM_PERIOD_SECONDS);
+    }
   });
 });

--- a/tests/queue-watch-interval.spec.ts
+++ b/tests/queue-watch-interval.spec.ts
@@ -1,0 +1,78 @@
+import { expect, describe, it, vi, beforeAll, beforeEach } from "vitest";
+
+// chromite はモジュール読み込み時に chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: {
+      id: "test",
+      onMessage: { addListener: () => {} },
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+  };
+});
+
+// QueueWatcher をモックし、アラーム1回の発火で監視間隔ごとに何回チェックされるかだけを検証する
+const { Once } = vi.hoisted(() => ({ Once: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../src/controllers/Cron/QueueWatcher", () => ({ Once }));
+
+// sleep を即時解決にして、待ち時間なしでループの回数と引数を検証する
+const { sleep } = vi.hoisted(() => ({ sleep: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../src/utils", async (importOriginal) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ...(await importOriginal() as any),
+  sleep,
+}));
+
+import Alarm from "../src/controllers/Alarm";
+import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+
+const fire = () => {
+  const listener = Alarm.listener();
+  // chromite の listener は同期的に呼び出され、ハンドラは Promise 内で実行される
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (listener as any)({ name: "/cron/queues" });
+};
+
+// アラーム周期（30秒）内を監視間隔で分割してチェックする回数のルール。
+describe("Alarm /cron/queues の監視間隔", () => {
+  // Alarm.ts はモジュール読み込みの10ms後にも Once を1回呼ぶため、
+  // それが発火しきってから各テストのカウントを始める
+  beforeAll(() => new Promise((resolve) => setTimeout(resolve, 30)));
+
+  beforeEach(() => {
+    Once.mockClear();
+    sleep.mockClear();
+  });
+
+  it("既定（30秒）ではアラーム1回につき1回チェックし、待ち時間なし", async () => {
+    fire();
+    await vi.waitFor(() => expect(Once).toHaveBeenCalledTimes(1));
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("監視間隔10秒ではアラーム1回につき3回チェックし、間に10秒ずつ待つ", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ queueWatchIntervalSeconds: 10 });
+    fire();
+    await vi.waitFor(() => expect(Once).toHaveBeenCalledTimes(3));
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10 * 1000);
+  });
+
+  it("監視間隔5秒ではアラーム1回につき6回チェックする", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ queueWatchIntervalSeconds: 5 });
+    fire();
+    await vi.waitFor(() => expect(Once).toHaveBeenCalledTimes(6));
+    expect(sleep).toHaveBeenCalledTimes(5);
+  });
+
+  it("選択肢にない保存値は既定の30秒として扱う", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ queueWatchIntervalSeconds: 7 });
+    fire();
+    await vi.waitFor(() => expect(Once).toHaveBeenCalledTimes(1));
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/tests/queue-watcher.spec.ts
+++ b/tests/queue-watcher.spec.ts
@@ -1,0 +1,71 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// import 連鎖の chromite がモジュール読み込み時に chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} } },
+  };
+});
+
+const { list, notify } = vi.hoisted(() => ({
+  list: vi.fn(),
+  notify: vi.fn().mockResolvedValue(""),
+}));
+vi.mock("../src/models/Queue", () => ({ default: { list } }));
+vi.mock("../src/services/NotificationService", () => ({
+  NotificationService: vi.fn(() => ({ notify })),
+}));
+
+import { Once } from "../src/controllers/Cron/QueueWatcher";
+
+// 期限判定に使う Queue の最小構成
+const queue = (scheduled: number) => ({
+  scheduled,
+  entry: () => ({ type: "mission" }),
+  delete: vi.fn().mockResolvedValue(undefined),
+});
+
+describe("QueueWatcher.Once", () => {
+  beforeEach(() => {
+    list.mockReset();
+    notify.mockClear();
+  });
+
+  it("期限を過ぎた Queue は通知して削除し、期限前の Queue には触らない", async () => {
+    const due = queue(Date.now() - 1000);
+    const pending = queue(Date.now() + 60 * 1000);
+    list.mockResolvedValueOnce([due, pending]);
+    await Once();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(due.delete).toHaveBeenCalledTimes(1);
+    expect(pending.delete).not.toHaveBeenCalled();
+  });
+
+  it("実行は直列化され、前の実行が完了するまで次のチェックは始まらない", async () => {
+    let resolveFirst!: (queues: unknown[]) => void;
+    list
+      .mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce([]);
+
+    const first = Once();
+    const second = Once();
+
+    // 1回目が完了していないうちは、2回目の Queue.list は呼ばれない
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(list).toHaveBeenCalledTimes(1);
+
+    resolveFirst([]);
+    await first;
+    await second;
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("前の実行が失敗しても次の実行は行われる", async () => {
+    list.mockRejectedValueOnce(new Error("storage unavailable"));
+    list.mockResolvedValueOnce([]);
+    await expect(Once()).rejects.toThrow("storage unavailable");
+    await expect(Once()).resolves.toBeUndefined();
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## 概要

遠征・入渠・建造などのタイマー期限の確認は30秒周期のアラームで行っているため、通知が予定時刻から最大30秒遅れる。この確認間隔を「細かい挙動設定」から 5/10/20/30秒 で選べるようにする（既定は30秒＝従来どおりの挙動）。

## 実装

- chrome.alarms の周期は下限が30秒のため、30秒未満の間隔は、アラーム発火で起きた Service Worker の生存中に間隔ごとに複数回チェックすることで実現する（例: 10秒なら1回の発火で0・10・20秒後の3回チェック）
- Service Worker が途中で停止した場合は残りのチェックが飛ぶだけで、次のアラーム発火から回復する（最悪でも従来の30秒間隔の挙動）
- `QueueWatcher.Once` を直列化し、チェックの多重実行による二重通知を防止
- 設定は `BehaviorConfig.queueWatchIntervalSeconds` に保存し、選択肢にない値は既定の30秒に正規化

## UI

- 「細かい挙動設定」セクションにドロップダウンを追加（専用セクションは設けない）
- 30秒より短い間隔では Service Worker が休止できずバッテリー消費が増えるため、その旨と「電力が気になる環境では既定の30秒を推奨」を説明文に明記

## 動作確認

- `pnpm typecheck` / `pnpm lint` / vitest（tests/ 配下 15 ファイル 74 件）通過
- デバッグ用 Chrome（unpacked 読み込み）で設定画面の表示と保存を確認
