### PR TITLE
OCR Workerをページ滞在中使い回してコールドスタートを解消する

### DIFF
--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -1,5 +1,5 @@
-import { createWorker, OEM, type RecognizeResult, type WorkerParams } from 'tesseract.js';
 import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
+import { ocr, warmUpOcrWorker } from './ocrWorker';
 // import { Rectangle, load, crop } from './crop';
 
 (async () => {
@@ -151,17 +151,6 @@ import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
     });
   }
 
-  async function ocr(url: string, params: Partial<WorkerParams> = { tessedit_char_whitelist: "0123456789:" }): Promise<RecognizeResult> {
-    const worker = await createWorker('eng', OEM.LSTM_ONLY, {
-      workerPath: chrome.runtime.getURL('tessworker.min.js'),
-      langPath: chrome.runtime.getURL('tessdata-4.0.0_best_int'),
-    });
-    worker.setParameters(params);
-    const ret = await worker.recognize(url);
-    worker.terminate();
-    return ret;
-  }
-
   /**
    * ウィンドウを閉じようとしたときに確認ダイアログを表示
    */
@@ -177,6 +166,7 @@ import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
   (async function __main__() {
     resize();
     setInterval(track, 10 * 1000);
+    warmUpOcrWorker();
     const configs = await fetchNecessaryConfig();
     startListeningMessage();
     InAppActionButtons.create(configs.game);

--- a/src/injection/ocrWorker.ts
+++ b/src/injection/ocrWorker.ts
@@ -11,11 +11,18 @@ function createOcrWorker(): ReturnType<typeof createWorker> {
   });
 }
 
+function resetWorker(): void {
+  const p = workerPromise;
+  workerPromise = null;
+  // 実体があれば解放する。生成失敗(rejected)やterminate失敗は握りつぶす。
+  p?.then((w) => w.terminate()).catch(() => {});
+}
+
 export function getWorker(): ReturnType<typeof createWorker> {
   if (!workerPromise) {
     workerPromise = createOcrWorker();
     // 生成に失敗したWorkerを使い回さないよう、次回呼び出しで作り直せるようにする。
-    workerPromise.catch(() => { workerPromise = null; });
+    workerPromise.catch(() => resetWorker());
   }
   return workerPromise;
 }
@@ -32,7 +39,7 @@ export async function ocr(url: string, params: Partial<WorkerParams> = { tessedi
     return await worker.recognize(url);
   } catch (e) {
     // 認識自体が失敗したWorkerも壊れている可能性があるため作り直す。
-    workerPromise = null;
+    resetWorker();
     throw e;
   }
 }

--- a/src/injection/ocrWorker.ts
+++ b/src/injection/ocrWorker.ts
@@ -1,0 +1,38 @@
+import { createWorker, OEM, type RecognizeResult, type WorkerParams } from 'tesseract.js';
+
+// Tesseract.jsのWorkerはWASMエンジンと言語データの読み込みに数秒かかるため、
+// OCRの都度作り直さずページ滞在中は使い回す。
+let workerPromise: ReturnType<typeof createWorker> | null = null;
+
+function createOcrWorker(): ReturnType<typeof createWorker> {
+  return createWorker('eng', OEM.LSTM_ONLY, {
+    workerPath: chrome.runtime.getURL('tessworker.min.js'),
+    langPath: chrome.runtime.getURL('tessdata-4.0.0_best_int'),
+  });
+}
+
+export function getWorker(): ReturnType<typeof createWorker> {
+  if (!workerPromise) {
+    workerPromise = createOcrWorker();
+    // 生成に失敗したWorkerを使い回さないよう、次回呼び出しで作り直せるようにする。
+    workerPromise.catch(() => { workerPromise = null; });
+  }
+  return workerPromise;
+}
+
+// 入渠・建造検知に備えてOCR Workerを先読みしておく（結果は待たない）
+export function warmUpOcrWorker(): void {
+  getWorker();
+}
+
+export async function ocr(url: string, params: Partial<WorkerParams> = { tessedit_char_whitelist: "0123456789:" }): Promise<RecognizeResult> {
+  const worker = await getWorker();
+  await worker.setParameters(params);
+  try {
+    return await worker.recognize(url);
+  } catch (e) {
+    // 認識自体が失敗したWorkerも壊れている可能性があるため作り直す。
+    workerPromise = null;
+    throw e;
+  }
+}

