### PR TITLE
feat: similarity-tsによるコード重複検知をCIに導入しPRコメントで通知する

### DIFF
--- a/.github/workflows/javascript-ci.yaml
+++ b/.github/workflows/javascript-ci.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   js-ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         node-version: [22.x]
@@ -26,6 +29,24 @@ jobs:
         version: 10
     - run: pnpm install
     - run: pnpm lint
+    - name: Detect code similarity (similarity-ts)
+      if: github.event_name == 'pull_request'
+      env:
+        SIMILARITY_TS_VERSION: v0.5.0
+      run: |
+        curl -sL -o similarity-ts.tar.gz "https://github.com/mizchi/similarity/releases/download/${SIMILARITY_TS_VERSION}/similarity-${SIMILARITY_TS_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+        tar xzf similarity-ts.tar.gz
+        "./similarity-${SIMILARITY_TS_VERSION}-x86_64-unknown-linux-gnu/similarity-ts" src > similarity-raw.txt 2>&1 || true
+        pnpm exec tsx scripts/format-similarity-comment.ts similarity-raw.txt > similarity-comment.md
+    - name: Post similarity report to PR
+      if: github.event_name == 'pull_request'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        gh pr comment "$PR_NUMBER" \
+          --edit-last --create-if-none \
+          --body-file similarity-comment.md
     - run: pnpm build
     - run: pnpm exec vitest run --coverage
     - name: Upload coverage to Codecov

--- a/scripts/format-similarity-comment.ts
+++ b/scripts/format-similarity-comment.ts
@@ -1,0 +1,46 @@
+/**
+ * similarity-ts の生出力を PR コメント用の Markdown に整形する
+ */
+
+import { readFileSync } from "node:fs";
+
+const main = () => {
+  const [, , inputPath] = process.argv;
+  if (!inputPath) {
+    console.error("使い方: tsx format-similarity-comment.ts <similarity-tsの生出力ファイル>");
+    process.exit(1);
+  }
+
+  const raw = readFileSync(inputPath, "utf-8");
+
+  const functionMatch = raw.match(/Found (\d+) duplicate pairs/);
+  const functionCount = functionMatch ? Number(functionMatch[1]) : 0;
+
+  const typeMatch = raw.match(/Total similar type pairs found: (\d+)/);
+  const typeCount = typeMatch ? Number(typeMatch[1]) : 0;
+
+  const header = "## 🔍 similarity-ts: コード類似度チェック";
+
+  if (functionCount === 0 && typeCount === 0) {
+    console.log(`${header}\n\n✅ 重複コードは検出されませんでした。`);
+    return;
+  }
+
+  console.log(
+    [
+      header,
+      "",
+      `関数の重複: **${functionCount}** 件 / 型の類似: **${typeCount}** 件`,
+      "",
+      "<details><summary>詳細を表示</summary>",
+      "",
+      "```",
+      raw.trim(),
+      "```",
+      "",
+      "</details>",
+    ].join("\n"),
+  );
+};
+
+main();


### PR DESCRIPTION
Closes #1833

## 背景

