### PR TITLE
演習・出撃の任務未着手通知と任務トラッカーを追加する

### DIFF
--- a/src/catalog/index.ts
+++ b/src/catalog/index.ts
@@ -26,3 +26,30 @@ export interface ServerEntry {
     ip_address: string;
 }
 export type ServerCatalog = ServerEntry[];
+
+// 任務カタログ（デイリー任務のうち、前提任務の連鎖を把握したいもののみ収録）
+import questdata from "./quests.json";
+export type QuestCategory =
+    | "sortie" // 出撃
+    | "supply" // 補給（該当任務なし、将来のため予約）
+    | "mission" // 遠征
+    | "recovery" // 入渠
+    | "shipbuilding" // 建造
+    | "createitem" // 開発
+    | "remodel" // 改修工廠
+    | "destroyship" // 解体
+    | "destroyitem" // 廃棄
+    | "practice"; // 演習
+export type QuestCondition =
+    | "date037" // 日付の下1桁が0/3/7の日のみ
+    | "date28"; // 日付の下1桁が2/8の日のみ
+export interface QuestSpec {
+    title: string;
+    category: QuestCategory;
+    requires: number[]; // 前提任務ID。空なら着手可能な状態から始まる
+    condition?: QuestCondition;
+}
+export interface QuestCatalog {
+    [id: string]: QuestSpec;
+}
+export const quests = questdata as unknown as QuestCatalog;

--- a/src/catalog/quests.json
+++ b/src/catalog/quests.json
@@ -1,0 +1,119 @@
+{
+    "201": {
+        "title": "敵艦隊を撃破せよ！",
+        "category": "sortie",
+        "requires": []
+    },
+    "210": {
+        "title": "敵艦隊を10回邀撃せよ！",
+        "category": "sortie",
+        "requires": [216]
+    },
+    "211": {
+        "title": "敵空母を3隻撃沈せよ！",
+        "category": "sortie",
+        "requires": [201],
+        "condition": "date037"
+    },
+    "212": {
+        "title": "敵輸送船団を叩け！",
+        "category": "sortie",
+        "requires": [201],
+        "condition": "date28"
+    },
+    "216": {
+        "title": "敵艦隊主力を撃滅せよ！",
+        "category": "sortie",
+        "requires": [201]
+    },
+    "218": {
+        "title": "敵補給艦を3隻撃沈せよ！",
+        "category": "sortie",
+        "requires": [216]
+    },
+    "226": {
+        "title": "南西諸島海域の制海権を握れ！",
+        "category": "sortie",
+        "requires": [218]
+    },
+    "230": {
+        "title": "敵潜水艦を制圧せよ！",
+        "category": "sortie",
+        "requires": [226]
+    },
+    "303": {
+        "title": "「演習」で練度向上！",
+        "category": "practice",
+        "requires": []
+    },
+    "304": {
+        "title": "「演習」で他提督を圧倒せよ！",
+        "category": "practice",
+        "requires": [303]
+    },
+    "402": {
+        "title": "「遠征」を3回成功させよう！",
+        "category": "mission",
+        "requires": []
+    },
+    "403": {
+        "title": "「遠征」を10回成功させよう！",
+        "category": "mission",
+        "requires": [402]
+    },
+    "503": {
+        "title": "艦隊大整備！",
+        "category": "recovery",
+        "requires": []
+    },
+    "504": {
+        "title": "艦隊酒保祭り！",
+        "category": "recovery",
+        "requires": [503]
+    },
+    "605": {
+        "title": "新装備「開発」指令",
+        "category": "createitem",
+        "requires": []
+    },
+    "606": {
+        "title": "新造艦「建造」指令",
+        "category": "shipbuilding",
+        "requires": [605]
+    },
+    "607": {
+        "title": "装備「開発」集中強化！",
+        "category": "createitem",
+        "requires": [606]
+    },
+    "608": {
+        "title": "艦娘「建造」艦隊強化！",
+        "category": "shipbuilding",
+        "requires": [607]
+    },
+    "609": {
+        "title": "軍縮条約対応！",
+        "category": "destroyship",
+        "requires": [608]
+    },
+    "619": {
+        "title": "装備の改修強化",
+        "category": "remodel",
+        "requires": [608]
+    },
+    "673": {
+        "title": "装備開発力の整備",
+        "category": "destroyitem",
+        "requires": [607]
+    },
+    "674": {
+        "title": "工廠環境の整備",
+        "category": "destroyitem",
+        "requires": [673]
+    },
+    "702": {
+        "title": "艦の「近代化改修」を実施せよ！",
+        "category": "shipbuilding",
+        "requires": []
+    }
+}

--- a/src/controllers/WebRequest/datatypes.ts
+++ b/src/controllers/WebRequest/datatypes.ts
@@ -46,3 +46,7 @@ export interface CreateShipFormData {
 export interface GetShipFormData {
     api_kdock_id: string[];
 }
+
+export interface QuestActionFormData {
+    api_quest_id: string[];
+}

--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -20,6 +20,7 @@ import {
   onSpMidnightBattleStarted,
   onCombinedSpMidnightBattleStarted,
 } from "./kcsapi";
+import { onQuestStart, onQuestStop, onQuestComplete, onPracticePrepare, onSortiePrepare } from "./quest";
 import { ScriptingService } from "../../services/ScriptingService";
 
 const requestLogger = Logger.get("WebRequest");
@@ -50,6 +51,11 @@ onBeforeRequest.on([
   '/kcsapi/api_get_member/kdock',
 ], onCreateShip); // 新造艦を作成しようとしたとき
 onBeforeRequest.on(["/kcsapi/api_req_kousyou/getship"], onGetShip); // 建造した艦を受け取ったとき
+
+// 任務
+onBeforeRequest.on(["/kcsapi/api_req_quest/start"], onQuestStart); // 任務を受託したとき
+onBeforeRequest.on(["/kcsapi/api_req_quest/stop"], onQuestStop); // 任務を放棄したとき
+onBeforeRequest.on(["/kcsapi/api_req_quest/clearitemget"], onQuestComplete); // 任務報酬を受け取ったとき
 
 onBeforeRequest.onNotFound(async (details) => {
   requestLogger.debug("-", details);
@@ -93,6 +99,9 @@ onComplete.on([
     }
   });
 })
