### PR TITLE
入渠画面への遷移時に修復通知を消去する

### DIFF
--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -83,10 +83,8 @@ onComplete.on(["/kcsapi/api_req_combined_battle/battleresult"], async ([details]
   });
 });
 
-onComplete.on([
-  "/kcsapi/api_port/port",
-  "/kcsapi/api_get_member/ndock"
-], async () => {
+// 入渠画面に遷移したとき、修復の通知を消す
+onComplete.on(["/kcsapi/api_get_member/ndock"], async () => {
   chrome.notifications.getAll((notifications) => {
     for (const id in notifications) {
       if (id.startsWith("/recovery")) chrome.notifications.clear(id);

--- a/tests/notification-clear-on-recovery.spec.ts
+++ b/tests/notification-clear-on-recovery.spec.ts
@@ -1,0 +1,62 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// NotificationService が chrome.notifications を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: {
+      id: "test",
+      onMessage: { addListener: () => {} },
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    notifications: {
+      getAll: vi.fn(),
+      clear: vi.fn(),
+    },
+  };
+});
+
+import { onComplete } from "../src/controllers/WebRequest";
+
+const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
+const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
+
+// 表示中の通知IDを与えてスタブを構成する（コールバック形式のAPI）
+const displaying = (ids: string[]) => {
+  getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
+    cb(Object.fromEntries(ids.map((id) => [id, true])));
+  });
+};
+
+const clearedIds = () => clear.mock.calls.map(([id]) => id);
+
+// ルーター（SequentialRouter）経由でイベントを流し、ルーティング挙動ごと検証する
+const listener = onComplete.listener();
+const fire = async (path: string) => {
+  listener({ url: `https://w00g.kancolle-server.com${path}` } as unknown as chrome.webRequest.OnCompletedDetails);
+  // listener はハンドラを Promise チェーンで実行するため、完了を待って戻る
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+// 入渠画面に遷移した（api_get_member/ndock が発行された）とき、修復通知が消えることを検証する。
+// 通知IDは /{type}/{trigger}/{deck|dock} 形式（tests/notification-id.spec.ts 参照）。
+describe("入渠画面遷移時の修復通知クリア", () => {
+  beforeEach(() => {
+    getAll.mockReset();
+    clear.mockReset();
+  });
+
+  it("母港以外の画面から入渠画面に遷移しても（直前のAPIが port でなくても）修復通知を消す", async () => {
+    displaying(["/recovery/start/1", "/recovery/end/2"]);
+    await fire("/kcsapi/api_req_hensei/change"); // 編成画面での操作
+    await fire("/kcsapi/api_get_member/ndock"); // 入渠画面への遷移
+    expect(clearedIds()).toEqual(expect.arrayContaining(["/recovery/start/1", "/recovery/end/2"]));
+    expect(clearedIds()).toHaveLength(2);
+  });
+
+  it("修復以外の通知は消さない", async () => {
+    displaying(["/recovery/end/1", "/mission/end/2", "/shipbuild/end/3"]);
+    await fire("/kcsapi/api_get_member/ndock");
+    expect(clearedIds()).toEqual(["/recovery/end/1"]);
+  });
+});


### PR DESCRIPTION
## 問題

- 入渠完了通知が、母港経由で入渠画面へ移動したときしか消えない。工廠や編成など母港以外の画面から入渠画面へ遷移した場合は通知が残る。

## 変更内容

- 消去トリガーを `api_get_member/ndock` 単独の登録に変更し、v3（`OnRecoveryPrepare`）と同様に、どの画面から入渠画面へ遷移しても修復通知が消えるようにした

## 動作確認

- `pnpm typecheck` / `pnpm lint` 通過
- 実プレイの kcsapi 記録から、母港以外の画面（編成・補給）から入渠画面へ遷移した場合にも `api_get_member/ndock` が発行されることを確認
