### PR TITLE
出撃記録を1出撃1行のコンパクトな一覧表示に変更する

### DIFF
--- a/src/page/logbook/LogbookPage.tsx
+++ b/src/page/logbook/LogbookPage.tsx
@@ -1,91 +1,90 @@
-import { useLoaderData } from "react-router-dom";
-import { BookOpenIcon } from "@heroicons/react/24/outline";
+import { useEffect, useState } from "react";
+import { useLoaderData, useRevalidator } from "react-router-dom";
+import { ArrowPathIcon, BookOpenIcon } from "@heroicons/react/24/outline";
 import { SortieContext } from "../../models/Logbook";
+import { describeBattles, formatStarted } from "./format";
+
+// 自動更新オン時の再読込間隔（ミリ秒）
+const RELOAD_INTERVAL_MS = 5 * 1000;
 
 export function LogbookPage() {
   const { sorties } = useLoaderData() as { sorties: SortieContext[] };
-  console.log(sorties);
+  const revalidator = useRevalidator();
+  const [autoReload, setAutoReload] = useState(false);
+
+  // 自動更新がオンの間だけ、保存された新しい出撃記録を定期的に再読込する
+  useEffect(() => {
+    if (!autoReload) return;
+    const interval = setInterval(() => revalidator.revalidate(), RELOAD_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [autoReload, revalidator]);
+
+  // 新しい出撃が上に来るよう降順で表示する
+  const sorted = [...sorties].sort((a, b) => b.started - a.started);
+
   return (
     <div className="p-4">
       <div className="mb-4 flex items-center space-x-2">
         <BookOpenIcon className="w-6 h-6 text-slate-600" />
         <h1 className="text-2xl font-bold text-slate-800">出撃記録</h1>
-      </div>
-      <div>
-        <blockquote className="border-l-4 border-teal-400 pl-4 italic text-slate-600 mb-4">
-          よくわかんねえけど作り始めたページ。よくわかんねえ。WebRequestで「マス」情報が取れるといいんだけどねえ。たぶん今取得できてる「マス」は間違ってる。でも何の意味なのかもわからん
-        </blockquote>
+        <button
+          onClick={() => revalidator.revalidate()}
+          className="ml-4 flex items-center space-x-1 border rounded px-2 py-1 text-sm text-slate-600 hover:bg-slate-50"
+        >
+          <ArrowPathIcon className="w-4 h-4" />
+          <span>更新</span>
+        </button>
+        <label className="flex items-center space-x-1 text-sm text-slate-600">
+          <input
+            type="checkbox"
+            checked={autoReload}
+            onChange={(e) => setAutoReload(e.target.checked)}
+            className="w-4 h-4"
+          />
+          <span>自動更新</span>
+        </label>
       </div>
 
-      {sorties.length === 0 ? (
+      {sorted.length === 0 ? (
         <div className="text-center py-8 text-slate-400">
           出撃記録がありません
         </div>
       ) : (
-        <div className="space-y-4">
-          {sorties.map((sortie) => (
-            <div
-              key={sortie._id}
-              className="border border-slate-200 rounded-lg p-4 bg-white hover:shadow-md transition"
-            >
-              <div className="flex justify-between items-start mb-2">
-                <div>
-                  <div className="text-sm text-slate-500">
-                    {new Date(sortie.started).toLocaleString("ja-JP")}
-                  </div>
-                  {sortie.map && (
-                    <div className="font-semibold text-slate-800">
-                      {sortie.map.area}-{sortie.map.info}
-                    </div>
-                  )}
-                  {sortie.deck && (
-                    <div className="text-sm text-slate-600">
-                      艦隊: {sortie.deck}
-                    </div>
-                  )}
-                </div>
-                <div className="text-sm text-slate-500">
-                  {sortie.battles.length} 戦闘
-                </div>
-              </div>
-
-              {sortie.battles.length > 0 && (
-                <div className="mt-3 space-y-2">
-                  {sortie.battles.map((battle, idx) => (
-                    <div
-                      key={idx}
-                      className="text-sm border-l-2 border-teal-400 pl-3 py-1"
-                    >
-                      <div className="flex items-center space-x-2">
-                        <span className="text-slate-600">
-                          マス: {battle.cell || "不明"}
-                        </span>
-                        <span className="text-slate-500">
-                          陣形: {battle.formation}
-                        </span>
-                        {battle.midnight && (
-                          <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded">
-                            夜戦
-                          </span>
-                        )}
-                      </div>
-                      {battle.result && (
-                        <div className="text-xs text-slate-500 mt-1">
-                          結果: {battle.result}
-                        </div>
-                      )}
-                      {battle.reward && (
-                        <div className="text-xs text-slate-500">
-                          報酬: {battle.reward}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+        <table className="w-full text-sm text-left">
+          <thead>
+            <tr className="text-xs text-slate-500 border-b border-slate-300">
+              <th className="py-2 pr-4 font-medium">出撃日時</th>
+              <th className="py-2 pr-4 font-medium">海域</th>
+              <th className="py-2 pr-4 font-medium">艦隊</th>
+              <th className="py-2 pr-4 font-medium">戦闘数</th>
+              <th className="py-2 font-medium">戦闘（陣形、(夜)=夜戦あり）</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((sortie) => (
+              <tr
+                key={sortie._id ?? sortie.started}
+                className="border-b border-slate-100 hover:bg-slate-50"
+              >
+                <td className="py-1.5 pr-4 text-slate-500 whitespace-nowrap">
+                  {formatStarted(sortie.started)}
+                </td>
+                <td className="py-1.5 pr-4 font-semibold text-slate-800 whitespace-nowrap">
+                  {sortie.map ? `${sortie.map.area}-${sortie.map.info}` : "-"}
+                </td>
+                <td className="py-1.5 pr-4 text-slate-600">
+                  {sortie.deck ?? "-"}
+                </td>
+                <td className="py-1.5 pr-4 text-slate-600 whitespace-nowrap">
+                  {sortie.battles.length}戦
+                </td>
+                <td className="py-1.5 text-slate-600">
+                  {describeBattles(sortie) || "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </div>
   );

--- a/src/page/logbook/format.ts
+++ b/src/page/logbook/format.ts
@@ -1,0 +1,38 @@
+import { SortieContext } from "../../models/Logbook";
+
+// api_formation の陣形コードと表示名の対応
+const FormationNames: Record<string, string> = {
+  "1": "単縦陣",
+  "2": "複縦陣",
+  "3": "輪形陣",
+  "4": "梯形陣",
+  "5": "単横陣",
+  "6": "警戒陣",
+  "11": "第一警戒航行序列",
+  "12": "第二警戒航行序列",
+  "13": "第三警戒航行序列",
+  "14": "第四警戒航行序列",
+};
+
+// 陣形コードを表示名にする。未知のコードはコードのまま、空は「不明」として表示する。
+export function formationName(formation: string): string {
+  return FormationNames[formation] ?? (formation || "不明");
+}
+
+// 出撃日時を「2026/7/5 12:34」のように簡潔に表示する
+export function formatStarted(started: number): string {
+  return new Date(started).toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// 戦闘ごとの陣形と夜戦有無を「単縦陣 / 複縦陣(夜)」のように列挙する
+export function describeBattles(sortie: SortieContext): string {
+  return sortie.battles
+    .map((battle) => formationName(battle.formation) + (battle.midnight ? "(夜)" : ""))
+    .join(" / ");
+}

--- a/tests/logbook-format.spec.ts
+++ b/tests/logbook-format.spec.ts
@@ -1,0 +1,53 @@
+import { expect, describe, it } from "vitest";
+
+import { SortieContext } from "../src/models/Logbook";
+import { describeBattles, formationName, formatStarted } from "../src/page/logbook/format";
+
+// 出撃記録一覧の表示整形ルール。
+describe("formationName", () => {
+  it.each([
+    ["1", "単縦陣"],
+    ["2", "複縦陣"],
+    ["3", "輪形陣"],
+    ["4", "梯形陣"],
+    ["5", "単横陣"],
+    ["6", "警戒陣"],
+    ["11", "第一警戒航行序列"],
+    ["14", "第四警戒航行序列"],
+  ])("陣形コード %s は %s と表示する", (code, name) => {
+    expect(formationName(code)).toBe(name);
+  });
+
+  it("未知のコードはコードのまま表示する", () => {
+    expect(formationName("99")).toBe("99");
+  });
+
+  it("空文字は「不明」と表示する", () => {
+    expect(formationName("")).toBe("不明");
+  });
+});
+
+describe("formatStarted", () => {
+  it("出撃日時を 年/月/日 時:分 で表示する", () => {
+    const started = new Date(2026, 6, 5, 12, 34, 56).getTime();
+    expect(formatStarted(started)).toBe("2026/7/5 12:34");
+  });
+});
+
+describe("describeBattles", () => {
+  const sortieWith = (battles: Array<{ formation: string; midnight: boolean }>) =>
+    ({ battles }) as unknown as SortieContext;
+
+  it("戦闘ごとの陣形を順に列挙し、夜戦があった戦闘には (夜) を付ける", () => {
+    const sortie = sortieWith([
+      { formation: "1", midnight: false },
+      { formation: "2", midnight: true },
+      { formation: "1", midnight: false },
+    ]);
+    expect(describeBattles(sortie)).toBe("単縦陣 / 複縦陣(夜) / 単縦陣");
+  });
+
+  it("戦闘がなければ空文字を返す", () => {
+    expect(describeBattles(sortieWith([]))).toBe("");
+  });
+});

--- a/tests/logbook-page.spec.tsx
+++ b/tests/logbook-page.spec.tsx
@@ -1,0 +1,63 @@
+import { expect, describe, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+
+import { LogbookPage } from "../src/page/logbook/LogbookPage";
+
+// LogbookPage を loader データ付きで単体レンダリングする。
+// loader の非同期初期化を待たずに済むよう、hydrationData で初期データを与える。
+const renderPage = (sorties: unknown[]) => {
+  const router = createMemoryRouter(
+    [{ id: "logbook", path: "/", element: <LogbookPage />, loader: () => ({ sorties }) }],
+    { hydrationData: { loaderData: { logbook: { sorties } } } },
+  );
+  return render(<RouterProvider router={router} />);
+};
+
+let seq = 0;
+const sortie = (over: Record<string, unknown> = {}) => ({
+  _id: `sortie-${seq++}`,
+  started: new Date(2026, 6, 5, 12, 0).getTime(),
+  map: { area: 3, info: 2 },
+  deck: "1",
+  battles: [],
+  ...over,
+});
+
+describe("LogbookPage", () => {
+  it("出撃記録がなければその旨を表示する", async () => {
+    renderPage([]);
+    expect(await screen.findByText("出撃記録がありません")).toBeInTheDocument();
+  });
+
+  it("更新ボタンと自動更新トグル（既定オフ）を表示する", async () => {
+    renderPage([]);
+    expect(await screen.findByText("更新")).toBeInTheDocument();
+    const toggle = screen.getByRole("checkbox");
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("新しい出撃が上の行に来る", async () => {
+    renderPage([
+      sortie({ started: new Date(2026, 6, 5, 10, 0).getTime(), map: { area: 3, info: 2 } }),
+      sortie({ started: new Date(2026, 6, 5, 11, 0).getTime(), map: { area: 5, info: 1 } }),
+    ]);
+    const rows = await screen.findAllByRole("row");
+    // rows[0] はヘッダ行
+    expect(rows[1].textContent).toContain("5-1");
+    expect(rows[2].textContent).toContain("3-2");
+  });
+
+  it("戦闘列に陣形名と夜戦有無を表示する", async () => {
+    renderPage([
+      sortie({
+        battles: [
+          { formation: "1", midnight: false },
+          { formation: "2", midnight: true },
+        ],
+      }),
+    ]);
+    expect(await screen.findByText("単縦陣 / 複縦陣(夜)")).toBeInTheDocument();
+    expect(screen.getByText("2戦")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

出撃記録ページのカード積み上げ表示を、1出撃1行のテーブル表示に変更する。新しい出撃が最上段に来るよう降順で表示する。

## 表示内容

- 出撃日時・海域・艦隊・戦闘数・戦闘ごとの陣形（名前表示、夜戦があった戦闘には (夜) を付記）
- 記録コードが存在せず常に空の「結果・報酬」と、値が信頼できない「マス」は表示しない

## 更新まわり

- 手動の更新ボタンと、自動更新トグル（既定オフ、オンの間だけ5秒ごとに再読込）を設置

## 動作確認

- `pnpm typecheck` / `pnpm lint` / vitest（tests/ 配下 17 ファイル 83 件）通過
- デバッグ用 Chrome（unpacked 読み込み）で実データの一覧表示・更新ボタン・自動更新トグルを確認
