### PR TITLE
入渠・建造の高速化剤使用時にQueueを削除し重複を防ぐ

### DIFF
--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -69,6 +69,9 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.RECOVERY}:result`, async (req) => {
   const dock = req[EntryType.RECOVERY].dock;
   const [h, m, s] = data.text.split(":").map(Number);
   const r = new Recovery(dock, (h * H + m * M + s * S));
+  // 同じドックの既存Queueを削除してから積み直す（speedchange検知漏れ等で古いQueueが
+  // 残っていても、次に同じドックで修復を始めた時点で重複が解消されるようにする保険）。
+  await Queue.deleteSlot(EntryType.RECOVERY, dock);
   const q = await Queue.create({ type: EntryType.RECOVERY, params: r, scheduled: Date.now() + r.time });
   const e = q.entry();
   NotificationService.new().notify(e, TriggerType.START);
@@ -79,6 +82,7 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.SHIPBUILD}:result`, async (req) => {
   const dock = req[EntryType.SHIPBUILD].dock;
   const [h, m, s] = data.text.split(":").map(Number);
   const sb = new Shipbuild(dock, (h * H + m * M + s * S));
+  await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
   const q = await Queue.create({ type: EntryType.SHIPBUILD, params: sb, scheduled: Date.now() + sb.time });
   const e = q.entry();
   NotificationService.new().notify(e, TriggerType.START);

--- a/src/controllers/WebRequest/datatypes.ts
+++ b/src/controllers/WebRequest/datatypes.ts
@@ -19,6 +19,10 @@ export interface RecoveryStartFormData {
     api_ship_id: string[];
 }
 
+export interface RecoverySpeedchangeFormData {
+    api_ndock_id: string[];
+}
+
 export interface MapStartFormData {
     api_deck_id: string[];
     api_maparea_id: string[];
@@ -41,6 +45,10 @@ export interface CreateShipFormData {
     // api_item5: string[];
     // api_token: string[];
     // api_verno: string[];
+}
+
+export interface ShipbuildSpeedchangeFormData {
+    api_kdock_id: string[];
 }
 
 export interface GetShipFormData {

--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -9,10 +9,12 @@ import {
   onMissionReturnInstruction,
   onMissionResult,
   onRecoveryStart,
+  onRecoveryHighspeed,
   onMapStart,
   onBattleStarted,
   onCombinedBattleStarted,
   onCreateShip,
+  onShipbuildHighspeed,
   onGetShip,
   onBattleResulted,
   onMapNext,
@@ -35,6 +37,7 @@ onBeforeRequest.on(["/kcsapi/api_req_mission/start"], onMissionStart); // 遠征
 onBeforeRequest.on(["/kcsapi/api_req_mission/return_instruction"], onMissionReturnInstruction); // 遠征帰還命令出したとき
 onBeforeRequest.on(["/kcsapi/api_req_mission/result"], onMissionResult); // 遠征結果の回収をしたとき
 onBeforeRequest.on(["/kcsapi/api_req_nyukyo/start"], onRecoveryStart); // 修復用の入渠をしようとしたとき
+onBeforeRequest.on(["/kcsapi/api_req_nyukyo/speedchange"], onRecoveryHighspeed); // 修復中に高速修復剤を使ったとき
 onBeforeRequest.on(["/kcsapi/api_req_map/start"], onMapStart); // 出撃をしようとしたとき
 onBeforeRequest.on(["/kcsapi/api_req_sortie/battle"], onBattleStarted); // 戦闘が開始されたとき
 onBeforeRequest.on(["/kcsapi/api_req_combined_battle/battle"], onCombinedBattleStarted); // 連合艦隊戦が開始されたとき(#1764)
@@ -50,6 +53,7 @@ onBeforeRequest.on([
   '/kcsapi/api_get_member/kdock',
 ], onCreateShip); // 新造艦を作成しようとしたとき
 onBeforeRequest.on(["/kcsapi/api_req_kousyou/getship"], onGetShip); // 建造した艦を受け取ったとき
+onBeforeRequest.on(["/kcsapi/api_req_kousyou/createship_speedchange"], onShipbuildHighspeed); // 建造中に高速建造材を使ったとき
 
 onBeforeRequest.onNotFound(async (details) => {
   requestLogger.debug("-", details);

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -2,7 +2,7 @@ import { Logger } from "../../logger";
 import { missions } from "../../catalog";
 import { sleep, WorkerImage } from "../../utils";
 import Queue from "../../models/Queue";
-import { CreateShipFormData, GetShipFormData, MapStartFormData, MissionResultFormData, MissionStartFormData, RecoveryStartFormData } from "./datatypes";
+import { CreateShipFormData, GetShipFormData, MapStartFormData, MissionResultFormData, MissionStartFormData, RecoveryStartFormData, RecoverySpeedchangeFormData, ShipbuildSpeedchangeFormData } from "./datatypes";
 import { EntryType, Fatigue, Mission } from "../../models/entry";
 import { TriggerType } from "../../models/entry";
 import { TabService } from "../../services/TabService";
@@ -39,6 +39,9 @@ export async function onMissionStart([details]: chrome.webRequest.OnBeforeReques
   // 遠征は残り1分を切ると母港復帰で即完了する仕様のため、通知を一律で1分早める（#1811, Mission.EARLY_RETURN_MARGIN）。
   // 入渠・建造はOCRで実時刻を読むためこの補正は不要。
   const scheduled = Date.now() + Math.max(0, m.time - Mission.EARLY_RETURN_MARGIN);
+  // 同じ艦隊の既存Queueを削除してから積み直す（他端末での帰投操作等、検知できない経路で
+  // 古いQueueが残っていても、同じ艦隊で次の遠征を始めた時点で解消される）。
+  await Queue.deleteSlot(EntryType.MISSION, did);
   const q = await Queue.create({ type: EntryType.MISSION, params: m, scheduled });
   const e = q.entry();
   NotificationService.new().notify(e, TriggerType.START);
@@ -79,6 +82,12 @@ export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeReque
   });
 }
 
+// 修復中に高速修復剤を使って完了させたとき、そのドックの修復Queueを削除する
+export async function onRecoveryHighspeed([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  const { api_ndock_id: [dock] } = details.requestBody?.formData as unknown as RecoverySpeedchangeFormData;
+  await Queue.deleteSlot(EntryType.RECOVERY, dock);
+}
+
 // 出撃開始時
 export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const data = details.requestBody?.formData as unknown as MapStartFormData;
@@ -92,10 +101,7 @@ export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDet
   // 既定では削除せず出撃ごとにタイマーが並ぶ（連続出撃の回数把握に使える）。
   const behavior = await BehaviorConfig.user();
   if (behavior.restackFatigueOnSortie) {
-    const queues = await Queue.list();
-    for (const q of queues) {
-      if (q.type === EntryType.FATIGUE && Number(q.entry<Fatigue>().deck) === fatigue.deck) await q.delete();
-    }
+    await Queue.deleteSlot(EntryType.FATIGUE, fatigue.deck);
   }
   await Queue.create({ type: EntryType.FATIGUE, params: fatigue, scheduled: Date.now() + fatigue.time });
 }
@@ -182,4 +188,10 @@ export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestD
     url, purpose: EntryType.SHIPBUILD,
     [EntryType.SHIPBUILD]: { dock }
   });
+}
+
+// 建造中に高速建造材を使って完了させたとき、そのドックの建造Queueを削除する
+export async function onShipbuildHighspeed([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as ShipbuildSpeedchangeFormData;
+  await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
 }

--- a/src/models/Queue.ts
+++ b/src/models/Queue.ts
@@ -5,7 +5,21 @@ import { Logger } from "../logger";
 import { H, M, S } from "../utils";
 
 export default class Queue extends Model {
-  public static readonly _namespace_ = "Queue";  
+  public static readonly _namespace_ = "Queue";
+
+  // 同じ種別・同じスロット（艦隊/ドック）の既存Queueを削除する。
+  // 艦隊もドックも同時に1件しか進行しないため、スロットは常に排他になる
+  // （遠征なら同じ艦隊、修復・建造なら同じドックで前のQueueが残っていれば
+  // 積み直しの取りこぼしとみなして消す）。
+  public static async deleteSlot(type: EntryType, slot: string | number): Promise<void> {
+    const queues = await this.list();
+    for (const q of queues) {
+      if (q.type !== type) continue;
+      const entry = q.entry<Mission | Recovery | Shipbuild | Fatigue>() as { dock?: string | number, deck?: string | number };
+      if (String(entry.dock ?? entry.deck) === String(slot)) await q.delete();
+    }
+  }
+
   public type: EntryType = EntryType.UNKNOWN;
   public params: Record<string, string | number> = {};
   public scheduled: number = 0; // 予定時刻 (Epoch Time) [ms]

--- a/tests/queue-dedupe-on-ocr-result.spec.ts
+++ b/tests/queue-dedupe-on-ocr-result.spec.ts
@@ -1,0 +1,84 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// Message.ts の import 連鎖が chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+  };
+});
+
+const { deleteSlot, create } = vi.hoisted(() => ({
+  deleteSlot: vi.fn().mockResolvedValue(undefined),
+  create: vi.fn().mockResolvedValue({ entry: () => ({}) }),
+}));
+vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create } }));
+
+const { notify } = vi.hoisted(() => ({ notify: vi.fn().mockResolvedValue("") }));
+vi.mock("../src/services/NotificationService", () => ({
+  NotificationService: { new: () => ({ notify }) },
+}));
+
+// 修復・建造以外のルート（frame/open-or-focus, screenshot 等）が参照する依存はこのテストの
+// 対象外なので、モジュール丸ごと最小スタブに差し替えて import 時の副作用を避ける。
+vi.mock("../src/models/Frame", () => ({ Frame: { find: vi.fn(), memory: vi.fn() } }));
+vi.mock("../src/services/Launcher", () => ({ Launcher: vi.fn() }));
+vi.mock("../src/services/ScreenshotService", () => ({ ScreenshotService: vi.fn() }));
+vi.mock("../src/services/CropService", () => ({ CropService: vi.fn() }));
+vi.mock("../src/models/configs/FileSaveConfig", () => ({ FileSaveConfig: { user: vi.fn() } }));
+vi.mock("../src/models/configs/DashboardConfig", () => ({ DashboardConfig: { user: vi.fn() } }));
+vi.mock("../src/models/configs/DamageSnapshotConfig", () => ({
+  DamageSnapshotConfig: { user: vi.fn() },
+  DamageSnapshotMode: { DISABLED: "disabled", INAPP: "inapp", SEPARATE: "separate" },
+}));
+vi.mock("../src/models/configs/GameWindowConfig", () => ({ GameWindowConfig: { user: vi.fn() } }));
+vi.mock("../src/models/Logbook", () => ({ Logbook: { record: vi.fn(), sortie: {} } }));
+vi.mock("../src/models/sortieLabel", () => ({ formatSortieLabel: vi.fn() }));
+
+import { onMessage } from "../src/controllers/Message";
+import { EntryType } from "../src/models/entry";
+
+// Router 経由でメッセージを1件処理させ、内部ハンドラの完了(sendResponse呼び出し)を待つ
+function dispatch(message: Record<string, unknown>): Promise<unknown> {
+  const listener = onMessage.listener();
+  return new Promise((resolve) => {
+    listener(message, {}, resolve);
+  });
+}
+
+// 入渠・建造のOCR結果受信時、同じドックの既存Queueを削除してから新規作成する保険が
+// 効いていることを検証する（#1826 系のドック重複バグの回帰防止）。
+describe("入渠・建造OCR結果受信時のQueue重複排除(保険)", () => {
+  beforeEach(() => {
+    deleteSlot.mockClear();
+    create.mockClear();
+  });
+
+  it("修復OCR結果: 同じドックの既存Queueを削除してから新規作成する", async () => {
+    await dispatch({
+      __action__: `/injected/dmm/ocr/${EntryType.RECOVERY}:result`,
+      data: { text: "01:23:45" },
+      [EntryType.RECOVERY]: { dock: "2" },
+    });
+
+    expect(deleteSlot).toHaveBeenCalledWith(EntryType.RECOVERY, "2");
+    expect(create).toHaveBeenCalledTimes(1);
+    const deleteOrder = deleteSlot.mock.invocationCallOrder[0];
+    const createOrder = create.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(createOrder);
+  });
+
+  it("建造OCR結果: 同じドックの既存Queueを削除してから新規作成する", async () => {
+    await dispatch({
+      __action__: `/injected/dmm/ocr/${EntryType.SHIPBUILD}:result`,
+      data: { text: "00:30:00" },
+      [EntryType.SHIPBUILD]: { dock: "1" },
+    });
+
+    expect(deleteSlot).toHaveBeenCalledWith(EntryType.SHIPBUILD, "1");
+    expect(create).toHaveBeenCalledTimes(1);
+    const deleteOrder = deleteSlot.mock.invocationCallOrder[0];
+    const createOrder = create.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(createOrder);
+  });
+});

