### PR TITLE
ダッシュボードの錨アイコンからゲーム窓を起動できるようにする

### DIFF
--- a/src/page/Dashboard.tsx
+++ b/src/page/Dashboard.tsx
@@ -6,7 +6,7 @@ import type Queue from "../models/Queue";
 import { useEffect } from "react";
 
 export function DashboardPage() {
-  const { window, queues, time } = useLoaderData() as { window: chrome.windows.Window, queues: Queue[], time: Date };
+  const { window, queues, time, frameId } = useLoaderData() as { window: chrome.windows.Window, queues: Queue[], time: Date, frameId: string };
   const revalidater = useRevalidator();
 
   // 1秒ごとにデータを再検証
@@ -46,7 +46,7 @@ export function DashboardPage() {
     <div className="p-4">
       <div className="flex space-x-4">
         <ClockView time={time} />
-        <ActionsView tab={window?.tabs?.[0]} />
+        <ActionsView tab={window?.tabs?.[0]} frameId={frameId} />
       </div>
       <QueuesView queues={queues} />
     </div>

--- a/src/page/components/dashboard/ActionsView.tsx
+++ b/src/page/components/dashboard/ActionsView.tsx
@@ -29,21 +29,34 @@ function CaptureControlButton({ tab, launcher }: { tab?: chrome.tabs.Tab, launch
   )
 }
 
-function LaunchControlButton() {
+function LaunchControlButton({ frameId }: { frameId: string }) {
+  const onClick = async () => {
+    try {
+      await chrome.runtime.sendMessage<
+        { action: string; frame_id?: string },
+        { opened: boolean; frame_id: string | null }
+      >(chrome.runtime.id, {
+        action: "/frame/open-or-focus",
+        frame_id: frameId,
+      });
+    } catch (error) {
+      console.error("/frame/open-or-focus の送信に失敗しました", error);
+    }
+  };
   return (
-    <div>
-      <img src="/anchor.svg" alt="anchor" className="w-12 h-12" />
+    <div onClick={onClick} className="cursor-pointer" title="抜錨！">
+      <img src="/anchor.svg" alt="抜錨！" className="w-12 h-12" />
     </div>
   )
 }
 
-export function ActionsView({tab}: { tab?: chrome.tabs.Tab }) {
+export function ActionsView({tab, frameId}: { tab?: chrome.tabs.Tab, frameId: string }) {
   const launcher = useMemo(() => new Launcher(), []);
   const revalidater = useRevalidator();
   const refresh = () => revalidater.revalidate();
   return (
     <div className="flex-1 flex items-center justify-end space-x-4">
-      <LaunchControlButton />
+      <LaunchControlButton frameId={frameId} />
       <CaptureControlButton tab={tab} launcher={launcher} />
       <MuteControlButton tab={tab} launcher={launcher} refresh={refresh} />
     </div>

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -86,10 +86,12 @@ export async function popup() {
 
 export async function dashboard() {
   const win = await (new Launcher()).find();
+  const game = await GameWindowConfig.user();
   return {
     queues: await Queue.list(),
     window: win,
     time: new Date(),
+    frameId: game.lastSelectedFrameId,
   }
 }
 

--- a/tests/dashboard-launch-anchor.spec.tsx
+++ b/tests/dashboard-launch-anchor.spec.tsx
@@ -1,0 +1,49 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+// ActionsView は Launcher 経由で chrome.tabs / chrome.windows を参照しうるため、
+// import より前にグローバル chrome をスタブする。
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: {
+      id: "test",
+      sendMessage: vi.fn().mockResolvedValue({ opened: true, frame_id: null }),
+      onMessage: { addListener: () => {} },
+    },
+  };
+});
+
+import { ActionsView } from "../src/page/components/dashboard/ActionsView";
+
+function renderView(frameId: string, tab?: chrome.tabs.Tab) {
+  const router = createMemoryRouter([
+    { path: "/", element: <ActionsView tab={tab} frameId={frameId} /> },
+  ]);
+  return render(<RouterProvider router={router} />);
+}
+
+describe("ActionsView の錨アイコン", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ゲーム窓が無くても表示される", () => {
+    renderView("__memory__");
+    expect(screen.getByAltText("抜錨！")).toBeInTheDocument();
+  });
+
+  it("クリックすると /frame/open-or-focus を frameId 付きで送信する", async () => {
+    renderView("__classic__");
+
+    await userEvent.click(screen.getByAltText("抜錨！"));
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(1);
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith("test", {
+      action: "/frame/open-or-focus",
+      frame_id: "__classic__",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ダッシュボードの錨アイコン（LaunchControlButton）に onClick が付いておらず、クリックしても何も起きなかった問題を修正
- ポップアップ画面と同じ `/frame/open-or-focus` メッセージを送るようにし、`GameWindowConfig.lastSelectedFrameId`（前回選択した Frame）を使って起動対象を決定
- 既存のゲーム窓があれば focus/retouch、無ければ新規作成される（Launcher.launch の既存挙動のまま）

## Test plan
- [x] `tsc --noEmit` / `eslint` 通過
- [x] `tests/dashboard-launch-anchor.spec.tsx` を追加（クリックで frame_id 付きメッセージが送られることを検証）
- [x] 実機でダッシュボードの錨アイコンをクリックし、ゲーム窓が起動/フォーカスされることを確認