コードの構造的な重複・類似度を検知する仕組みが CI/lint に存在しなかった。ESLint は構文・型の
チェックのみで、関数の意味的な重複（変数名は違うがロジックが同じ、等）は検出できない。
実際に [similarity-ts](https://github.com/mizchi/similarity) をこのリポジトリの `src/` に対して
実行したところ、デフォルト閾値では表面化しない "隠れた" 重複（`useFleetCapture` /
`useScreenshotEditor` の 77.60% 一致など）が見つかった。今後どちらか一方だけを修正して
他方の追従を忘れる、というバグ混入経路になり得る。

## 目的

今後 PR を出す・レビューする開発者が、CI ログを開かなくても PR 画面上で重複に気づけるように
する。これにより車輪の再発明や片手落ちの修正を防ぐ。

## 方針

- similarity-ts は npm には無く、Rust 製 CLI として GitHub Releases の prebuilt バイナリで
  配布されている。CI 毎回 `cargo install` でビルドせず、`ubuntu-latest` 向けの
  prebuilt バイナリ（linux-gnu）を curl で取得する
- CI をブロックするゲートにはしない（`--fail-on-duplicates` を付けない）。重複はあくまで
  レビュー参考情報として PR コメントに載せ、マージ判断はレビュアーに委ねる
- push のたびにコメントを積み増さない sticky comment 方式（`gh pr comment --edit-last
  --create-if-none`）を採用。追加の Marketplace Action を増やさず、既存の `tweet-new-pr.yaml`
  と同じ「独自スクリプトで API を直接叩く」流儀に揃えた

<details><summary>Issue #1833 の意思決定テーブル（仮採用・設計判断の経緯）</summary>

| # | 対象 | 問い | 採用案 | 代替案 | 根拠・優先価値 | 確定方法 |
|---|---|---|---|---|---|---|
| 1 | 修正提案 | similarity-ts のバイナリバージョンを固定するか、`latest` を動的取得するか | `v0.5.0` にピン留め | `latest` を動的取得 | ツール側の破壊的変更や配布障害で CI が不意に壊れるのを防ぐ | 仮採用 |
| 2 | 修正提案 | 重複 0 件になった場合、sticky comment をどう扱うか | 常に最新 diff の結果で全文置換 | 追記型で過去の指摘を蓄積 | 「push のたびに積み増さない」という要件と整合 | 仮採用 |
| 3 | 修正提案 | PR の変更ファイルに関わらず `src` 全体を毎回スキャンするか、diff に絞るか | 常に `src` 全体をスキャン | 変更ファイルのみに絞る | 構造比較ツールのため一部だけ見ると重複相手を見落とす | 仮採用 |
| 4 | 修正提案 + AC-1 | `--classes`/`--types` を含めるか | 含めない（デフォルトオプションのみ） | 含める | zero-configuration の思想に従い最小スコープ | 仮採用 |

</details>

## 設計

| 変更 | 内容 | AC |
|---|---|---|
| `.github/workflows/javascript-ci.yaml` | `pnpm lint` の後段に、PR イベント時のみ `similarity-ts`（v0.5.0 ピン留め）を実行するstepと、結果を `gh pr comment --edit-last --create-if-none` で投稿するstepを追加。job に `permissions.pull-requests: write` を追加 | AC-1, AC-2, AC-3 |
| `scripts/format-similarity-comment.ts`（新規） | similarity-ts の生出力を、件数サマリ + 折りたたみ詳細の Markdown に整形するスクリプト。重複 0 件なら「✅ 重複コードは検出されませんでした」の一行のみ出力 | AC-1, AC-4 |

## 受入条件

- [x] [BUILD] `.github/workflows/javascript-ci.yaml` に `similarity-ts`（`v0.5.0` ピン留め）
  実行 + PR コメント投稿 step が追加され、`pnpm lint` / `pnpm build` と同様に CI ジョブ全体が
  正常完走する（重複があっても CI は失敗しないこと）
  → 本 PR 自身の CI 実行（[JavaScript CI #28800100253](https://github.com/KanCraft/kanColleWidget/actions/runs/28800100253)）で確認済み
- [x] [UI] 対象 PR を開き、`similarity-ts` の結果コメントが投稿されていることを確認する
  → [投稿されたコメント](https://github.com/KanCraft/kanColleWidget/pull/1835#issuecomment-4894112692)で確認済み（重複0件のため「✅ 重複コードは検出されませんでした」を表示）
- [x] [UI] 同じ PR に追加 push をしても新規コメントが積み増されず、既存の 1 コメントが
  更新されること（sticky comment の動作確認）
  → 動作確認用の空コミットを push → 2 回目の CI 実行後もコメント数は 1 件のまま、
  `updated_at` が `created_at` より後の時刻に更新されていることを GitHub API で確認済み
- [x] [MANUAL] コメントの表示（サマリ + 折りたたみ詳細）が PR レビュー時に読みやすい
  分量・形式であること
  → 実際の PR 画面で目視確認済み（本 PR 上のコメント自体がその実例）

## 評価観点

- Issue の意思決定 4 件はすべて `/grill` の自律モードによる **仮採用**（人の明示合意なし）。
  特に「バージョンピン留め（意思決定テーブル 1 行目）」と
  「diff 絞り込みなしで毎回 `src` 全体スキャン（同 3 行目）」は
  運用してみないと最適解か判断しづらい設計判断のため、レビュー時に妥当性を見てほしい
- `similarity-ts` のバイナリ配布元は `mizchi/similarity`（個人メンテナのリポジトリ）。
  サプライチェーン上の信頼性（GitHub Releases からの直接ダウンロード、checksum 検証はまだ
  入れていない）は許容範囲か判断してほしい
- 本 PR 自体の CI で実際にコメントが投稿されるかどうかが、[UI] 系の受入条件の一次証跡になる

## 発見

なし
