### PR TITLE
ダッシュボードのタイマー手入力欄を HH:MM 形式に切り替えられるようにする

### DIFF
--- a/src/models/configs/DashboardConfig.ts
+++ b/src/models/configs/DashboardConfig.ts
@@ -1,5 +1,10 @@
 import { Model } from "jstorm/chrome/local";
 
+// タイマー手入力モーダルの残り時間入力欄の形式
+// - "split": 時・分を別々の数値ボックスで入力する（24時間以上も入力できる）
+// - "time": HH:MM の time input 1つで入力する（"0130" のようにキーボードで一括入力できる。上限 23:59）
+export type ManualTimerInputStyle = "split" | "time";
+
 export class DashboardConfig extends Model {
   public static readonly _namespace_ = "DashboardConfig";
 
@@ -11,6 +16,7 @@ export class DashboardConfig extends Model {
       "top": 10,
       // ゲーム窓を新規に開いたとき、ダッシュボードも同時に開くか（#1216）。既定は false（従来どおり手動）。
       "openWithGame": false,
+      "manualTimerInput": "split" as ManualTimerInputStyle,
     },
   };
 
@@ -19,6 +25,7 @@ export class DashboardConfig extends Model {
   public left: number = 100;
   public top: number = 100;
   public openWithGame: boolean = false;
+  public manualTimerInput: ManualTimerInputStyle = "split";
 
   static async user(): Promise<DashboardConfig> {
     return (await this.find("user"))!;

--- a/src/page/Dashboard.tsx
+++ b/src/page/Dashboard.tsx
@@ -3,10 +3,11 @@ import { ActionsView } from "./components/dashboard/ActionsView";
 import { ClockView } from "./components/dashboard/ClockView";
 import { QueuesView } from "./components/dashboard/QueuesView";
 import type Queue from "../models/Queue";
+import type { DashboardConfig } from "../models/configs/DashboardConfig";
 import { useEffect } from "react";
 
 export function DashboardPage() {
-  const { window, queues, time } = useLoaderData() as { window: chrome.windows.Window, queues: Queue[], time: Date };
+  const { window, queues, time, config } = useLoaderData() as { window: chrome.windows.Window, queues: Queue[], time: Date, config: DashboardConfig };
   const revalidater = useRevalidator();
 
   // 1秒ごとにデータを再検証
@@ -48,7 +49,7 @@ export function DashboardPage() {
         <ClockView time={time} />
         <ActionsView tab={window?.tabs?.[0]} />
       </div>
-      <QueuesView queues={queues} />
+      <QueuesView queues={queues} manualTimerInput={config.manualTimerInput} />
     </div>
   )
 }

--- a/src/page/components/dashboard/CustomQueueModal.tsx
+++ b/src/page/components/dashboard/CustomQueueModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import Queue from "../../../models/Queue";
 import { EntryType } from "../../../models/entry";
+import { ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
 import { H, M } from "../../../utils";
 
 function clampMinutes(value: number): number {
@@ -13,27 +14,46 @@ function clampHours(value: number): number {
   return Math.max(0, Math.min(9999, value));
 }
 
+// 残り時間を time input (HH:MM) の値文字列にする。time input の上限 23:59 に丸める。
+function toTimeInputValue(remain: { hours: number, minutes: number }): string {
+  if (remain.hours >= 24) return "23:59";
+  return `${String(remain.hours).padStart(2, "0")}:${String(remain.minutes).padStart(2, "0")}`;
+}
+
 export function CustomQueueModal({
-  queue, close, update,
+  queue, close, update, manualTimerInput = "split",
 }: {
   queue: Queue | null,
   close: () => void,
   update: (queue: Queue) => void,
+  manualTimerInput?: ManualTimerInputStyle,
 }) {
   const [hours, setHours] = useState(0);
   const [minutes, setMinutes] = useState(0);
+  const [draft, setDraft] = useState("00:00");
 
   useEffect(() => {
     if (!queue) return;
     const remain = queue.remain();
     setHours(clampHours(remain.hours));
     setMinutes(clampMinutes(remain.minutes));
+    setDraft(toTimeInputValue(remain));
   }, [queue]);
 
   const updateSchedule = (nextHours: number, nextMinutes: number) => {
     if (!queue) return;
     queue.scheduled = Date.now() + nextHours * H + nextMinutes * M;
     update(queue);
+  }
+
+  const save = async () => {
+    if (!queue) return;
+    await queue.save();
+    close();
+  }
+
+  const saveOnEnter = (ev: React.KeyboardEvent) => {
+    if (ev.key === "Enter") save();
   }
 
   if (!queue) return null;
@@ -67,37 +87,61 @@ export function CustomQueueModal({
           <div>
             <label>残り</label>
           </div>
-          <div className="flex items-center space-x-2">
-            <input
-              type="number"
-              min={0}
-              max={9999}
-              className="w-20 rounded-md border px-2 py-1 text-right"
-              value={hours}
-              onChange={e => {
-                const value = clampHours(Number(e.target.value));
-                setHours(value);
-                updateSchedule(value, minutes);
-              }}
-            />
-            <span>時間</span>
-            <input
-              type="number"
-              min={0}
-              max={59}
-              className="w-16 rounded-md border px-2 py-1 text-right"
-              value={minutes}
-              onChange={e => {
-                const value = clampMinutes(Number(e.target.value));
-                setMinutes(value);
-                updateSchedule(hours, value);
-              }}
-            />
-            <span>分</span>
-          </div>
+          {manualTimerInput === "time" ? (
+            <div className="flex items-center space-x-2">
+              <input
+                type="time"
+                className="rounded-md border px-2 py-1"
+                value={draft}
+                autoFocus
+                onKeyDown={saveOnEnter}
+                onChange={e => {
+                  const value = e.target.value;
+                  setDraft(value);
+                  const matched = value.match(/^(\d{2}):(\d{2})$/);
+                  if (!matched) return;
+                  updateSchedule(Number(matched[1]), Number(matched[2]));
+                }}
+              />
+            </div>
+          ) : (
+            <div className="flex items-center space-x-2">
+              <input
+                type="number"
+                min={0}
+                max={9999}
+                className="w-20 rounded-md border px-2 py-1 text-right"
+                value={hours}
+                autoFocus
+                onFocus={e => e.currentTarget.select()}
+                onKeyDown={saveOnEnter}
+                onChange={e => {
+                  const value = clampHours(Number(e.target.value));
+                  setHours(value);
+                  updateSchedule(value, minutes);
+                }}
+              />
+              <span>時間</span>
+              <input
+                type="number"
+                min={0}
+                max={59}
+                className="w-16 rounded-md border px-2 py-1 text-right"
+                value={minutes}
+                onFocus={e => e.currentTarget.select()}
+                onKeyDown={saveOnEnter}
+                onChange={e => {
+                  const value = clampMinutes(Number(e.target.value));
+                  setMinutes(value);
+                  updateSchedule(hours, value);
+                }}
+              />
+              <span>分</span>
+            </div>
+          )}
         </div>
         <div className="flex space-x-2 justify-end">
-          <button onClick={async () => { await queue.save(); close(); }}>保存</button>
+          <button onClick={save}>保存</button>
           <button onClick={async () => { await queue.delete(); close(); }}>削除</button>
           <button onClick={close}>閉じる</button>
         </div>

--- a/src/page/components/dashboard/CustomQueueModal.tsx
+++ b/src/page/components/dashboard/CustomQueueModal.tsx
@@ -74,7 +74,7 @@ export function CustomQueueModal({
         </div>
         <div className="flex space-x-2">
           <label>{[EntryType.RECOVERY, EntryType.SHIPBUILD].includes(queue.type) ? "ドック" : "艦隊"}</label>
-          <select defaultValue={queue.params["deck"] || queue.params["dock"]} className="flex-1 rounded-md"
+          <select defaultValue={queue.params["deck"] || queue.params["dock"]} className="flex-1 rounded-md bg-slate-100"
             onChange={e => {
               queue.params[[EntryType.RECOVERY, EntryType.SHIPBUILD].includes(queue.type) ? "dock" : "deck"] = e.target.value;
               update(queue);
@@ -141,9 +141,9 @@ export function CustomQueueModal({
           )}
         </div>
         <div className="flex space-x-2 justify-end">
-          <button onClick={save}>保存</button>
-          <button onClick={async () => { await queue.delete(); close(); }}>削除</button>
-          <button onClick={close}>閉じる</button>
+          <button className="px-3 py-1 bg-blue-500 text-white rounded-md text-sm" onClick={save}>保存</button>
+          <button className="px-3 py-1 bg-red-400 text-white rounded-md text-sm" onClick={async () => { await queue.delete(); close(); }}>削除</button>
+          <button className="px-3 py-1 border border-slate-200 bg-slate-100 rounded-md text-sm" onClick={close}>閉じる</button>
         </div>
       </div>
     </div>

--- a/src/page/components/dashboard/QueuesView.tsx
+++ b/src/page/components/dashboard/QueuesView.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { EntryType, Fatigue, Mission, Recovery, Shipbuild } from "../../../models/entry";
+import { ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
 import Queue from "../../../models/Queue";
 import { KCWDate } from "../../../utils";
 import { FatigueQueueView } from "./FatigueQueueView";
@@ -62,7 +63,7 @@ function QueueTableView({
   )
 }
 
-export function QueuesView({ queues }: { queues: Queue[] }) {
+export function QueuesView({ queues, manualTimerInput }: { queues: Queue[], manualTimerInput?: ManualTimerInputStyle }) {
   const [modalQueue, setModalQueue] = useState<Queue | null>(null);
   return (
     <div>
@@ -75,6 +76,7 @@ export function QueuesView({ queues }: { queues: Queue[] }) {
       <CustomQueueModal
         queue={modalQueue} close={() => setModalQueue(null)}
         update={(q) => setModalQueue(q)}
+        manualTimerInput={manualTimerInput}
       />
     </div>
   )

--- a/src/page/components/options/DashboardSettingView.tsx
+++ b/src/page/components/options/DashboardSettingView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { DashboardConfig } from "../../../models/configs/DashboardConfig";
+import { DashboardConfig, ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
 import { FoldableSection } from "../FoldableSection";
 
 export function DashboardSettingView({
@@ -9,6 +9,12 @@ export function DashboardSettingView({
 }) {
   const [config] = useState<DashboardConfig>(_config);
   const [openWithGame, setOpenWithGame] = useState<boolean>(config.openWithGame ?? false);
+  const [manualTimerInput, setManualTimerInput] = useState<ManualTimerInputStyle>(config.manualTimerInput ?? "split");
+
+  const selectManualTimerInput = async (style: ManualTimerInputStyle) => {
+    await config.update({ manualTimerInput: style });
+    setManualTimerInput(style);
+  };
 
   return (
     <FoldableSection title="ダッシュボードの設定" id="dashboard">
@@ -96,9 +102,39 @@ export function DashboardSettingView({
         </div>
       </div>
 
-      <div className="text-sm text-gray-600 mt-4">
-        <div>※ 設定は次回ダッシュボードを開く際に反映されます</div>
+      <div className="text-sm text-gray-600 mb-4">
+        <div>※ サイズと位置は次回ダッシュボードを開く際に反映されます</div>
       </div>
+
+      <div className="mb-4">
+        <div className="font-bold mb-1">タイマー手入力欄の形式</div>
+        <div className="flex space-x-6">
+          <label className="flex items-center space-x-2">
+            <input
+              type="radio"
+              name="manual-timer-input"
+              checked={manualTimerInput === "split"}
+              onChange={() => selectManualTimerInput("split")}
+              className="w-4 h-4"
+            />
+            <span>時間と分を分けて入力</span>
+          </label>
+          <label className="flex items-center space-x-2">
+            <input
+              type="radio"
+              name="manual-timer-input"
+              checked={manualTimerInput === "time"}
+              onChange={() => selectManualTimerInput("time")}
+              className="w-4 h-4"
+            />
+            <span>HH:MM 形式でまとめて入力</span>
+          </label>
+        </div>
+        <div className="text-sm text-gray-600 mt-1">
+          HH:MM 形式はキーボードで「0130」と打つと 01:30 を入力でき、Enter で保存します。入力できるのは 23:59 まで。24時間以上のタイマーは「時間と分を分けて入力」を使ってください。
+        </div>
+      </div>
+
     </FoldableSection>
   );
 }

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -80,6 +80,7 @@ export async function dashboard() {
     queues: await Queue.list(),
     window: win,
     time: new Date(),
+    config: await DashboardConfig.user(),
   }
 }
 

--- a/tests/custom-queue-modal.spec.tsx
+++ b/tests/custom-queue-modal.spec.tsx
@@ -1,0 +1,99 @@
+import { expect, describe, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// chromite（logger 経由で import される）はモジュール読み込み時に chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = { runtime: { id: "test", onMessage: { addListener: () => {} } } };
+});
+
+import { CustomQueueModal } from "../src/page/components/dashboard/CustomQueueModal";
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+import Queue from "../src/models/Queue";
+import { EntryType } from "../src/models/entry";
+import { H, M, S } from "../src/utils";
+
+function newQueue(remainMsec: number): Queue {
+  return Queue.new({
+    type: EntryType.MISSION,
+    scheduled: Date.now() + remainMsec,
+    params: { deck: 1 },
+  });
+}
+
+// タイマー手入力欄の形式設定（manualTimerInput）の既定値。
+describe("DashboardConfig.manualTimerInput", () => {
+  it("既定は split（時・分の分割入力。既存ユーザーの挙動を変えない）", () => {
+    expect(new DashboardConfig().manualTimerInput).toBe("split");
+    expect(DashboardConfig.default.user.manualTimerInput).toBe("split");
+  });
+});
+
+// 既定（split）モード: 時・分の分割入力にキーボード操作を足した挙動。
+describe("CustomQueueModal (split)", () => {
+  it("時ボックスに自動フォーカスされる", () => {
+    const queue = newQueue(1 * H + 30 * M);
+    render(<CustomQueueModal queue={queue} close={() => {}} update={() => {}} />);
+    const [hoursInput] = screen.getAllByRole("spinbutton");
+    expect(hoursInput).toHaveFocus();
+  });
+
+  it("時・分の変更が scheduled に反映される", () => {
+    const queue = newQueue(0);
+    render(<CustomQueueModal queue={queue} close={() => {}} update={() => {}} />);
+    const [hoursInput, minutesInput] = screen.getAllByRole("spinbutton");
+    const before = Date.now();
+    fireEvent.change(hoursInput, { target: { value: "2" } });
+    fireEvent.change(minutesInput, { target: { value: "45" } });
+    expect(queue.scheduled).toBeGreaterThanOrEqual(before + 2 * H + 45 * M);
+    expect(queue.scheduled).toBeLessThanOrEqual(Date.now() + 2 * H + 45 * M);
+  });
+
+  it("Enter で保存されてモーダルが閉じる", async () => {
+    const queue = newQueue(1 * H);
+    const close = vi.fn();
+    render(<CustomQueueModal queue={queue} close={close} update={() => {}} />);
+    const [hoursInput] = screen.getAllByRole("spinbutton");
+    fireEvent.keyDown(hoursInput, { key: "Enter" });
+    await waitFor(() => expect(close).toHaveBeenCalled());
+    expect(await Queue.list()).toHaveLength(1);
+  });
+});
+
+// time モード: HH:MM の time input 1つで入力する。
+describe("CustomQueueModal (time)", () => {
+  function renderTimeMode(queue: Queue, close: () => void = () => {}) {
+    const { container } = render(
+      <CustomQueueModal queue={queue} close={close} update={() => {}} manualTimerInput="time" />,
+    );
+    return container.querySelector<HTMLInputElement>('input[type="time"]')!;
+  }
+
+  it("time input が1つ表示され、残り時間が HH:MM で入り、自動フォーカスされる", () => {
+    // remain() は floor で丸めるため、描画までの経過時間で分が繰り下がらないよう 30 秒のバッファを足す
+    const queue = newQueue(1 * H + 30 * M + 30 * S);
+    const input = renderTimeMode(queue);
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("01:30");
+    expect(input).toHaveFocus();
+  });
+
+  it("残り24時間以上の queue を開くと 23:59 に丸めて表示する", () => {
+    const queue = newQueue(30 * H);
+    const input = renderTimeMode(queue);
+    expect(input.value).toBe("23:59");
+  });
+
+  it("HH:MM の入力が scheduled に反映され、Enter で保存されてモーダルが閉じる", async () => {
+    const queue = newQueue(0);
+    const close = vi.fn();
+    const input = renderTimeMode(queue, close);
+    const before = Date.now();
+    fireEvent.change(input, { target: { value: "01:30" } });
+    expect(queue.scheduled).toBeGreaterThanOrEqual(before + 1 * H + 30 * M);
+    expect(queue.scheduled).toBeLessThanOrEqual(Date.now() + 1 * H + 30 * M);
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(close).toHaveBeenCalled());
+    expect(await Queue.list()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 概要

ダッシュボードのタイマー手入力モーダルの残り時間入力欄を、設定で2形式から選べるようにします。

- **時間と分を分けて入力**（既定・従来どおり）: 24時間以上のタイマーも扱えます
- **HH:MM 形式でまとめて入力**: v3 と同じ time input で、モーダルを開いてすぐ「0130 Enter」のようにキーボードだけで登録できます（上限 23:59）

## 変更点

- `DashboardConfig` に `manualTimerInput`（`"split" | "time"`、既定 `"split"`）を追加し、「ダッシュボードの設定」に選択ラジオを追加
- どちらの形式でも開いた直後に入力欄へ自動フォーカスし、Enter で保存して閉じられるように
- split の数値ボックスはフォーカス時に全選択
- あわせてモーダルの「保存」「削除」「閉じる」ボタンと艦隊/ドック番号セレクトの視認性を改善
- 設定画面の「※ 次回開く際に反映」の注記を、対象（サイズと位置）を明記してその直下へ移動
- コンポーネントテストを追加（`tests/custom-queue-modal.spec.tsx`、7件）
