### PR TITLE
スクショ撮影後に編集画面を経由して保存できるようにする

### DIFF
--- a/src/controllers/Commands.ts
+++ b/src/controllers/Commands.ts
@@ -1,6 +1,6 @@
 import { Router } from "chromite";
 import { Launcher } from "../services/Launcher";
-import { DownloadService } from "../services/DownloadService";
+import { ScreenshotService } from "../services/ScreenshotService";
 import { FileSaveConfig } from "../models/configs/FileSaveConfig";
 
 const onCommand = new Router<typeof chrome.commands.onCommand>(async (command) => ({ __action__: command }));
@@ -12,9 +12,8 @@ onCommand.on("/screenshot", async () => {
     throw new Error("スクリーンショット対象のウィンドウが見つかりませんでした");
   }
   const config = await FileSaveConfig.user();
-  const service = new DownloadService(config);
   const uri = await launcher.capture(win.id, { format: config.format });
-  return await service.download(uri);
+  return await new ScreenshotService(config).deliver(uri);
 });
 
 export {

--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -6,7 +6,7 @@ import { H, M, S, sleep, WorkerImage } from "../utils";
 import Queue from "../models/Queue";
 import { TriggerType } from "../models/entry";
 import { Launcher } from "../services/Launcher";
-import { DownloadService } from "../services/DownloadService";
+import { ScreenshotService } from "../services/ScreenshotService";
 import { CropService } from "../services/CropService";
 import { FileSaveConfig } from "../models/configs/FileSaveConfig";
 import { DashboardConfig } from "../models/configs/DashboardConfig";
@@ -60,9 +60,8 @@ onMessage.on("/screenshot", async (_, sender) => {
   if (!sender.tab) return;
   const launcher = new Launcher();
   const config = await FileSaveConfig.user();
-  const s = new DownloadService(config);
   const uri = await launcher.capture(sender.tab.windowId, { format: config.format });
-  return await s.download(uri);
+  return await new ScreenshotService(config).deliver(uri);
 });
 
 onMessage.on(`/injected/dmm/ocr/${EntryType.RECOVERY}:result`, async (req) => {

--- a/src/models/configs/FileSaveConfig.ts
+++ b/src/models/configs/FileSaveConfig.ts
@@ -13,6 +13,7 @@ export class FileSaveConfig extends Model {
       folder: "艦これ",
       filenameTemplate: "%Y%m%d_%H%M%S",
       format: "png" as ImageFormat,
+      editBeforeSave: false,
     }
   };
 
@@ -36,6 +37,9 @@ export class FileSaveConfig extends Model {
 
   // 保存画像フォーマット。ファイル名の拡張子もこれに従う
   public format: ImageFormat = "png";
+
+  // 撮影後すぐダウンロードせず、編集ページを開いてそこの保存操作でダウンロードするか
+  public editBeforeSave: boolean = false;
 
   /**
    * filenameTemplate 末尾に拡張子を含む設定を、拡張子なしテンプレートと format の組に

--- a/src/page/components/dashboard/ActionsView.tsx
+++ b/src/page/components/dashboard/ActionsView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Launcher } from "../../../services/Launcher";
 import { useRevalidator } from "react-router-dom";
-import { DownloadService } from "../../../services/DownloadService";
+import { ScreenshotService } from "../../../services/ScreenshotService";
 import { CameraIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from "@heroicons/react/24/outline";
 import { FileSaveConfig } from "../../../models/configs/FileSaveConfig";
 
@@ -22,9 +22,7 @@ function CaptureControlButton({ tab, launcher }: { tab?: chrome.tabs.Tab, launch
     <div onClick={async () => {
       const config = await FileSaveConfig.user();
       const uri = await launcher.capture(tab.windowId, { format: config.format });
-      const s = new DownloadService(config);
-      /* const downloadId = */ await s.download(uri);
-      // await s.show(downloadId);
+      await new ScreenshotService(config).deliver(uri);
     }} className="cursor-pointer text-slate-400 hover:text-slate-600" title="スクリーンショットを保存">
       <CameraIcon className="w-8 h-8" aria-hidden="true" />
     </div>

--- a/src/page/components/options/FileSaveSettingView.tsx
+++ b/src/page/components/options/FileSaveSettingView.tsx
@@ -37,6 +37,25 @@ export function FileSaveSettingView({
         </label>
       </div>
 
+      <div className="mb-6">
+        <label className="flex items-center space-x-3">
+          <input
+            type="checkbox"
+            className="h-4 w-4"
+            defaultChecked={config.editBeforeSave}
+            onChange={async (e) => {
+              await config.update({ editBeforeSave: e.target.checked });
+            }}
+          />
+          <div>
+            <div className="font-bold">保存前に編集画面を開く</div>
+            <div className="text-sm text-gray-600">
+              有効にすると撮影後すぐにはダウンロードせず、切り取りや描き込みができる編集画面を開きます。ダウンロードは編集画面の保存ボタンで行ないます。
+            </div>
+          </div>
+        </label>
+      </div>
+
       <div className="mb-4">
         <div className="mb-4">
           <label className="block mb-2">

--- a/src/page/main.tsx
+++ b/src/page/main.tsx
@@ -11,6 +11,7 @@ import { OptionsPage } from './options/OptionsPage';
 import { PopupPage } from './PopupPage';
 import { DashboardPage } from './Dashboard';
 import { FleetCapturePage } from './fleet-capture/FleetCapturePage';
+import { ScreenshotEditPage } from './screenshot-edit/ScreenshotEditPage';
 import { DamageSnapshotPage } from './snapshot/DamageSnapshotPage';
 import { LogbookPage } from './logbook/LogbookPage';
 
@@ -28,6 +29,10 @@ const router = createHashRouter([
   {
     path: "/fleet-capture",
     element: <FleetCapturePage />,
+  },
+  {
+    path: "/screenshot-edit",
+    element: <ScreenshotEditPage />,
   },
   {
     path: "/dashboard",

--- a/src/page/screenshot-edit/ScreenshotEditPage.tsx
+++ b/src/page/screenshot-edit/ScreenshotEditPage.tsx
@@ -1,0 +1,108 @@
+import { useSearchParams } from "react-router-dom";
+import {
+  ArrowDownTrayIcon,
+  ArrowUturnLeftIcon,
+  ScissorsIcon,
+  StopIcon,
+} from "@heroicons/react/24/outline";
+import { useScreenshotEditor, type ToolType } from "./useScreenshotEditor";
+
+function ToolButton({
+  active,
+  disabled,
+  onClick,
+  icon: Icon,
+  label,
+}: {
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  icon: typeof ScissorsIcon;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={`flex items-center gap-1 px-3 py-2 rounded border ${
+        active ? "bg-blue-500 text-white border-blue-500" : "bg-white text-gray-700"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+    >
+      <Icon className="w-5 h-5" aria-hidden="true" />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export function ScreenshotEditPage() {
+  const [searchParams] = useSearchParams();
+  const editor = useScreenshotEditor(searchParams.get("key"));
+
+  const toggleTool = (tool: ToolType) => {
+    editor.selectTool(editor.tool === tool ? null : tool);
+  };
+
+  if (editor.status === "missing") {
+    return (
+      <div className="p-8 space-y-4">
+        <h1 className="text-3xl font-bold">スクリーンショット編集</h1>
+        <p>
+          編集対象の画像が見つかりませんでした。
+          撮影から時間が経つと画像は破棄されるため、もう一度撮影してください。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">スクリーンショット編集</h1>
+      <p className="text-sm text-gray-600">
+        切り取りや矩形の描き込みをしてから保存できます。保存せずにこのタブを閉じると画像は破棄されます。
+      </p>
+      <div className="flex items-center gap-2">
+        <ToolButton
+          active={editor.tool === "crop"}
+          onClick={() => toggleTool("crop")}
+          icon={ScissorsIcon}
+          label="切り取り"
+        />
+        <ToolButton
+          active={editor.tool === "rect"}
+          onClick={() => toggleTool("rect")}
+          icon={StopIcon}
+          label="矩形"
+        />
+        <input
+          type="color"
+          value={editor.color}
+          onChange={(e) => editor.setColor(e.target.value)}
+          className="h-10 w-10 cursor-pointer"
+          title="矩形の色"
+        />
+        <ToolButton
+          disabled={!editor.canUndo}
+          onClick={editor.undo}
+          icon={ArrowUturnLeftIcon}
+          label="ひとつ戻す"
+        />
+        <div className="flex-1" />
+        <ToolButton
+          disabled={editor.status !== "ready"}
+          onClick={() => void editor.save()}
+          icon={ArrowDownTrayIcon}
+          label="保存"
+        />
+      </div>
+      <canvas
+        ref={editor.canvasRef}
+        onMouseDown={editor.onMouseDown}
+        onMouseMove={editor.onMouseMove}
+        onMouseUp={editor.onMouseUp}
+        onMouseLeave={editor.onMouseLeave}
+        className={`max-w-full border shadow ${editor.tool ? "cursor-crosshair" : ""}`}
+      />
+    </div>
+  );
+}

--- a/src/page/screenshot-edit/useScreenshotEditor.ts
+++ b/src/page/screenshot-edit/useScreenshotEditor.ts
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { TempStorage } from "../../services/TempStorage";
+import { DownloadService } from "../../services/DownloadService";
+import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
+
+// 編集ツール種別。crop: ドラッグ範囲で切り取り、rect: ドラッグ範囲に矩形を描く
+export type ToolType = "crop" | "rect";
+
+// 画像の読み込み状態。missing はキー不正・有効期限切れなどで画像を取得できなかった状態
+export type EditorStatus = "loading" | "ready" | "missing";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+export interface ScreenshotEditorController {
+  canvasRef: RefObject<HTMLCanvasElement>;
+  status: EditorStatus;
+  tool: ToolType | null;
+  color: string;
+  canUndo: boolean;
+  // null 指定でツール選択を解除する
+  selectTool: (tool: ToolType | null) => void;
+  setColor: (color: string) => void;
+  undo: () => void;
+  save: () => Promise<void>;
+  onMouseDown: (ev: React.MouseEvent<HTMLCanvasElement>) => void;
+  onMouseMove: (ev: React.MouseEvent<HTMLCanvasElement>) => void;
+  onMouseUp: (ev: React.MouseEvent<HTMLCanvasElement>) => void;
+  onMouseLeave: (ev: React.MouseEvent<HTMLCanvasElement>) => void;
+}
+
+/**
+ * スクショ編集ページの canvas 編集ロジック。
+ * TempStorage から画像を読み込んで canvas に展開し、
+ * 切り取り・矩形描画・undo・保存（ダウンロード）を提供する。
+ * @param key TempStorage の取り出しキー（URL パラメータから渡される）
+ */
+export function useScreenshotEditor(key: string | null): ScreenshotEditorController {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [status, setStatus] = useState<EditorStatus>("loading");
+  const [tool, setTool] = useState<ToolType | null>(null);
+  const [color, setColor] = useState("#01d0d0");
+  // undo ボタンの活性制御用。実体は historyRef で、これはその長さを反映するだけ
+  const [historySize, setHistorySize] = useState(0);
+  // 過去の状態のスタック。現在の状態は含まない
+  const historyRef = useRef<ImageData[]>([]);
+  // ドラッグ中の始点と、ドラッグ開始時点の canvas スナップショット
+  const dragRef = useRef<{ start: Position, snapshot: ImageData } | null>(null);
+  // TempStorage.draw は取得と同時に削除するため、二重実行（React.StrictMode の
+  // 二重マウント等）で2回目が missing になるのをガードする
+  const loadStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (loadStartedRef.current) return;
+    loadStartedRef.current = true;
+    (async () => {
+      if (!key) {
+        setStatus("missing");
+        return;
+      }
+      const uri = await new TempStorage().draw(key);
+      if (!uri) {
+        setStatus("missing");
+        return;
+      }
+      const img = new Image();
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = () => reject(new Error("撮影画像を読み込めませんでした"));
+        img.src = uri;
+      });
+      const canvas = canvasRef.current;
+      const ctx = canvas?.getContext("2d");
+      if (!canvas || !ctx) return;
+      canvas.width = img.width;
+      canvas.height = img.height;
+      ctx.drawImage(img, 0, 0);
+      setStatus("ready");
+    })().catch(() => setStatus("missing"));
+  }, [key]);
+
+  const popHistory = useCallback((): ImageData | undefined => {
+    const memory = historyRef.current.pop();
+    setHistorySize(historyRef.current.length);
+    return memory;
+  }, []);
+
+  const pushHistory = useCallback((snapshot: ImageData) => {
+    historyRef.current.push(snapshot);
+    setHistorySize(historyRef.current.length);
+  }, []);
+
+  const onMouseDown = useCallback((ev: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!tool || status !== "ready") return;
+    const canvas = ev.currentTarget;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const snapshot = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    pushHistory(snapshot);
+    dragRef.current = { start: positionOf(ev), snapshot };
+  }, [tool, status, pushHistory]);
+
+  const onMouseMove = useCallback((ev: React.MouseEvent<HTMLCanvasElement>) => {
+    const drag = dragRef.current;
+    if (!drag || !tool) return;
+    const ctx = ev.currentTarget.getContext("2d");
+    if (!ctx) return;
+    ctx.putImageData(drag.snapshot, 0, 0);
+    drawPreview(ctx, tool, color, drag.start, positionOf(ev));
+  }, [tool, color]);
+
+  const onMouseUp = useCallback((ev: React.MouseEvent<HTMLCanvasElement>) => {
+    const drag = dragRef.current;
+    if (!drag || !tool) return;
+    dragRef.current = null;
+    const canvas = ev.currentTarget;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.putImageData(drag.snapshot, 0, 0);
+    const applied = applyTool(canvas, ctx, tool, color, drag.start, positionOf(ev));
+    // 大きさゼロで確定した場合など、何も変わらなかったら履歴も積まなかったことにする
+    if (!applied) popHistory();
+  }, [tool, color, popHistory]);
+
+  // ドラッグ中にカーソルが canvas 外へ出たら、その操作はキャンセルする
+  const onMouseLeave = useCallback((ev: React.MouseEvent<HTMLCanvasElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    dragRef.current = null;
+    ev.currentTarget.getContext("2d")?.putImageData(drag.snapshot, 0, 0);
+    popHistory();
+  }, [popHistory]);
+
+  const undo = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+    const memory = popHistory();
+    if (!memory) return;
+    // 切り取りで canvas サイズが変わっていることがあるため、サイズごと戻す
+    canvas.width = memory.width;
+    canvas.height = memory.height;
+    ctx.putImageData(memory, 0, 0);
+  }, [popHistory]);
+
+  const save = useCallback(async () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const config = await FileSaveConfig.user();
+    const uri = canvas.toDataURL(`image/${config.format}`);
+    await new DownloadService(config).download(uri);
+  }, []);
+
+  return {
+    canvasRef,
+    status,
+    tool,
+    color,
+    canUndo: historySize > 0,
+    selectTool: setTool,
+    setColor,
+    undo,
+    save,
+    onMouseDown,
+    onMouseMove,
+    onMouseUp,
+    onMouseLeave,
+  };
+}
+
+/**
+ * マウスイベントの位置を canvas 内部座標系に変換する。
+ * canvas は CSS で縮小表示されることがあるため、表示サイズとの比率で補正する。
+ */
+function positionOf(ev: React.MouseEvent<HTMLCanvasElement>): Position {
+  const canvas = ev.currentTarget;
+  const scale = canvas.width / canvas.offsetWidth;
+  return {
+    x: ev.nativeEvent.offsetX * scale,
+    y: ev.nativeEvent.offsetY * scale,
+  };
+}
+
+/**
+ * ドラッグ中のプレビューを描画する。crop は白の破線、rect は選択色の実線
+ */
+function drawPreview(
+  ctx: CanvasRenderingContext2D,
+  tool: ToolType,
+  color: string,
+  start: Position,
+  end: Position,
+) {
+  ctx.save();
+  if (tool === "crop") {
+    ctx.strokeStyle = "#fff";
+    ctx.lineWidth = 2;
+    ctx.setLineDash([10, 5]);
+  } else {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 3;
+  }
+  ctx.strokeRect(start.x, start.y, end.x - start.x, end.y - start.y);
+  ctx.restore();
+}
+
+/**
+ * ドラッグ確定時にツールの効果を canvas に適用する
+ * @returns 変更を適用したら true、大きさゼロなどで何もしなかったら false
+ */
+function applyTool(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+  tool: ToolType,
+  color: string,
+  start: Position,
+  end: Position,
+): boolean {
+  const sx = Math.max(0, Math.min(start.x, end.x));
+  const sy = Math.max(0, Math.min(start.y, end.y));
+  const sw = Math.min(canvas.width - sx, Math.abs(end.x - start.x));
+  const sh = Math.min(canvas.height - sy, Math.abs(end.y - start.y));
+  if (sw < 1 || sh < 1) return false;
+
+  if (tool === "rect") {
+    ctx.save();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 3;
+    ctx.strokeRect(start.x, start.y, end.x - start.x, end.y - start.y);
+    ctx.restore();
+    return true;
+  }
+
+  // crop: 選択範囲を取り出して canvas を選択範囲サイズに作り直す
+  const data = ctx.getImageData(sx, sy, sw, sh);
+  canvas.width = sw;
+  canvas.height = sh;
+  ctx.putImageData(data, 0, 0);
+  return true;
+}

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -77,6 +77,16 @@ export class Launcher {
   }
 
   /**
+   * スクショ編集ページを新規タブで開く。
+   * @param key TempStorage に保存した撮影画像の取り出しキー
+   * @returns 作成されたタブの Promise
+   */
+  public static async screenshotEdit(key: string) {
+    const search = new URLSearchParams({ key });
+    return await (new this()).tabs.create({ url: `page/index.html#/screenshot-edit?${search.toString()}` });
+  }
+
+  /**
    * ダメージスナップショットページを新規ウィンドウ（popup）で開く。
    * @returns {Promise<chrome.windows.Window>} 作成されたウィンドウのPromise
    */

--- a/src/services/ScreenshotService.ts
+++ b/src/services/ScreenshotService.ts
@@ -1,0 +1,31 @@
+import { FileSaveConfig } from "../models/configs/FileSaveConfig";
+import { DownloadService } from "./DownloadService";
+import { TempStorage } from "./TempStorage";
+import { Launcher } from "./Launcher";
+
+/**
+ * 撮影済みスクリーンショットの後処理を設定に応じて振り分けるサービス。
+ * 編集ページを開く設定なら TempStorage 経由で画像を編集ページへ渡し、
+ * そうでなければそのままダウンロードする。
+ */
+export class ScreenshotService {
+  constructor(
+    private readonly config: FileSaveConfig,
+    private readonly downloads: Pick<DownloadService, "download"> = new DownloadService(config),
+    private readonly temp: Pick<TempStorage, "store"> = new TempStorage(),
+    private readonly openEditPage: (key: string) => Promise<unknown> = (key) => Launcher.screenshotEdit(key),
+  ) { }
+
+  /**
+   * 撮影画像を設定に応じて処理する
+   * @param uri 撮影画像の dataURL
+   */
+  public async deliver(uri: string): Promise<void> {
+    if (this.config.editBeforeSave) {
+      const key = await this.temp.store(`capture_${Date.now()}`, uri);
+      await this.openEditPage(key);
+    } else {
+      await this.downloads.download(uri);
+    }
+  }
+}

--- a/src/services/TempStorage.ts
+++ b/src/services/TempStorage.ts
@@ -1,0 +1,72 @@
+// chrome.storage.local と同じ非同期サーフェスのうち TempStorage が使う部分。
+// テストでは in-memory 実装（jstorm/testing の MemoryStorageArea）を注入する
+interface StorageAreaLike {
+  get(keys?: string | string[] | null): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(keys: string | string[]): Promise<void>;
+}
+
+// 保存エントリの形。expires（Epoch ミリ秒）を過ぎたものは取り出せない
+interface TempEntry {
+  value: string;
+  expires: number;
+}
+
+/**
+ * 大きめの画像 dataURL などを chrome.storage.local に一時保存し、
+ * 取り出しと同時に削除するための受け渡し用ストレージ。
+ * Service Worker で撮影したスクリーンショットを編集ページへ渡すケースで使う。
+ * URL パラメータには載らないサイズのデータを、キーだけ URL で渡して受け取る。
+ */
+export class TempStorage {
+
+  // 通常の設定・モデルのキーと衝突しないための名前空間接頭辞
+  private static readonly PREFIX = "TempStorage:";
+
+  private static readonly DEFAULT_EXPIRES_MS = 60 * 1000;
+
+  constructor(private readonly storage: StorageAreaLike = chrome.storage.local) { }
+
+  /**
+   * 値を保存し、取り出しに使うキーを返す。
+   * MV3 の Service Worker は停止しうるため setTimeout での遅延削除は当てにできず、
+   * 期限切れエントリの掃除は保存のたびに行なう。
+   * @param name キーの識別部（呼び出し側で一意にする）
+   * @param value 保存する値
+   * @param expiresIn 有効期間（ミリ秒）
+   * @returns 取り出しに使うキー
+   */
+  public async store(name: string, value: string, expiresIn = TempStorage.DEFAULT_EXPIRES_MS): Promise<string> {
+    await this.purgeExpired();
+    const key = TempStorage.PREFIX + name;
+    const entry: TempEntry = { value, expires: Date.now() + expiresIn };
+    await this.storage.set({ [key]: entry });
+    return key;
+  }
+
+  /**
+   * 値を取得し、同時に削除する。
+   * @param key store が返したキー
+   * @returns 保存した値。存在しない・期限切れの場合は undefined
+   */
+  public async draw(key: string): Promise<string | undefined> {
+    const items = await this.storage.get(key);
+    const entry = items[key] as TempEntry | undefined;
+    if (!entry) return undefined;
+    await this.storage.remove(key);
+    if (entry.expires < Date.now()) return undefined;
+    return entry.value;
+  }
+
+  /**
+   * 期限切れのまま残っているエントリを削除する
+   */
+  private async purgeExpired(): Promise<void> {
+    const items = await this.storage.get(null);
+    const now = Date.now();
+    const expired = Object.keys(items).filter((key) =>
+      key.startsWith(TempStorage.PREFIX) && ((items[key] as TempEntry).expires ?? 0) < now
+    );
+    if (expired.length > 0) await this.storage.remove(expired);
+  }
+}

--- a/tests/file-save-config.spec.ts
+++ b/tests/file-save-config.spec.ts
@@ -12,6 +12,7 @@ describe("FileSaveConfig", () => {
     const config = await FileSaveConfig.user();
     expect(config.filenameTemplate).toBe("%Y%m%d_%H%M%S");
     expect(config.format).toBe("png");
+    expect(config.editBeforeSave).toBe(false);
     expect(config.getFilename(new Date(2024, 5, 15, 13, 45, 1))).toBe("20240615_134501.png");
   });
 

--- a/tests/screenshot-service.spec.ts
+++ b/tests/screenshot-service.spec.ts
@@ -1,0 +1,41 @@
+import { expect, describe, it, vi } from "vitest";
+
+import { installMemoryStorage } from "jstorm/testing";
+
+import { ScreenshotService } from "../src/services/ScreenshotService";
+import { TempStorage } from "../src/services/TempStorage";
+import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
+
+const URI = "data:image/png;base64,xxxx";
+
+// ScreenshotService.deliver が editBeforeSave 設定に応じて
+// 「即ダウンロード」と「編集ページへの受け渡し」を振り分けることを検証する。
+describe("ScreenshotService", () => {
+  it("editBeforeSave が無効なら即ダウンロードし、編集ページは開かない", async () => {
+    const config = await FileSaveConfig.user();
+    const downloads = { download: vi.fn(async () => 1) };
+    const temp = new TempStorage(installMemoryStorage());
+    const openEditPage = vi.fn<(key: string) => Promise<undefined>>();
+
+    await new ScreenshotService(config, downloads, temp, openEditPage).deliver(URI);
+
+    expect(downloads.download).toHaveBeenCalledWith(URI);
+    expect(openEditPage).not.toHaveBeenCalled();
+  });
+
+  it("editBeforeSave が有効なら TempStorage 経由で編集ページを開き、ダウンロードしない", async () => {
+    const config = await FileSaveConfig.user();
+    await config.update({ editBeforeSave: true });
+    const downloads = { download: vi.fn(async () => 1) };
+    const temp = new TempStorage(installMemoryStorage());
+    const openEditPage = vi.fn<(key: string) => Promise<undefined>>();
+
+    await new ScreenshotService(config, downloads, temp, openEditPage).deliver(URI);
+
+    expect(openEditPage).toHaveBeenCalledTimes(1);
+    expect(downloads.download).not.toHaveBeenCalled();
+    // 渡されたキーで、編集ページ側から実際に画像を取り出せる
+    const key = openEditPage.mock.calls[0][0];
+    expect(await temp.draw(key)).toBe(URI);
+  });
+});

--- a/tests/temp-storage.spec.ts
+++ b/tests/temp-storage.spec.ts
@@ -1,0 +1,41 @@
+import { expect, describe, it } from "vitest";
+
+import { installMemoryStorage } from "jstorm/testing";
+
+import { TempStorage } from "../src/services/TempStorage";
+
+// TempStorage（撮影画像などの一時受け渡し用ストレージ）の
+// 保存・取り出しと同時の削除・期限切れの扱いを検証する。
+describe("TempStorage", () => {
+  it("store した値を draw で取り出せて、取り出しと同時に削除される", async () => {
+    const temp = new TempStorage(installMemoryStorage());
+
+    const key = await temp.store("capture_1", "data:image/png;base64,xxxx");
+
+    expect(await temp.draw(key)).toBe("data:image/png;base64,xxxx");
+    expect(await temp.draw(key)).toBeUndefined();
+  });
+
+  it("期限切れのエントリは draw で取り出せない", async () => {
+    const temp = new TempStorage(installMemoryStorage());
+
+    const key = await temp.store("capture_1", "value", -1);
+
+    expect(await temp.draw(key)).toBeUndefined();
+  });
+
+  it("store のたびに期限切れの残骸を掃除し、TempStorage 以外のキーには触らない", async () => {
+    const area = installMemoryStorage({
+      "TempStorage:stale": { value: "old", expires: 0 },
+      "FileSaveConfig": { user: { folder: "艦これ" } },
+    });
+    const temp = new TempStorage(area);
+
+    await temp.store("capture_2", "new");
+
+    const all = await area.get(null);
+    expect(all["TempStorage:stale"]).toBeUndefined();
+    expect(all["FileSaveConfig"]).toEqual({ user: { folder: "艦これ" } });
+    expect(all["TempStorage:capture_2"]).toMatchObject({ value: "new" });
+  });
+});


### PR DESCRIPTION
## 概要

v3 にあった「撮影 → 編集画面 → ダウンロードボタンで初めて保存」の流れを v4 に導入します。
設定「保存前に編集画面を開く」を有効にすると、撮影後すぐにはダウンロードせず、簡易編集ができる編集画面を開きます。**既定はオフ**なので、既存の「撮影 → 即ダウンロード」の挙動は変わりません。

## 変更内容

- **設定**: `FileSaveConfig` に `editBeforeSave`（既定 `false`）を追加し、オプションの「スクショ保存の設定」にチェックボックスを追加
- **編集画面** (`#/screenshot-edit`): 切り取り（ドラッグで範囲選択）・矩形の描き込み（色選択つき）・ひとつ戻す・保存。保存ボタンを押したときに初めて `DownloadService` でダウンロードする（フォルダ・ファイル名・フォーマットは既存設定に従う）
- **画像の受け渡し**: `TempStorage`（chrome.storage.local）に dataURL を一時保存し、URL にはキーだけ載せて編集画面へ渡す。取り出しと同時に削除、未取り出しの残骸は次回保存時に掃除（既定60秒で期限切れ）
- **振り分け**: `ScreenshotService.deliver()` が設定に応じて「即ダウンロード / 編集画面」を分岐。対象はゲーム内カメラボタン・キーボードショートカット・ダッシュボードの3経路（編成キャプチャは専用UIがあるため従来どおり）

## v3 との意図的な差分

- ペン・消しゴム（v3 でもアイコンのみで未実装）と Twitter 投稿（API 廃止）は対象外
- 切り取り後に新しいタブを開き直さず、同じ画面で続けて編集できる

## テスト

- `tests/temp-storage.spec.ts`（保存・取り出し削除・期限切れ）、`tests/screenshot-service.spec.ts`（振り分け）を追加
- typecheck / lint / vitest（17ファイル79テスト）パス
- 実機確認済み: 設定トグルの永続化、撮影 → 編集画面表示、切り取り・矩形・undo・保存

<img width="1864" height="1454" alt="image" src="https://github.com/user-attachments/assets/25987c81-3909-427d-8782-c556e969e51f" />