--- a/tests/queue-dedupe-on-speedchange-and-start.spec.ts
+++ b/tests/queue-dedupe-on-speedchange-and-start.spec.ts
@@ -1,0 +1,95 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// kcsapi.ts の import 連鎖が chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+    notifications: { getAll: vi.fn(), clear: vi.fn() },
+  };
+});
+
+const { deleteSlot, create } = vi.hoisted(() => ({
+  deleteSlot: vi.fn().mockResolvedValue(undefined),
+  create: vi.fn().mockResolvedValue({ entry: () => ({}) }),
+}));
+vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create } }));
+
+const { notify, clear } = vi.hoisted(() => ({
+  notify: vi.fn().mockResolvedValue(""),
+  clear: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("../src/services/NotificationService", () => ({
+  NotificationService: { new: () => ({ notify, clear }) },
+}));
+
+vi.mock("../src/models/Logbook", () => ({ Logbook: { sortie: { start: vi.fn() } } }));
+
+const { behaviorUser } = vi.hoisted(() => ({ behaviorUser: vi.fn() }));
+vi.mock("../src/models/configs/BehaviorConfig", () => ({ BehaviorConfig: { user: behaviorUser } }));
+
+vi.mock("../src/catalog", () => ({
+  missions: { "999": { title: "テスト遠征", category: "test", time: 3_600_000 } },
+}));
+
+import { onRecoveryHighspeed, onShipbuildHighspeed, onMissionStart, onMapStart } from "../src/controllers/WebRequest/kcsapi";
+
+// ハンドラに渡す webRequest details の最小構成
+const details = (formData: Record<string, string[]>) =>
+  [{ requestBody: { formData } }] as unknown as chrome.webRequest.OnBeforeRequestDetails[];
+
+describe("修復・建造の高速化剤使用(speedchange)検知", () => {
+  beforeEach(() => {
+    deleteSlot.mockClear();
+  });
+
+  it("onRecoveryHighspeed: 対象ドックの修復Queueを削除する", async () => {
+    await onRecoveryHighspeed(details({ api_ndock_id: ["2"] }));
+    expect(deleteSlot).toHaveBeenCalledWith("recovery", "2");
+    expect(deleteSlot).toHaveBeenCalledTimes(1);
+  });
+
+  it("onShipbuildHighspeed: 対象ドックの建造Queueを削除する", async () => {
+    await onShipbuildHighspeed(details({ api_kdock_id: ["3"] }));
+    expect(deleteSlot).toHaveBeenCalledWith("shipbuild", "3");
+    expect(deleteSlot).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("遠征開始時の重複排除", () => {
+  beforeEach(() => {
+    deleteSlot.mockClear();
+    create.mockClear();
+  });
+
+  it("onMissionStart: 同じ艦隊の既存Queueを削除してから積み直す", async () => {
+    await onMissionStart(details({ api_deck_id: ["4"], api_mission_id: ["999"], api_mission: ["93"] }));
+    expect(deleteSlot).toHaveBeenCalledWith("mission", "4");
+    // 削除は新規作成より前に行う（作成後に削除すると新しいQueueごと消える恐れがあるため）
+    const deleteOrder = deleteSlot.mock.invocationCallOrder[0];
+    const createOrder = create.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(createOrder);
+  });
+});
+
+describe("疲労Queueの積み直し設定(restackFatigueOnSortie)", () => {
+  beforeEach(() => {
+    deleteSlot.mockClear();
+    create.mockClear();
+    behaviorUser.mockReset();
+  });
+
+  const mapStartDetails = () => details({ api_deck_id: ["1"], api_maparea_id: ["1"], api_mapinfo_no: ["1"] });
+
+  it("設定が有効なら同じ艦隊の既存の疲労Queueを削除する", async () => {
+    behaviorUser.mockResolvedValue({ restackFatigueOnSortie: true });
+    await onMapStart(mapStartDetails());
+    expect(deleteSlot).toHaveBeenCalledWith("fatigue", 1);
+  });
+
+  it("設定が無効なら既存の疲労Queueを削除しない（出撃ごとに積み上がる仕様）", async () => {
+    behaviorUser.mockResolvedValue({ restackFatigueOnSortie: false });
+    await onMapStart(mapStartDetails());
+    expect(deleteSlot).not.toHaveBeenCalled();
+  });
+});

--- a/tests/queue-delete-slot.spec.ts
+++ b/tests/queue-delete-slot.spec.ts
@@ -1,0 +1,67 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// jstorm の Model が chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = { runtime: { getURL: (p: string) => p } };
+});
+
+import Queue from "../src/models/Queue";
+import { EntryType } from "../src/models/entry";
+
+// Queue.deleteSlot が読む entry() の戻り値だけを持つ疑似Queue
+const fakeQueue = (type: EntryType, key: "dock" | "deck", slot: string | number) => ({
+  type,
+  entry: () => ({ [key]: slot }),
+  delete: vi.fn().mockResolvedValue(undefined),
+});
+
+// 同じスロット（艦隊/ドック）は同時に1件しか進行しないため、Queue.deleteSlot は
+// 「同じ種別・同じスロット」の既存Queueだけを削除し、他は一切触らない契約であることを検証する。
+describe("Queue.deleteSlot", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("同じ種別・同じドックのQueueだけを削除する", async () => {
+    const target = fakeQueue(EntryType.RECOVERY, "dock", "2");
+    const otherDock = fakeQueue(EntryType.RECOVERY, "dock", "3");
+    const otherType = fakeQueue(EntryType.SHIPBUILD, "dock", "2");
+    vi.spyOn(Queue, "list").mockResolvedValue([target, otherDock, otherType] as unknown as Queue[]);
+
+    await Queue.deleteSlot(EntryType.RECOVERY, "2");
+
+    expect(target.delete).toHaveBeenCalledTimes(1);
+    expect(otherDock.delete).not.toHaveBeenCalled();
+    expect(otherType.delete).not.toHaveBeenCalled();
+  });
+
+  it("deck系（遠征・疲労）のスロットも同様に判定できる", async () => {
+    const target = fakeQueue(EntryType.MISSION, "deck", "4");
+    const other = fakeQueue(EntryType.MISSION, "deck", "1");
+    vi.spyOn(Queue, "list").mockResolvedValue([target, other] as unknown as Queue[]);
+
+    await Queue.deleteSlot(EntryType.MISSION, "4");
+
+    expect(target.delete).toHaveBeenCalledTimes(1);
+    expect(other.delete).not.toHaveBeenCalled();
+  });
+
+  it("保存されている値が数値でも文字列指定と同一スロットとして判定する", async () => {
+    const target = fakeQueue(EntryType.SHIPBUILD, "dock", 2);
+    vi.spyOn(Queue, "list").mockResolvedValue([target] as unknown as Queue[]);
+
+    await Queue.deleteSlot(EntryType.SHIPBUILD, "2");
+
+    expect(target.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("該当するQueueが無ければ何も削除しない", async () => {
+    const other = fakeQueue(EntryType.RECOVERY, "dock", "3");
+    vi.spyOn(Queue, "list").mockResolvedValue([other] as unknown as Queue[]);
+
+    await Queue.deleteSlot(EntryType.RECOVERY, "2");
+
+    expect(other.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 高速修復剤・高速建造材（`api_req_nyukyo/speedchange` / `api_req_kousyou/createship_speedchange`）の使用を検知しておらず、完了済みのQueueが消えずに残ることで、同じドックへの次の入渠・建造時に重複したQueueが生成される不具合を修正
- 上記2つのspeedchangeを検知してQueueを削除するハンドラを新設
- 入渠・建造・遠征それぞれの開始時に、同じスロット（艦隊/ドック）の既存Queueを削除してから積み直す処理を `Queue.deleteSlot` として共通化

## Test plan
- [x] kcw-debugで実機検証: 修復にバケツ使用→Queueが即削除されることを確認
- [x] 同ドックにバケツなしで再度入渠→重複せず1件のみになることを確認
- [x] 建造に高速建造材使用→Queueが即削除されることを確認
- [x] 同ドックに再度建造開始（既存Queueがある状態から）→重複せず1件のみになることを確認
- [x] `pnpm typecheck` / `pnpm lint` 実行済み