+
+onComplete.on(["/kcsapi/api_get_member/practice"], onPracticePrepare); // 演習画面に遷移したとき
+onComplete.on(["/kcsapi/api_get_member/mapinfo"], onSortiePrepare); // 出撃準備画面に遷移したとき
 
 export {
   onBeforeRequest,

--- a/src/controllers/WebRequest/quest.ts
+++ b/src/controllers/WebRequest/quest.ts
@@ -1,0 +1,41 @@
+import { quests, QuestCategory } from "../../catalog";
+import { QUEST_ALERT_NOTIFICATION_ID } from "../../models/configs/NotificationConfig";
+import { QuestProgress } from "../../models/QuestProgress";
+import { NotificationService } from "../../services/NotificationService";
+import { QuestActionFormData } from "./datatypes";
+
+export async function onQuestStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  const { api_quest_id: [id] } = details.requestBody?.formData as unknown as QuestActionFormData;
+  await (await QuestProgress.user()).start(parseInt(id, 10));
+}
+
+export async function onQuestStop([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  const { api_quest_id: [id] } = details.requestBody?.formData as unknown as QuestActionFormData;
+  await (await QuestProgress.user()).stop(parseInt(id, 10));
+}
+
+export async function onQuestComplete([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  const { api_quest_id: [id] } = details.requestBody?.formData as unknown as QuestActionFormData;
+  await (await QuestProgress.user()).complete(parseInt(id, 10));
+}
+
+// 指定カテゴリに着手可能なのにまだ着手していない任務があれば、その一覧を通知する
+async function warnIfQuestNotAccepted(category: QuestCategory, notificationId: string, title: string) {
+  const ids = (await QuestProgress.user()).availables(category);
+  if (ids.length === 0) return;
+  const message = ids.map((id) => quests[String(id)].title).join("\n");
+  await NotificationService.new().notifyRaw(notificationId, QUEST_ALERT_NOTIFICATION_ID, (config) => ({
+    type: "basic",
+    iconUrl: config.icon ?? chrome.runtime.getURL("icons/128.png"),
+    title,
+    message,
+  }));
+}
+
+export async function onPracticePrepare() {
+  await warnIfQuestNotAccepted("practice", "/quest-alert/practice", "演習任務が未着手です");
+}
+
+export async function onSortiePrepare() {
+  await warnIfQuestNotAccepted("sortie", "/quest-alert/sortie", "出撃任務が未着手です");
+}

--- a/src/models/QuestProgress.ts
+++ b/src/models/QuestProgress.ts
@@ -1,0 +1,103 @@
+import { Model } from "jstorm/chrome/local";
+import { quests, QuestCategory } from "../catalog";
+import { KCWDate } from "../utils";
+
+export enum QuestStatus {
+  LOCKED = "locked", // 前提任務未達成で着手不可
+  OPEN = "open", // 着手可能で未着手
+  ONGOING = "ongoing", // 着手中
+  COMPLETED = "completed", // 達成・報酬受領済み
+}
+
+export interface VisibleQuest {
+  id: number;
+  title: string;
+  category: QuestCategory;
+  status: QuestStatus;
+}
+
+// 任務トラッカー表示での並び順（未着手→遂行中→達成）。LOCKEDはvisibleQuestsで除外される
+const STATUS_ORDER: Record<QuestStatus, number> = {
+  [QuestStatus.OPEN]: 0,
+  [QuestStatus.ONGOING]: 1,
+  [QuestStatus.COMPLETED]: 2,
+  [QuestStatus.LOCKED]: 3,
+};
+
+function initialStatuses(): Record<number, QuestStatus> {
+  return Object.entries(quests).reduce((acc, [id, spec]) => {
+    acc[Number(id)] = spec.requires.length === 0 ? QuestStatus.OPEN : QuestStatus.LOCKED;
+    return acc;
+  }, {} as Record<number, QuestStatus>);
+}
+
+// 日付条件付き任務（211/212）が当日出現するかどうか
+function isVisibleToday(id: number, now: number): boolean {
+  const condition = quests[String(id)]?.condition;
+  if (!condition) return true;
+  const lastDigit = KCWDate.dayOfMonth(now) % 10;
+  switch (condition) {
+  case "date037": return lastDigit === 0 || lastDigit === 3 || lastDigit === 7;
+  case "date28": return lastDigit === 2 || lastDigit === 8;
+  }
+}
+
+// デイリー任務の着手状況。前提任務の連鎖（requires）を解決しながら、
+// カテゴリごとの「今日まだ着手していない任務」を availables() で取得できる。
+export class QuestProgress extends Model {
+  static override _namespace_ = "QuestProgress";
+  static override default = {
+    "user": { statuses: initialStatuses(), refreshedAt: 0 },
+  };
+
+  public statuses: Record<number, QuestStatus> = {};
+  public refreshedAt: number = 0;
+
+  public static async user(): Promise<QuestProgress> {
+    const progress = (await this.find("user"))!;
+    return progress.refreshed();
+  }
+
+  private async refreshed(now: number = Date.now()): Promise<QuestProgress> {
+    if (KCWDate.isSameKCDay(this.refreshedAt, now)) return this;
+    return this.update({ statuses: initialStatuses(), refreshedAt: now });
+  }
+
+  public async start(id: number): Promise<QuestProgress> {
+    if (!(id in this.statuses)) return this;
+    return this.update({ statuses: { ...this.statuses, [id]: QuestStatus.ONGOING } });
+  }
+
+  public async stop(id: number): Promise<QuestProgress> {
+    if (!(id in this.statuses)) return this;
+    return this.update({ statuses: { ...this.statuses, [id]: QuestStatus.OPEN } });
+  }
+
+  public async complete(id: number): Promise<QuestProgress> {
+    if (!(id in this.statuses)) return this;
+    const statuses = { ...this.statuses, [id]: QuestStatus.COMPLETED };
+    for (const [qid, spec] of Object.entries(quests)) {
+      const numId = Number(qid);
+      if (statuses[numId] !== QuestStatus.LOCKED) continue;
+      if (spec.requires.every((r) => statuses[r] === QuestStatus.COMPLETED)) statuses[numId] = QuestStatus.OPEN;
+    }
+    return this.update({ statuses });
+  }
+
+  // 指定カテゴリで、着手可能なのにまだ着手していない任務のIDを返す
+  public availables(category: QuestCategory, now: number = Date.now()): number[] {
+    return Object.entries(quests)
+      .filter(([, spec]) => spec.category === category)
+      .map(([id]) => Number(id))
+      .filter((id) => this.statuses[id] === QuestStatus.OPEN && isVisibleToday(id, now));
+  }
+
+  // カテゴリを問わず、その日「見えている」（前提未達成や日付条件で隠れていない）任務を
+  // 未着手→遂行中→達成の順で返す。任務トラッカー表示用
+  public visibleQuests(now: number = Date.now()): VisibleQuest[] {
+    return Object.entries(quests)
+      .map(([id, spec]) => ({ id: Number(id), title: spec.title, category: spec.category, status: this.statuses[Number(id)] }))
+      .filter((q) => q.status !== QuestStatus.LOCKED && isVisibleToday(q.id, now))
+      .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+  }
+}

--- a/src/models/configs/NotificationConfig.ts
+++ b/src/models/configs/NotificationConfig.ts
@@ -8,6 +8,10 @@ export interface NotificationConfigData {
   stay: boolean;
 }
 
+// 任務未着手通知は Queue のタイマーEntryを持たないため EntryType には加えず、
+// NotificationConfig の1エントリとして直接キーを持つ（開始/完了のペアが無い一発通知）
+export const QUEST_ALERT_NOTIFICATION_ID = "/quest-alert/start";
+
 export class NotificationConfig extends Model {
   static override _namespace_ = "NotificationConfig";
   static override default = {
@@ -66,6 +70,12 @@ export class NotificationConfig extends Model {
       stay: false,
     },
     [`/${EntryType.FATIGUE}/${TriggerType.END}`]: {
+      enabled: true,
+      sound: null,
+      icon: null,
+      stay: false,
+    },
+    [QUEST_ALERT_NOTIFICATION_ID]: {
       enabled: true,
       sound: null,
       icon: null,

--- a/src/models/configs/QuestTrackerConfig.ts
+++ b/src/models/configs/QuestTrackerConfig.ts
@@ -1,0 +1,19 @@
+import { Model } from "jstorm/chrome/local";
+
+// 任務トラッカー機能そのものの設定。通知の有効/無効やアイコン・音は
+// NotificationConfig の "/quest-alert/start" エントリが別途持つ。
+export class QuestTrackerConfig extends Model {
+  static override _namespace_ = "QuestTrackerConfig";
+  static override default = {
+    "user": {
+      // ダッシュボードにも一覧を表示するか。既定はfalse（独立タブが既定の導線）
+      "showOnDashboard": false,
+    },
+  };
+
+  public showOnDashboard: boolean = false;
+
+  public static async user(): Promise<QuestTrackerConfig> {
+    return (await this.find("user"))!;
+  }
+}

--- a/src/page/Dashboard.tsx
+++ b/src/page/Dashboard.tsx
@@ -2,11 +2,20 @@ import { useLoaderData, useRevalidator } from "react-router-dom";
 import { ActionsView } from "./components/dashboard/ActionsView";
 import { ClockView } from "./components/dashboard/ClockView";
 import { QueuesView } from "./components/dashboard/QueuesView";
+import { QuestTrackerList } from "./components/quest-tracker/QuestTrackerList";
 import type Queue from "../models/Queue";
+import type { QuestTrackerConfig } from "../models/configs/QuestTrackerConfig";
+import type { QuestProgress } from "../models/QuestProgress";
 import { useEffect } from "react";
 
 export function DashboardPage() {
-  const { window, queues, time } = useLoaderData() as { window: chrome.windows.Window, queues: Queue[], time: Date };
+  const { window, queues, time, questTrackerConfig, questProgress } = useLoaderData() as {
+    window: chrome.windows.Window,
+    queues: Queue[],
+    time: Date,
+    questTrackerConfig: QuestTrackerConfig,
+    questProgress: QuestProgress,
+  };
   const revalidater = useRevalidator();
 
   // 1秒ごとにデータを再検証
@@ -49,6 +58,9 @@ export function DashboardPage() {
         <ActionsView tab={window?.tabs?.[0]} />
       </div>
       <QueuesView queues={queues} />
+      {questTrackerConfig.showOnDashboard ? (
+        <QuestTrackerList progress={questProgress} onChanged={() => revalidater.revalidate()} compact />
+      ) : null}
     </div>
   )
 }

--- a/src/page/PopupPage.tsx
+++ b/src/page/PopupPage.tsx
@@ -4,7 +4,7 @@ import { type Frame } from "../models/Frame"
 import { GameWindowConfig } from "../models/configs/GameWindowConfig"
 
 import { useState, type ReactNode } from "react";
-import { ClockIcon, SquaresPlusIcon, Cog6ToothIcon, BookOpenIcon } from "@heroicons/react/24/outline";
+import { ClockIcon, SquaresPlusIcon, Cog6ToothIcon, BookOpenIcon, ClipboardDocumentCheckIcon } from "@heroicons/react/24/outline";
 
 function ShortCutIcon({icon, title, action}: {
   icon: ReactNode;
@@ -69,6 +69,7 @@ export function PopupPage() {
         <ShortCutIcon icon={<ClockIcon className="w-5 h-5" aria-hidden="true" />} title="ダッシュボードを開く" action={() => Launcher.dashboard()} />
         <ShortCutIcon icon={<SquaresPlusIcon className="w-5 h-5" aria-hidden="true" />} title="編成キャプチャを開く" action={() => Launcher.fleetcapture()} />
         <ShortCutIcon icon={<BookOpenIcon className="w-5 h-5" aria-hidden="true" />} title="出撃記録を開く" action={() => Launcher.logbook()} />
+        <ShortCutIcon icon={<ClipboardDocumentCheckIcon className="w-5 h-5" aria-hidden="true" />} title="任務トラッカーを開く" action={() => Launcher.questTracker()} />
         <ShortCutIcon icon={<Cog6ToothIcon className="w-5 h-5" aria-hidden="true" />} title="設定を開く" action={() => Launcher.options()} />
       </div>
     </div>

--- a/src/page/components/options/NotificationSettingView.tsx
+++ b/src/page/components/options/NotificationSettingView.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 import { FoldableSection } from "../FoldableSection";
-import { NotificationConfig } from "../../../models/configs/NotificationConfig";
+import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../../../models/configs/NotificationConfig";
 import { Entry, EntryType, Fatigue, Mission, Recovery, Shipbuild, TriggerType } from "../../../models/entry";
 import { NotificationService } from "../../../services/NotificationService";
 
@@ -158,7 +158,7 @@ export function NotificationSettingView({
   );
 }
 
-function NotificationConfigEditor({
+export function NotificationConfigEditor({
   title,
   description,
   config,
@@ -319,6 +319,7 @@ function StaySettingView({
 }
 
 function TestPlayView({
+  config,
   type,
   trigger,
 }: {
@@ -326,6 +327,25 @@ function TestPlayView({
   type: EntryType;
   trigger: TriggerType;
 }) {
+  // 任務未着手通知はQueueのEntry（艦隊・ドック等）を持たない一発通知なので、Entry経由のnotify()ではなくnotifyRaw()でテストする
+  if (config._id === QUEST_ALERT_NOTIFICATION_ID) {
+    return (
+      <button className="px-3 py-1 bg-blue-500 text-white rounded-md text-sm"
+        onClick={async () => {
+          const s = new NotificationService();
+          await s.notifyRaw("/quest-alert/test", QUEST_ALERT_NOTIFICATION_ID, (c) => ({
+            type: "basic",
+            iconUrl: c.icon ?? chrome.runtime.getURL("icons/128.png"),
+            title: "テスト",
+            message: "任務未着手通知のテストです",
+          }));
+        }}
+      >
+        テスト通知を送信
+      </button>
+    );
+  }
+
   const entry: Entry = (() => {
     switch (type) {
     case EntryType.MISSION:

--- a/src/page/components/options/QuestTrackerSettingView.tsx
+++ b/src/page/components/options/QuestTrackerSettingView.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { NotificationConfig } from "../../../models/configs/NotificationConfig";
+import { QuestTrackerConfig } from "../../../models/configs/QuestTrackerConfig";
+import { FoldableSection } from "../FoldableSection";
+import { NotificationConfigEditor } from "./NotificationSettingView";
+
+export function QuestTrackerSettingView({
+  notification: _notification, tracker: _tracker,
+}: {
+  notification: NotificationConfig;
+  tracker: QuestTrackerConfig;
+}) {
+  const [notification] = useState<NotificationConfig>(_notification);
+  const [enabled, setEnabled] = useState<boolean>(notification.enabled);
+  const [tracker] = useState<QuestTrackerConfig>(_tracker);
+  const [showOnDashboard, setShowOnDashboard] = useState<boolean>(tracker.showOnDashboard);
+
+  return (
+    <FoldableSection title="任務トラッカーの設定" id="quest-tracker">
+      <div className="grid gap-4 md:grid-cols-2">
+        <NotificationConfigEditor
+          title="演習・出撃の任務未着手を通知する"
+          config={notification}
+          configId="quest-alert"
+          enabled={enabled}
+          onEnabledChange={(_id, next) => setEnabled(next)}
+        />
+      </div>
+      <div className="text-sm text-gray-600 mt-1">
+        演習画面・出撃準備画面を開いたとき、その日まだ着手していないデイリー任務があれば通知します。
+      </div>
+
+      <div className="mt-4">
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={showOnDashboard}
+            onChange={async (e) => {
+              const next = e.target.checked;
+              await tracker.update({ showOnDashboard: next });
+              setShowOnDashboard(next);
+            }}
+            className="w-4 h-4"
+          />
+          <span className="font-bold">ダッシュボードにも任務トラッカーを表示する</span>
+        </label>
+        <div className="text-sm text-gray-600 mt-1">
+          任務トラッカーは既定では独立したタブで開きます。オンにするとダッシュボードにも同じ一覧を表示します。
+        </div>
+      </div>
+    </FoldableSection>
+  );
+}

--- a/src/page/components/quest-tracker/QuestTrackerList.tsx
+++ b/src/page/components/quest-tracker/QuestTrackerList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { QuestCategory } from "../../../catalog";
 import { QuestProgress, QuestStatus, VisibleQuest } from "../../../models/QuestProgress";
 
@@ -83,16 +83,23 @@ export function QuestTrackerList({
 }) {
   const [editing, setEditing] = useState<VisibleQuest | null>(null);
 
+  // onChanged は呼び出し側で毎レンダー新しいクロージャになりうる（ダッシュボードは1秒毎に再レンダー）
+  // ため、ref経由で参照して購読の貼り直しを避ける。
+  const onChangedRef = useRef(onChanged);
+  useEffect(() => {
+    onChangedRef.current = onChanged;
+  }, [onChanged]);
+
   // 他タブ・ダッシュボード・バックグラウンド側での着手/達成をポーリングなしで反映する。
   // 更新頻度は低いので、更新ボタンやインターバルではなくストレージ変更イベントに任せる。
   useEffect(() => {
     const listener = (changes: Record<string, chrome.storage.StorageChange>, areaName: string) => {
       if (areaName !== "local" || !("QuestProgress" in changes)) return;
-      onChanged();
+      onChangedRef.current();
     };
     chrome.storage.onChanged.addListener(listener);
     return () => chrome.storage.onChanged.removeListener(listener);
-  }, [onChanged]);
+  }, []);
 
   const applyStatus = async (id: number, status: QuestStatus) => {
     if (status === QuestStatus.OPEN) await progress.stop(id);

--- a/src/page/components/quest-tracker/QuestTrackerList.tsx
+++ b/src/page/components/quest-tracker/QuestTrackerList.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+import { QuestCategory } from "../../../catalog";
+import { QuestProgress, QuestStatus, VisibleQuest } from "../../../models/QuestProgress";
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  [QuestStatus.OPEN]: "未着手",
+  [QuestStatus.ONGOING]: "遂行中",
+  [QuestStatus.COMPLETED]: "達成",
+  [QuestStatus.LOCKED]: "未解放",
+};
+
+const STATUS_COLORS: Record<QuestStatus, string> = {
+  [QuestStatus.OPEN]: "bg-slate-100 text-slate-600",
+  [QuestStatus.ONGOING]: "bg-amber-100 text-amber-700",
+  [QuestStatus.COMPLETED]: "bg-emerald-100 text-emerald-700",
+  [QuestStatus.LOCKED]: "bg-slate-100 text-slate-400",
+};
+
+const CATEGORY_LABELS: Record<QuestCategory, string> = {
+  sortie: "出撃",
+  supply: "補給",
+  mission: "遠征",
+  recovery: "入渠",
+  shipbuilding: "建造",
+  createitem: "開発",
+  remodel: "改修",
+  destroyship: "解体",
+  destroyitem: "廃棄",
+  practice: "演習",
+};
+
+// ゲーム内の任務カテゴリ配色に合わせた色（v3 dashboard.scss 準拠。未定義カテゴリはv3でも無地だった）
+const CATEGORY_COLORS: Record<QuestCategory, string> = {
+  sortie: "bg-[#e85600]",
+  practice: "bg-[#32b643]",
+  mission: "bg-[#5755d9]",
+  recovery: "bg-[#56c2c1]",
+  shipbuilding: "bg-[#fa9836]",
+  createitem: "bg-[#fa9836]",
+  remodel: "bg-slate-400",
+  destroyship: "bg-slate-400",
+  destroyitem: "bg-slate-400",
+  supply: "bg-slate-400",
+};
+
+// 任務の状態を手動で上書きする（API傍受の取りこぼしや他端末での進行とのズレを補正するため）
+function StatusEditModal({
+  quest, onSelect, onClose,
+}: {
+  quest: VisibleQuest;
+  onSelect: (status: QuestStatus) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center text-lg">
+      <div className="bg-white p-4 flex flex-col space-y-4 rounded-md max-w-sm">
+        <div className="font-bold">{quest.title}</div>
+        <div className="flex space-x-2 justify-end">
+          {([QuestStatus.OPEN, QuestStatus.ONGOING, QuestStatus.COMPLETED] as const).map((status) => (
+            <button
+              key={status}
+              className={`px-3 py-1 rounded text-sm ${STATUS_COLORS[status]}`}
+              onClick={() => onSelect(status)}
+            >
+              {STATUS_LABELS[status]}
+            </button>
+          ))}
+          <button className="px-3 py-1 rounded text-sm bg-slate-50" onClick={onClose}>閉じる</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function QuestTrackerList({
+  progress, onChanged, compact = false,
+}: {
+  progress: QuestProgress;
+  onChanged: () => void;
+  // ダッシュボードの小窓に埋め込むとき用に、他ウィジェット（FatigueQueueViewなど）と
+  // 同じtext-xs基調の詰まった表示にする。独立タブでは既定のtext-smのまま
+  compact?: boolean;
+}) {
+  const [editing, setEditing] = useState<VisibleQuest | null>(null);
+
+  // 他タブ・ダッシュボード・バックグラウンド側での着手/達成をポーリングなしで反映する。
+  // 更新頻度は低いので、更新ボタンやインターバルではなくストレージ変更イベントに任せる。
+  useEffect(() => {
+    const listener = (changes: Record<string, chrome.storage.StorageChange>, areaName: string) => {
+      if (areaName !== "local" || !("QuestProgress" in changes)) return;
+      onChanged();
+    };
+    chrome.storage.onChanged.addListener(listener);
+    return () => chrome.storage.onChanged.removeListener(listener);
+  }, [onChanged]);
+
+  const applyStatus = async (id: number, status: QuestStatus) => {
+    if (status === QuestStatus.OPEN) await progress.stop(id);
+    else if (status === QuestStatus.ONGOING) await progress.start(id);
+    else if (status === QuestStatus.COMPLETED) await progress.complete(id);
+    setEditing(null);
+    onChanged();
+  };
+
+  const visible = progress.visibleQuests();
+
+  if (visible.length === 0) {
+    return <div className="text-center py-4 text-slate-400 text-sm">今日の任務はありません</div>;
+  }
+
+  return (
+    <div>
+      {visible.map((quest) => (
+        <div
+          key={quest.id}
+          className={`flex items-center space-x-2 px-1 odd:bg-slate-100 ${compact ? "text-xs py-0.5" : "text-sm py-1"}`}
+        >
+          <span
+            className={`text-white text-center shrink-0 rounded ${CATEGORY_COLORS[quest.category]} ${compact ? "text-[10px] px-1 w-10" : "text-xs px-1.5 py-0.5 w-12"}`}
+          >
+            {CATEGORY_LABELS[quest.category]}
+          </span>
+          <span className="flex-1">{quest.title}</span>
+          <button
+            className={`rounded ${STATUS_COLORS[quest.status]} ${compact ? "text-[10px] px-1.5" : "px-2 py-0.5"}`}
+            onClick={() => setEditing(quest)}
+          >
+            {STATUS_LABELS[quest.status]}
+          </button>
+        </div>
+      ))}
+      {editing ? (
+        <StatusEditModal
+          quest={editing}
+          onSelect={(status) => applyStatus(editing.id, status)}
+          onClose={() => setEditing(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -9,7 +9,7 @@ import { DashboardConfig } from "../../models/configs/DashboardConfig";
 import { DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig";
 import { BehaviorConfig } from "../../models/configs/BehaviorConfig";
 import { GameWindowConfig } from "../../models/configs/GameWindowConfig";
-import { NotificationConfig } from "../../models/configs/NotificationConfig";
+import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../../models/configs/NotificationConfig";
 import { EntryType, TriggerType } from "../../models/entry";
 import { Logbook } from "../../models/Logbook";
 import { CapturePreset } from "../../models/CapturePreset";
@@ -65,6 +65,8 @@ export async function options() {
     },
     capturePresets: await CapturePreset.list(),
     fleetcapture: await FleetCaptureConfig.user(),
+    questAlert: (await NotificationConfig.find(QUEST_ALERT_NOTIFICATION_ID))!,
+    questTracker: await QuestTrackerConfig.user(),
   };
 }
 

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -14,6 +14,8 @@ import { EntryType, TriggerType } from "../../models/entry";
 import { Logbook } from "../../models/Logbook";
 import { CapturePreset } from "../../models/CapturePreset";
 import { FleetCaptureConfig } from "../../models/configs/FleetCaptureConfig";
+import { QuestTrackerConfig } from "../../models/configs/QuestTrackerConfig";
+import { QuestProgress } from "../../models/QuestProgress";
 
 export async function options() {
   const frames = await Frame.list();
@@ -90,6 +92,8 @@ export async function dashboard() {
     queues: await Queue.list(),
     window: win,
     time: new Date(),
+    questTrackerConfig: await QuestTrackerConfig.user(),
+    questProgress: await QuestProgress.user(),
   }
 }
 
@@ -100,5 +104,11 @@ export async function damagesnapshot() {
 export async function logbook() {
   return {
     sorties: await Logbook.list(),
+  };
+}
+
+export async function questTracker() {
+  return {
+    progress: await QuestProgress.user(),
   };
 }

--- a/src/page/logbook/LogbookPage.tsx
+++ b/src/page/logbook/LogbookPage.tsx
@@ -64,7 +64,7 @@ export function LogbookPage() {
             {sorted.map((sortie) => (
               <tr
                 key={sortie._id ?? sortie.started}
-                className="border-b border-slate-100 hover:bg-slate-50"
+                className="border-b border-slate-100 odd:bg-slate-100 hover:bg-slate-200"
               >
                 <td className="py-1.5 pr-4 text-slate-500 whitespace-nowrap">
                   {formatStarted(sortie.started)}

--- a/src/page/main.tsx
+++ b/src/page/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { RouterProvider, createHashRouter } from "react-router-dom";
 
 // Loaders
-import { popup, options, dashboard, damagesnapshot, logbook, fleetcapture } from './loader';
+import { popup, options, dashboard, damagesnapshot, logbook, fleetcapture, questTracker } from './loader';
 
 // View
 import './index.scss'
@@ -14,6 +14,7 @@ import { FleetCapturePage } from './fleet-capture/FleetCapturePage';
 import { ScreenshotEditPage } from './screenshot-edit/ScreenshotEditPage';
 import { DamageSnapshotPage } from './snapshot/DamageSnapshotPage';
 import { LogbookPage } from './logbook/LogbookPage';
+import { QuestTrackerPage } from './quest-tracker/QuestTrackerPage';
 
 const router = createHashRouter([
   {
@@ -49,6 +50,11 @@ const router = createHashRouter([
     path: "/logbook",
     element: <LogbookPage />,
     loader: logbook,
+  },
+  {
+    path: "/quest-tracker",
+    element: <QuestTrackerPage />,
+    loader: questTracker,
   }
 ]);
 

--- a/src/page/options/OptionsPage.tsx
+++ b/src/page/options/OptionsPage.tsx
@@ -7,6 +7,7 @@ import { FleetCaptureSettingView } from "../components/options/FleetCaptureSetti
 import { BehaviorSettingView } from "../components/options/BehaviorSettingView";
 import { NotificationSettingView } from "../components/options/NotificationSettingView";
 import { InAppSettingView } from "../components/options/InAppSettingView";
+import { QuestTrackerSettingView } from "../components/options/QuestTrackerSettingView";
 
 import { type Frame } from "../../models/Frame";
 import { type CapturePreset } from "../../models/CapturePreset";
@@ -19,6 +20,7 @@ import { DevelopmentInfoView, type ReleaseNoteObject } from "../components/optio
 import { VersionView } from "../components/options/VersionView";
 import { type GameWindowConfig } from "../../models/configs/GameWindowConfig";
 import { NotificationConfig } from "../../models/configs/NotificationConfig";
+import { type QuestTrackerConfig } from "../../models/configs/QuestTrackerConfig";
 import { EntryType, TriggerType } from "../../models/entry";
 
 const KCWidgetChanURL = "https://cloud.githubusercontent.com/assets/931554/26664134/361ee756-46ca-11e7-98f5-d99e95dd90b8.png";
@@ -35,6 +37,8 @@ export function OptionsPage() {
     notification,
     capturePresets,
     fleetcapture,
+    questAlert,
+    questTracker,
   } = useLoaderData() as {
     frames: Frame[];
     game: GameWindowConfig;
@@ -49,6 +53,8 @@ export function OptionsPage() {
     };
     capturePresets: CapturePreset[];
     fleetcapture: FleetCaptureConfig;
+    questAlert: NotificationConfig;
+    questTracker: QuestTrackerConfig;
   };
   const manifest = chrome.runtime.getManifest();
   return (
@@ -64,6 +70,8 @@ export function OptionsPage() {
         defaults={notification.defaults}
         entries={notification.entries}
       />
+      <Divider />
+      <QuestTrackerSettingView notification={questAlert} tracker={questTracker} />
       <Divider />
       <DashboardSettingView config={dashboard} />
       <Divider />

--- a/src/page/quest-tracker/QuestTrackerPage.tsx
+++ b/src/page/quest-tracker/QuestTrackerPage.tsx
@@ -1,0 +1,27 @@
+import { useLoaderData, useRevalidator } from "react-router-dom";
+import { ArrowPathIcon, ClipboardDocumentCheckIcon } from "@heroicons/react/24/outline";
+import { QuestProgress } from "../../models/QuestProgress";
+import { QuestTrackerList } from "../components/quest-tracker/QuestTrackerList";
+
+export function QuestTrackerPage() {
+  const { progress } = useLoaderData() as { progress: QuestProgress };
+  const revalidator = useRevalidator();
+
+  return (
+    <div className="p-4">
+      <div className="mb-4 flex items-center space-x-2">
+        <ClipboardDocumentCheckIcon className="w-6 h-6 text-slate-600" />
+        <h1 className="text-2xl font-bold text-slate-800">任務トラッカー</h1>
+        <button
+          onClick={() => revalidator.revalidate()}
+          className="ml-4 flex items-center space-x-1 border rounded px-2 py-1 text-sm text-slate-600 hover:bg-slate-50"
+        >
+          <ArrowPathIcon className="w-4 h-4" />
+          <span>更新</span>
+        </button>
+      </div>
+
+      <QuestTrackerList progress={progress} onChanged={() => revalidator.revalidate()} />
+    </div>
+  );
+}

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -77,6 +77,14 @@ export class Launcher {
   }
 
   /**
+   * 任務トラッカーページを新規タブで開く。
+   * @returns 作成されたタブの Promise
+   */
+  public static async questTracker() {
+    return await (new this()).tabs.create({ url: "page/index.html#/quest-tracker" });
+  }
+
+  /**
    * スクショ編集ページを新規タブで開く。
    * @param key TempStorage に保存した撮影画像の取り出しキー
    * @returns 作成されたタブの Promise

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,4 +1,4 @@
-import { NotificationConfig } from "../models/configs/NotificationConfig";
+import { NotificationConfig, NotificationConfigData } from "../models/configs/NotificationConfig";
 import { Entry, TriggerType } from "../models/entry";
 import { SoundPlayer } from "./SoundService";
 
@@ -44,5 +44,30 @@ export class NotificationService {
     }
 
     return entry.$n.id();
+  }
+
+  /**
+   * Queue の Entry（艦隊・ドック等の対象を持つ時限通知）に依らない、単発の通知を送る。
+   * NotificationConfig の設定（有効/アイコン/通知音/消去方式）は entry 版の notify と共通のものを使う。
+   * @param id 通知ID（表示・消去に使う）
+   * @param configId NotificationConfig を引く際のID（例: "/quest-alert/start"）
+   * @param buildOptions 解決済みの設定から通知オプションを組み立てる
+   */
+  public async notifyRaw(
+    id: string,
+    configId: string,
+    buildOptions: (config: NotificationConfigData) => chrome.notifications.NotificationCreateOptions,
+  ): Promise<string> {
+    const config = await NotificationConfig.get(configId);
+    if (!config.enabled) return "";
+    await this.clear(id);
+    await this.create(id, buildOptions(config));
+    await this.sound.play(config.sound);
+
+    if (config.stay === false) {
+      setTimeout(() => this.clear(id), 10 * 1000);
+    }
+
+    return id;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,15 @@ export class WorkerImage {
 
 }
 
+const S = 1000;
+const M = 60 * S;
+const H = 60 * M;
+const D = 24 * H;
+
 export class KCWDate extends Date {
+
+  // デイリーリセット時刻（朝5時）。この時刻より前は前日として扱う
+  private static readonly RESET_HOUR = 5;
 
   static fmt = Intl.DateTimeFormat("ja-JP", {
     year: "numeric",
@@ -46,16 +54,24 @@ export class KCWDate extends Date {
   public static ETA(time: number, now: number = Date.now()): KCWDate {
     return new KCWDate(now + time);
   }
+
+  // 朝5時を境界とした「艦これ的な同じ日」かどうかを返す
+  public static isSameKCDay(a: number, b: number): boolean {
+    const shifted = (epoch: number) => new Date(epoch - KCWDate.RESET_HOUR * H);
+    const da = shifted(a), db = shifted(b);
+    return da.getFullYear() === db.getFullYear() && da.getMonth() === db.getMonth() && da.getDate() === db.getDate();
+  }
+
+  // 朝5時を境界とした「艦これ的な日付」の日部分(1-31)を返す
+  public static dayOfMonth(epoch: number = Date.now()): number {
+    return new Date(epoch - KCWDate.RESET_HOUR * H).getDate();
+  }
 }
 
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const S = 1000;
-const M = 60 * S;
-const H = 60 * M;
-const D = 24 * H;
 export {
   S, M, H, D
 }

--- a/tests/model-namespace.spec.ts
+++ b/tests/model-namespace.spec.ts
@@ -19,6 +19,7 @@ import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
 import { FleetCaptureConfig } from "../src/models/configs/FleetCaptureConfig";
 import { GameWindowConfig } from "../src/models/configs/GameWindowConfig";
 import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+import { QuestTrackerConfig } from "../src/models/configs/QuestTrackerConfig";
 import { QuestProgress } from "../src/models/QuestProgress";
 
 // jstorm の Model は _namespace_ が未指定だとクラス名を chrome.storage.local のキーに使う。
@@ -36,6 +37,7 @@ const models = [
   FleetCaptureConfig,
   GameWindowConfig,
   NotificationConfig,
+  QuestTrackerConfig,
   QuestProgress,
 ] as const;
 

--- a/tests/model-namespace.spec.ts
+++ b/tests/model-namespace.spec.ts
@@ -19,6 +19,7 @@ import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
 import { FleetCaptureConfig } from "../src/models/configs/FleetCaptureConfig";
 import { GameWindowConfig } from "../src/models/configs/GameWindowConfig";
 import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+import { QuestProgress } from "../src/models/QuestProgress";
 
 // jstorm の Model は _namespace_ が未指定だとクラス名を chrome.storage.local のキーに使う。
 // minify でクラス名はビルドごとに変わる短縮名になるため、_namespace_ を明示しないモデルは
@@ -35,6 +36,7 @@ const models = [
   FleetCaptureConfig,
   GameWindowConfig,
   NotificationConfig,
+  QuestProgress,
 ] as const;
 
 describe("jstorm モデルの _namespace_", () => {

--- a/tests/quest-action-tracking.spec.ts
+++ b/tests/quest-action-tracking.spec.ts
@@ -1,0 +1,43 @@
+import { expect, describe, it, vi } from "vitest";
+
+// quest.ts が NotificationConfig 経由で chrome.runtime.getURL を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+});
+
+import { onQuestStart, onQuestStop, onQuestComplete } from "../src/controllers/WebRequest/quest";
+import { QuestProgress, QuestStatus } from "../src/models/QuestProgress";
+
+// api_req_quest/{start,stop,clearitemget} の formData から任務IDを取り出し、
+// QuestProgress へ反映できているかを検証する（連鎖解放そのものは quest-progress.spec.ts 側で検証済み）。
+const details = (questId: number) =>
+  [{ requestBody: { formData: { api_quest_id: [String(questId)] } } }] as unknown as chrome.webRequest.OnBeforeRequestDetails[];
+
+describe("onQuestStart", () => {
+  it("formDataのapi_quest_idが示す任務をONGOINGにする", async () => {
+    await onQuestStart(details(303));
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[303]).toBe(QuestStatus.ONGOING);
+  });
+});
+
+describe("onQuestStop", () => {
+  it("formDataのapi_quest_idが示す任務をOPENに戻す", async () => {
+    await onQuestStart(details(303));
+    await onQuestStop(details(303));
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[303]).toBe(QuestStatus.OPEN);
+  });
+});
+
+describe("onQuestComplete", () => {
+  it("formDataのapi_quest_idが示す任務をCOMPLETEDにし、後続任務を解放する", async () => {
+    await onQuestComplete(details(303));
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[303]).toBe(QuestStatus.COMPLETED);
+    expect(progress.statuses[304]).toBe(QuestStatus.OPEN);
+  });
+});

--- a/tests/quest-alert-notification.spec.ts
+++ b/tests/quest-alert-notification.spec.ts
@@ -1,0 +1,118 @@
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+
+// chrome.notifications を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: {
+      id: "test",
+      onMessage: { addListener: () => {} },
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    notifications: {
+      // NotificationService.create/clear はコールバック経由でPromiseを解決するため、素の vi.fn() だとawaitがハングする
+      create: vi.fn((id: string, _options: unknown, cb?: (id: string) => void) => cb?.(id)),
+      clear: vi.fn((id: string, cb?: (wasCleared: boolean) => void) => cb?.(true)),
+    },
+  };
+});
+
+import { onPracticePrepare, onSortiePrepare } from "../src/controllers/WebRequest/quest";
+import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../src/models/configs/NotificationConfig";
+import { QuestProgress } from "../src/models/QuestProgress";
+
+const create = chrome.notifications.create as unknown as ReturnType<typeof vi.fn>;
+const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
+
+// 消去方式(stay)が既定のfalse(自動)だと10秒後に自動でclearされる。fake timerで固定し、
+// 実時間の待ちタイマーをテストプロセスに残さないようにする。
+beforeEach(() => {
+  // mockReset() だとコールバックを呼ぶ実装（hoisted側で設定）まで消えてPromiseがハングするので、
+  // 呼び出し履歴だけ消す mockClear() を使う
+  create.mockClear();
+  clear.mockClear();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// 演習・出撃の画面遷移(api_get_member/practice, mapinfo)で、未着手の任務があるときだけ
+// NotificationConfig("/quest-alert/start")の設定に沿って通知を出す。
+describe("onPracticePrepare", () => {
+  it("演習任務が未着手なら通知を出し、アイコンは他の通知と同じ既定値を使う", async () => {
+    await onPracticePrepare();
+    expect(clear).toHaveBeenCalledWith("/quest-alert/practice", expect.any(Function));
+    expect(create).toHaveBeenCalledTimes(1);
+    const [id, options] = create.mock.calls[0] as [string, chrome.notifications.NotificationCreateOptions];
+    expect(id).toBe("/quest-alert/practice");
+    expect(options.message).toContain("「演習」で練度向上！");
+    expect(options.iconUrl).toBe("chrome-extension://test/icons/128.png");
+  });
+
+  it("演習任務に着手済みなら通知を出さない", async () => {
+    const progress = await QuestProgress.user();
+    await progress.start(303);
+    try {
+      await onPracticePrepare();
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      // QuestProgress も default が書き換わる同種の問題があるため、着手状態を戻しておく
+      await progress.stop(303);
+    }
+  });
+
+  it("設定が無効なら通知を出さない", async () => {
+    const config = (await NotificationConfig.find(QUEST_ALERT_NOTIFICATION_ID))!;
+    await config.update({ enabled: false });
+    try {
+      await onPracticePrepare();
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      // jstorm は保存先が空のとき static default をその場で書き換えるため、
+      // ここで false のまま残すと他テストの既定値に波及する。明示的に戻す
+      await config.update({ enabled: true });
+    }
+  });
+
+  it("消去方式が既定(自動)なら10秒後に自動でclearされる", async () => {
+    await onPracticePrepare();
+    expect(clear).toHaveBeenCalledTimes(1); // 発火直前のclearのみ
+    vi.advanceTimersByTime(10_000);
+    expect(clear).toHaveBeenCalledTimes(2); // 自動消去分
+  });
+
+  it("消去方式を手動にすると自動では消えない", async () => {
+    const config = (await NotificationConfig.find(QUEST_ALERT_NOTIFICATION_ID))!;
+    await config.update({ stay: true });
+    try {
+      await onPracticePrepare();
+      vi.advanceTimersByTime(10_000);
+      expect(clear).toHaveBeenCalledTimes(1); // 発火直前のclearのみ
+    } finally {
+      await config.update({ stay: false });
+    }
+  });
+});
+
+describe("onSortiePrepare", () => {
+  it("出撃任務が未着手なら通知を出す", async () => {
+    await onSortiePrepare();
+    expect(clear).toHaveBeenCalledWith("/quest-alert/sortie", expect.any(Function));
+    expect(create).toHaveBeenCalledTimes(1);
+    const [id, options] = create.mock.calls[0] as [string, chrome.notifications.NotificationCreateOptions];
+    expect(id).toBe("/quest-alert/sortie");
+    expect(options.message).toContain("敵艦隊を撃破せよ！");
+  });
+
+  it("出撃任務に着手済みなら通知を出さない", async () => {
+    const progress = await QuestProgress.user();
+    await progress.start(201);
+    try {
+      await onSortiePrepare();
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      await progress.stop(201);
+    }
+  });
+});

--- a/tests/quest-catalog.spec.ts
+++ b/tests/quest-catalog.spec.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it } from "vitest";
+
+import { quests, QuestCategory } from "../src/catalog";
+
+const KNOWN_CATEGORIES: QuestCategory[] = [
+  "sortie", "supply", "mission", "recovery", "shipbuilding",
+  "createitem", "remodel", "destroyship", "destroyitem", "practice",
+];
+
+// quests.json は as unknown as QuestCatalog でキャストしているだけで実行時検証がないため、
+// カタログ自体の整合性（参照する前提任務IDの実在、カテゴリ値の妥当性）をここで担保する。
+describe("quests カタログの整合性", () => {
+  const entries = Object.entries(quests);
+
+  it.each(entries)("id=%s の category は既知の値である", (_id, spec) => {
+    expect(KNOWN_CATEGORIES).toContain(spec.category);
+  });
+
+  it.each(entries)("id=%s の requires が参照する任務は全てカタログに存在する", (_id, spec) => {
+    for (const requiredId of spec.requires) {
+      expect(quests[String(requiredId)]).toBeDefined();
+    }
+  });
+
+  it("演習カテゴリは303→304の連鎖を持つ", () => {
+    expect(quests["303"].requires).toEqual([]);
+    expect(quests["304"].requires).toEqual([303]);
+  });
+
+  it("出撃カテゴリの211/212は日付条件を持つ", () => {
+    expect(quests["211"].condition).toBe("date037");
+    expect(quests["212"].condition).toBe("date28");
+  });
+});

--- a/tests/quest-progress.spec.ts
+++ b/tests/quest-progress.spec.ts
@@ -1,0 +1,142 @@
+import { expect, describe, it, vi } from "vitest";
+
+import { QuestProgress, QuestStatus } from "../src/models/QuestProgress";
+import { quests } from "../src/catalog";
+import { KCWDate } from "../src/utils";
+
+describe("QuestProgress 初期状態", () => {
+  it.each([303, 201])("前提任務のない任務(id=%i)はOPENで始まる", async (id) => {
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[id]).toBe(QuestStatus.OPEN);
+  });
+
+  it.each([304, 216])("前提任務のある任務(id=%i)はLOCKEDで始まる", async (id) => {
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[id]).toBe(QuestStatus.LOCKED);
+  });
+});
+
+describe("start/stop", () => {
+  it("start()でONGOINGになる", async () => {
+    const progress = await QuestProgress.user();
+    const updated = await progress.start(303);
+    expect(updated.statuses[303]).toBe(QuestStatus.ONGOING);
+  });
+
+  it("stop()でOPENに戻る", async () => {
+    const progress = await QuestProgress.user();
+    const started = await progress.start(303);
+    const stopped = await started.stop(303);
+    expect(stopped.statuses[303]).toBe(QuestStatus.OPEN);
+  });
+
+  it("カタログに無いIDはno-op", async () => {
+    const progress = await QuestProgress.user();
+    const updated = await progress.start(99999);
+    expect(updated.statuses[99999]).toBeUndefined();
+  });
+});
+
+describe("complete() による前提任務の連鎖解放", () => {
+  it("303完了で304がLOCKED→OPENになる", async () => {
+    const progress = await QuestProgress.user();
+    const completed = await progress.complete(303);
+    expect(completed.statuses[303]).toBe(QuestStatus.COMPLETED);
+    expect(completed.statuses[304]).toBe(QuestStatus.OPEN);
+  });
+
+  it("608完了で609と619の両方がOPENになる（1つの完了が複数任務を解放する）", async () => {
+    const progress = await QuestProgress.user();
+    const completed = await progress.complete(608);
+    expect(completed.statuses[609]).toBe(QuestStatus.OPEN);
+    expect(completed.statuses[619]).toBe(QuestStatus.OPEN);
+  });
+});
+
+describe("availables()", () => {
+  it("カテゴリと日付条件でフィルタする", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new KCWDate("August 10, 2024 12:00:00")); // 日付下1桁が0 → date037対象日
+    const progress = await QuestProgress.user();
+    // 211/212/216 は201完了で初めてOPENになる（211/212の条件差を見るための前提解放）
+    const completed = await progress.complete(201);
+    const sorties = completed.availables("sortie");
+    expect(sorties).toContain(216); // 条件なし
+    expect(sorties).toContain(211); // date037対象なので出現する
+    expect(sorties).not.toContain(212); // date28対象外の日なので出現しない
+    vi.useRealTimers();
+  });
+
+  it("着手済み(ONGOING)の任務はavailablesに含まれない", async () => {
+    const progress = await QuestProgress.user();
+    const started = await progress.start(303);
+    expect(started.availables("practice")).not.toContain(303);
+  });
+
+  it("他カテゴリの任務は含まれない", async () => {
+    const progress = await QuestProgress.user();
+    expect(progress.availables("practice")).not.toContain(201);
+  });
+});
+
+describe("日次リセット（朝5時境界）", () => {
+  it("同じ艦これ日のうちは着手状態が保たれる", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new KCWDate("August 10, 2024 06:00:00"));
+    await (await QuestProgress.user()).start(303);
+
+    vi.setSystemTime(new KCWDate("August 10, 2024 23:00:00"));
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[303]).toBe(QuestStatus.ONGOING);
+    vi.useRealTimers();
+  });
+
+  it("朝5時を跨ぐと着手状態がリセットされる", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new KCWDate("August 10, 2024 06:00:00"));
+    await (await QuestProgress.user()).start(303);
+
+    vi.setSystemTime(new KCWDate("August 11, 2024 06:00:00"));
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[303]).toBe(QuestStatus.OPEN);
+    vi.useRealTimers();
+  });
+});
+
+// 任務トラッカー表示用。606は605(未着手のまま推移)に依存し、他のテストで触れられないので
+// 「LOCKEDのまま」を安定して検証できる
+describe("visibleQuests()", () => {
+  it("LOCKEDな任務は含まれない", async () => {
+    const progress = await QuestProgress.user();
+    expect(progress.statuses[606]).toBe(QuestStatus.LOCKED);
+    expect(progress.visibleQuests().some((q) => q.id === 606)).toBe(false);
+  });
+
+  it("未着手→遂行中→達成の順に並ぶ", async () => {
+    const progress = await QuestProgress.user();
+    await progress.start(402);
+    await progress.complete(503);
+    const visible = progress.visibleQuests();
+    const firstOpenIndex = visible.findIndex((q) => q.status === QuestStatus.OPEN);
+    const ongoingIndex = visible.findIndex((q) => q.id === 402);
+    const completedIndex = visible.findIndex((q) => q.id === 503);
+    expect(firstOpenIndex).toBeLessThan(ongoingIndex);
+    expect(ongoingIndex).toBeLessThan(completedIndex);
+  });
+
+  it("カタログのtitle/categoryを持つ", async () => {
+    const progress = await QuestProgress.user();
+    const entry = progress.visibleQuests().find((q) => q.id === 303);
+    expect(entry?.title).toBe(quests["303"].title);
+    expect(entry?.category).toBe("practice");
+  });
+
+  it("日付条件に合わない任務は、前提任務が解放されていても含まれない", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new KCWDate("August 10, 2024 12:00:00")); // 日付下1桁が0 → date28(2,8)対象外
+    const progress = await QuestProgress.user();
+    await progress.complete(201); // 212のLOCKEDを解除する
+    expect(progress.visibleQuests().some((q) => q.id === 212)).toBe(false);
+    vi.useRealTimers();
+  });
+});

--- a/tests/quest-tracker-config.spec.ts
+++ b/tests/quest-tracker-config.spec.ts
@@ -1,0 +1,22 @@
+import { expect, describe, it } from "vitest";
+
+import { QuestTrackerConfig } from "../src/models/configs/QuestTrackerConfig";
+
+// 任務トラッカーは既定で独立タブが導線。ダッシュボードへの表示はオプトイン。
+describe("QuestTrackerConfig.showOnDashboard", () => {
+  it("既定ではfalse（ダッシュボードには表示しない）", async () => {
+    const config = await QuestTrackerConfig.user();
+    expect(config.showOnDashboard).toBe(false);
+  });
+
+  it("static default の showOnDashboard も false", () => {
+    expect(QuestTrackerConfig.default.user.showOnDashboard).toBe(false);
+  });
+
+  it("update で保存した値を読み出せる", async () => {
+    const config = await QuestTrackerConfig.user();
+    await config.update({ showOnDashboard: true });
+    const reloaded = await QuestTrackerConfig.user();
+    expect(reloaded.showOnDashboard).toBe(true);
+  });
+});

--- a/tests/quest-tracker-list.spec.tsx
+++ b/tests/quest-tracker-list.spec.tsx
@@ -1,0 +1,105 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// QuestTrackerList が chrome.storage.onChanged を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    storage: { onChanged: { addListener: vi.fn(), removeListener: vi.fn() } },
+  };
+});
+
+import { QuestTrackerList } from "../src/page/components/quest-tracker/QuestTrackerList";
+import { QuestProgress, QuestStatus } from "../src/models/QuestProgress";
+
+const addListener = chrome.storage.onChanged.addListener as unknown as ReturnType<typeof vi.fn>;
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() はそのオブジェクトへ
+// 書き込む。テスト間の汚染を防ぐため毎回復元する。
+const pristineDefaults = structuredClone(QuestProgress.default);
+beforeEach(() => {
+  QuestProgress.default = structuredClone(pristineDefaults);
+  addListener.mockClear();
+});
+
+describe("QuestTrackerList", () => {
+  it("その日見えている任務を一覧表示する", async () => {
+    const progress = await QuestProgress.user();
+    render(<QuestTrackerList progress={progress} onChanged={() => {}} />);
+    expect(screen.getByText("「演習」で練度向上！")).toBeInTheDocument();
+    expect(screen.getByText("敵艦隊を撃破せよ！")).toBeInTheDocument();
+  });
+
+  it("LOCKEDな任務（前提未達成）は表示されない", async () => {
+    const progress = await QuestProgress.user();
+    render(<QuestTrackerList progress={progress} onChanged={() => {}} />);
+    expect(screen.queryByText("「演習」で他提督を圧倒せよ！")).not.toBeInTheDocument(); // 304はrequires:[303]
+  });
+
+  it("状態ボタンをクリックすると手動変更モーダルが開く", async () => {
+    const user = userEvent.setup();
+    const progress = await QuestProgress.user();
+    render(<QuestTrackerList progress={progress} onChanged={() => {}} />);
+
+    const row = screen.getByText("「演習」で練度向上！").closest("div")!;
+    await user.click(within(row).getByText("未着手"));
+
+    // モーダル内にも同じ任務名が再掲される
+    expect(screen.getAllByText("「演習」で練度向上！").length).toBeGreaterThan(1);
+    expect(screen.getByRole("button", { name: "遂行中" })).toBeInTheDocument();
+  });
+
+  it("モーダルで状態を選ぶと着手状況が更新されonChangedが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const progress = await QuestProgress.user();
+    const onChanged = vi.fn();
+    render(<QuestTrackerList progress={progress} onChanged={onChanged} />);
+
+    const row = screen.getByText("「演習」で練度向上！").closest("div")!;
+    await user.click(within(row).getByText("未着手"));
+    await user.click(screen.getByRole("button", { name: "遂行中" }));
+
+    expect(progress.statuses[303]).toBe(QuestStatus.ONGOING);
+    expect(onChanged).toHaveBeenCalledOnce();
+  });
+
+  it("「閉じる」を押すとモーダルが閉じる", async () => {
+    const user = userEvent.setup();
+    const progress = await QuestProgress.user();
+    render(<QuestTrackerList progress={progress} onChanged={() => {}} />);
+
+    const row = screen.getByText("「演習」で練度向上！").closest("div")!;
+    await user.click(within(row).getByText("未着手"));
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+
+    expect(screen.getAllByText("「演習」で練度向上！")).toHaveLength(1);
+  });
+});
+
+// 他タブ・ダッシュボード・バックグラウンド側での着手/達成を、ポーリングではなく
+// chrome.storage.onChanged で検知して反映する（更新ボタンやインターバルに頼らない）。
+describe("chrome.storage.onChangedによるリアルタイム更新", () => {
+  it("QuestProgressの変更を検知するとonChangedを呼ぶ", async () => {
+    const progress = await QuestProgress.user();
+    const onChanged = vi.fn();
+    render(<QuestTrackerList progress={progress} onChanged={onChanged} />);
+
+    const listener = addListener.mock.calls[0][0];
+    listener({ QuestProgress: { newValue: {} } }, "local");
+
+    expect(onChanged).toHaveBeenCalledOnce();
+  });
+
+  it("QuestProgress以外の変更やlocal以外の領域では反応しない", async () => {
+    const progress = await QuestProgress.user();
+    const onChanged = vi.fn();
+    render(<QuestTrackerList progress={progress} onChanged={onChanged} />);
+
+    const listener = addListener.mock.calls[0][0];
+    listener({ NotificationConfig: { newValue: {} } }, "local");
+    listener({ QuestProgress: { newValue: {} } }, "sync");
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/tests/quest-tracker-page.spec.tsx
+++ b/tests/quest-tracker-page.spec.tsx
@@ -1,0 +1,45 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+
+// QuestTrackerList が chrome.storage.onChanged を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    storage: { onChanged: { addListener: vi.fn(), removeListener: vi.fn() } },
+  };
+});
+
+import { QuestTrackerPage } from "../src/page/quest-tracker/QuestTrackerPage";
+import { QuestProgress } from "../src/models/QuestProgress";
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() はそのオブジェクトへ
+// 書き込む。テスト間の汚染を防ぐため毎回復元する。
+const pristineDefaults = structuredClone(QuestProgress.default);
+beforeEach(() => {
+  QuestProgress.default = structuredClone(pristineDefaults);
+});
+
+// QuestTrackerPage を loader データ付きで単体レンダリングする。
+// loader の非同期初期化を待たずに済むよう、hydrationData で初期データを与える。
+const renderPage = async () => {
+  const progress = await QuestProgress.user();
+  const router = createMemoryRouter(
+    [{ id: "quest-tracker", path: "/", element: <QuestTrackerPage />, loader: () => ({ progress }) }],
+    { hydrationData: { loaderData: { "quest-tracker": { progress } } } },
+  );
+  return render(<RouterProvider router={router} />);
+};
+
+describe("QuestTrackerPage", () => {
+  it("見出しと更新ボタンを表示する", async () => {
+    await renderPage();
+    expect(await screen.findByText("任務トラッカー")).toBeInTheDocument();
+    expect(screen.getByText("更新")).toBeInTheDocument();
+  });
+
+  it("QuestProgressの内容を一覧表示する", async () => {
+    await renderPage();
+    expect(await screen.findByText("「演習」で練度向上！")).toBeInTheDocument();
+  });
+});

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -16,3 +16,36 @@ describe("ETA", () => {
     expect(eta.format("YYYY/mm/dd HH:MM:SS")).toBe("2024/08/25 08:00:00");
   });
 });
+
+// デイリーリセットは朝5時。それより前は前日として扱う
+describe("isSameKCDay", () => {
+  it("同日の朝5時以降は同じ艦これ日", () => {
+    const a = new KCWDate("August 25, 2024 05:00:00").getTime();
+    const b = new KCWDate("August 25, 2024 23:59:59").getTime();
+    expect(KCWDate.isSameKCDay(a, b)).toBe(true);
+  });
+
+  it("日付が変わっても朝5時より前は前日の続き扱い", () => {
+    const beforeReset = new KCWDate("August 26, 2024 04:59:59").getTime();
+    const previousDay = new KCWDate("August 25, 2024 12:00:00").getTime();
+    expect(KCWDate.isSameKCDay(beforeReset, previousDay)).toBe(true);
+  });
+
+  it("朝5時ちょうどを跨ぐと別の艦これ日になる", () => {
+    const beforeReset = new KCWDate("August 26, 2024 04:59:59").getTime();
+    const afterReset = new KCWDate("August 26, 2024 05:00:00").getTime();
+    expect(KCWDate.isSameKCDay(beforeReset, afterReset)).toBe(false);
+  });
+});
+
+describe("dayOfMonth", () => {
+  it("朝5時以降はその日の日付を返す", () => {
+    const epoch = new KCWDate("August 7, 2024 05:00:00").getTime();
+    expect(KCWDate.dayOfMonth(epoch)).toBe(7);
+  });
+
+  it("朝5時より前は前日の日付を返す", () => {
+    const epoch = new KCWDate("August 8, 2024 04:59:59").getTime();
+    expect(KCWDate.dayOfMonth(epoch)).toBe(7);
+  });
+});


### PR DESCRIPTION
## 概要

v3 にあった「演習任務を受けずに演習画面に行くと警告が出る」機能を v4 向けに再設計します。
演習・出撃カテゴリのデイリー任務未着手を検知して通知するとともに、任務の着手状況を一覧・
手動補正できる「任務トラッカー」画面を追加します。

## 変更内容

### 任務の追跡（QuestProgress）
- 出撃・演習・遠征・入渠・開発・建造・解体・改修・廃棄の全カテゴリ（23任務）について、
  前提任務の連鎖解放込みで着手状況を追跡
- 任務の着手・放棄・報酬受領API（`api_req_quest/{start,stop,clearitemget}`）を傍受して反映
- デイリーリセットは朝5時境界で判定（`KCWDate` に追加）

### 未着手通知
- 演習画面・出撃準備画面（`api_get_member/{practice,mapinfo}`）を開いたとき、その日まだ
  着手していない任務があれば通知
- 既存の `NotificationConfig` の仕組みに統合し、アイコン・通知音・消去方式（自動/手動）を
  他の通知と同じ設定画面で変更可能

### 任務トラッカー
- 独立タブ（`/quest-tracker`、ポップアップにショートカット追加）で任務一覧を表示
- カテゴリはゲーム内配色に合わせたバッジ、状態（未着手/遂行中/達成）はクリックで手動補正可能
  （API傍受の取りこぼしや他端末での進行とのズレを補正するため）
- ポーリングではなく `chrome.storage.onChanged` でリアルタイム更新
- 設定でダッシュボードにも同じ一覧を表示可能（既定オフ）

### 設定画面
- 「任務トラッカーの設定」セクションを追加（通知ON/OFF、ダッシュボード表示ON/OFF）

## v3 との意図的な差分

- v3 はダッシュボード常駐表示のみだったが、v4 はログブックと同様に独立タブを既定の導線とし、
  ダッシュボード表示はオプトインにした

## テスト

- typecheck / lint / vitest（35ファイル228テスト）パス
- 実機確認済み: 通知の発火・アイコン/音/消去方式の切替、任務トラッカーの手動補正・
  リアルタイム反映、ダッシュボード表示切替

<img width="1864" height="1456" alt="image" src="https://github.com/user-attachments/assets/66cca678-2ce7-4ae7-9d85-d9e30ac5ee88" />
<img width="1864" height="1456" alt="image" src="https://github.com/user-attachments/assets/8e517721-c220-48d5-9102-56a7b43c5bca" />
<img width="1864" height="1456" alt="image" src="https://github.com/user-attachments/assets/3e095227-50dd-4698-9a05-7bcb3ce15cc0" />
<img width="1864" height="1456" alt="image" src="https://github.com/user-attachments/assets/2f082e41-1fea-4772-b312-12ca62c3ebf6" />