--- a/tests/ocr-worker-reuse.spec.ts
+++ b/tests/ocr-worker-reuse.spec.ts
@@ -1,0 +1,75 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = { runtime: { getURL: (p: string) => p } };
+});
+
+const { createWorker } = vi.hoisted(() => ({ createWorker: vi.fn() }));
+vi.mock("tesseract.js", () => ({
+  createWorker,
+  OEM: { LSTM_ONLY: "lstm_only" },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fakeWorker(overrides: Record<string, any> = {}) {
+  return {
+    setParameters: vi.fn().mockResolvedValue(undefined),
+    recognize: vi.fn().mockResolvedValue({ data: { text: "00:00:00" } }),
+    ...overrides,
+  };
+}
+
+// OCR用Workerの生成コストが高い(WASM初期化+言語データ読み込み)ため使い回す実装の契約を検証する。
+// モジュール内の singleton 状態をテスト間で共有しないよう、各テストで resetModules して読み直す。
+describe("ocrWorker", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    createWorker.mockReset();
+  });
+
+  it("getWorkerを複数回呼んでも、Workerの生成は1回だけ行われる", async () => {
+    const worker = fakeWorker();
+    createWorker.mockResolvedValue(worker);
+    const { getWorker } = await import("../src/injection/ocrWorker");
+
+    const [w1, w2] = await Promise.all([getWorker(), getWorker()]);
+
+    expect(createWorker).toHaveBeenCalledTimes(1);
+    expect(w1).toBe(worker);
+    expect(w2).toBe(worker);
+  });
+
+  it("Workerの生成に失敗したら、次回呼び出しで作り直す", async () => {
+    createWorker.mockRejectedValueOnce(new Error("boom"));
+    const worker = fakeWorker();
+    createWorker.mockResolvedValueOnce(worker);
+    const { getWorker } = await import("../src/injection/ocrWorker");
+
+    await expect(getWorker()).rejects.toThrow("boom");
+    await expect(getWorker()).resolves.toBe(worker);
+    expect(createWorker).toHaveBeenCalledTimes(2);
+  });
+
+  it("ocr()の認識(recognize)が失敗しても、次回呼び出しではWorkerを作り直して成功する", async () => {
+    const brokenWorker = fakeWorker({ recognize: vi.fn().mockRejectedValue(new Error("recognize failed")) });
+    const freshWorker = fakeWorker();
+    createWorker.mockResolvedValueOnce(brokenWorker).mockResolvedValueOnce(freshWorker);
+    const { ocr } = await import("../src/injection/ocrWorker");
+
+    await expect(ocr("data:image/png;base64,xxx")).rejects.toThrow("recognize failed");
+    await expect(ocr("data:image/png;base64,xxx")).resolves.toEqual({ data: { text: "00:00:00" } });
+    expect(createWorker).toHaveBeenCalledTimes(2);
+  });
+
+  it("warmUpOcrWorkerは呼び出し直後にWorker生成を開始する（完了を待たない）", async () => {
+    let resolveWorker!: (w: unknown) => void;
+    createWorker.mockReturnValue(new Promise((resolve) => { resolveWorker = resolve; }));
+    const { warmUpOcrWorker } = await import("../src/injection/ocrWorker");
+
+    warmUpOcrWorker();
+
+    expect(createWorker).toHaveBeenCalledTimes(1);
+    resolveWorker(fakeWorker());
+  });
+});

--- a/tests/ocr-worker-reuse.spec.ts
+++ b/tests/ocr-worker-reuse.spec.ts
@@ -16,6 +16,7 @@ function fakeWorker(overrides: Record<string, any> = {}) {
   return {
     setParameters: vi.fn().mockResolvedValue(undefined),
     recognize: vi.fn().mockResolvedValue({ data: { text: "00:00:00" } }),
+    terminate: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -60,6 +61,19 @@ describe("ocrWorker", () => {
     await expect(ocr("data:image/png;base64,xxx")).rejects.toThrow("recognize failed");
     await expect(ocr("data:image/png;base64,xxx")).resolves.toEqual({ data: { text: "00:00:00" } });
     expect(createWorker).toHaveBeenCalledTimes(2);
+  });
+
+  it("認識に失敗して作り直すとき、壊れたWorkerはterminateで解放される", async () => {
+    const brokenWorker = fakeWorker({ recognize: vi.fn().mockRejectedValue(new Error("recognize failed")) });
+    const freshWorker = fakeWorker();
+    createWorker.mockResolvedValueOnce(brokenWorker).mockResolvedValueOnce(freshWorker);
+    const { ocr } = await import("../src/injection/ocrWorker");
+
+    await expect(ocr("data:image/png;base64,xxx")).rejects.toThrow("recognize failed");
+    await expect(ocr("data:image/png;base64,xxx")).resolves.toEqual({ data: { text: "00:00:00" } });
+
+    expect(brokenWorker.terminate).toHaveBeenCalledTimes(1);
+    expect(freshWorker.terminate).not.toHaveBeenCalled();
   });
 
   it("warmUpOcrWorkerは呼び出し直後にWorker生成を開始する（完了を待たない）", async () => {


### PR DESCRIPTION
## Summary
- 入渠・建造のOCRを都度Worker生成・破棄していたため、WASMエンジンと言語データの読み込みが毎回発生し数秒の遅延になっていた
- Worker管理を `ocrWorker.ts` に切り出してページ滞在中は使い回すようにし、ページロード時に先読みしておくことで入渠・建造検知時には温まった状態にする
- 生成・認識に失敗した場合は次回呼び出しでWorkerを作り直す

## Test plan
- [x] kcw-debugで実機検証: 入渠検知からQueue作成まで約90msで完了することを確認（リファクタ前後で同等）
- [x] `ocrWorker.spec.ts` でWorker使い回し・生成失敗時の作り直し・認識失敗時の作り直し・先読みの非同期性をユニットテスト
- [x] `pnpm typecheck` / `pnpm lint` 実行済み