### PR TITLE
chore(release): betaリリースをpush毎回発火から日次cronトリガーに変更

### DIFF
--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -3,9 +3,12 @@ name: Release BETA
 # ベータ版の自動公開。
 #
 # モデル: 「main は常にベータ版として生きている」
-#   - main への push のたびに、package.json の version が直近タグより先行していれば
+#   - 毎朝 06:30 JST に定期実行し、直近24時間に main へ commit（ドキュメント等を除く）が
+#     あり、かつ package.json の version が直近タグより先行していれば
 #     （= まだ本番公開していない未リリース版があれば）ベータ版を BETA リスティングへ公開する。
-#   - version が直近タグと同じ（= 未公開の変更が無い）場合は何もしない。
+#   - 直近24時間に対象 commit が無い、または version が直近タグと同じ（= 未公開の変更が無い）
+#     場合は何もしない。
+#   - 緊急で今すぐベータ公開したい場合は workflow_dispatch で手動実行できる。
 #
 # Chrome Webstore は同一リスティングへ同じ version を再アップロードできないため、
 # manifest.version は「<base>.<直近タグからの commit 数>」で単調増加させる（例 4.9.0.5）。
@@ -14,12 +17,9 @@ name: Release BETA
 # 本番公開は GitHub Release の作成（release-prod.yaml）で行う。
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "design/**"
+  schedule:
+    - cron: "30 21 * * *" # 21:30 UTC = 06:30 JST（毎朝）
+  workflow_dispatch: {}
 
 concurrency:
   group: release-beta
@@ -51,9 +51,17 @@ jobs:
           version: 10
       - run: pnpm install
 
-      - name: ベータ版バージョンを算出（未公開の版が無ければスキップ）
+      - name: ベータ版バージョンを算出（直近24時間に変更が無い／未公開の版が無ければスキップ）
         id: ver
         run: |
+          RECENT=$(git log --since="24 hours ago" --oneline \
+            -- . ':(exclude,glob)**/*.md' ':(exclude)docs' ':(exclude)design' | wc -l | tr -d ' ')
+          if [ "${RECENT}" = "0" ]; then
+            echo "[INFO] 直近24時間に対象パスへの commit が無いため、ベータ公開をスキップします。"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           BASE=$(jq -r .version package.json)
           LASTTAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           LASTVER=${LASTTAG#v}
@@ -74,11 +82,11 @@ jobs:
           echo "version_name=${BASE}-beta.${N}" >> "$GITHUB_OUTPUT"
           echo "base_version=v${BASE}" >> "$GITHUB_OUTPUT"
           echo "[INFO] BETA version=${BASE}.${N} (version_name=${BASE}-beta.${N})"
-          # サイクル開始（=版上げコミット vX.Y.Z の push）の時だけ beta 告知を出す（β1）
-          HEAD_MSG=$(git log -1 --pretty=%s)
-          if echo "${HEAD_MSG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # サイクル開始（=版上げコミット vX.Y.Z が直近24時間以内にある）の時だけ beta 告知を出す（β1）
+          CYCLE_COMMIT=$(git log --since="24 hours ago" --pretty=%s | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "${CYCLE_COMMIT}" ]; then
             echo "cycle_start=true" >> "$GITHUB_OUTPUT"
-            echo "[INFO] 版上げコミットのため、新バージョンのベータ配信開始を告知します"
+            echo "[INFO] 版上げコミットが直近24時間以内にあるため、新バージョンのベータ配信開始を告知します"
           else
             echo "cycle_start=false" >> "$GITHUB_OUTPUT"
           fi
@@ -98,8 +106,8 @@ jobs:
         if: steps.ver.outputs.skip == 'false'
         run: npx -y tsx scripts/webstore-publish.ts ./release/艦これウィジェット.zip
 
-  # 新バージョンが beta 入りした時（版上げコミットの push）だけ1回告知する（β1）。
-  # 毎 push の beta build では告知しない（ノイズ・コスト抑制）。
+  # 新バージョンが beta 入りした時（版上げコミットが直近24時間以内にあった日次実行）だけ
+  # 1回告知する（β1）。変更の無い日次実行では告知しない（ノイズ・コスト抑制）。
   announce_beta_tweet:
     needs: release_beta
     if: needs.release_beta.outputs.cycle_start == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ pnpm typecheck        # 型チェックのみ（ビルドなし）
 # package.json の version がバージョンの単一の真実源。manifest.json はビルド時に生成される。
 make version v=4.9.0
 
-# → commit & push to main すると BETA が自動公開される（release-beta.yaml）
+# → main に push すると、毎朝 06:30 JST の定期実行で BETA が自動公開される（release-beta.yaml）
+# → 緊急時は release-beta.yaml を workflow_dispatch で手動実行も可能
 # → 本番公開は GitHub Release を作成する（release-prod.yaml が発火）
 gh release create v4.9.0 --generate-notes
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ docker run --rm -it \
 **バージョンの位置** で配信先が決まる、という1つのルールに集約されています。
 
 - **ベータ版** … `main` の `package.json` の version が **直近のタグより先行している間**、
-  `main` への push のたびに自動で BETA リスティングへ公開される（「main は常にベータ版として生きている」）。
+  毎朝 06:30 JST の定期実行で、直近24時間に main へ commit があれば自動で BETA リスティングへ
+  公開される（「main は常にベータ版として生きている」）。緊急時は `workflow_dispatch` で
+  手動公開もできる。
 - **プロダクション版** … **GitHub Release を作成（= タグを打つ）** と、その版が PROD リスティングへ公開される。
 
 バージョンの単一の真実源は **`package.json` の `version`** だけです。
@@ -94,18 +96,21 @@ make version v=4.9.0
 # 生成された release-note.json の message を書く
 vim src/release-note.json
 
-# main に push すると、ベータ版が自動公開される
+# main に push する（毎朝 06:30 JST の定期実行で自動的にベータ公開される）
 git add package.json src/release-note.json
 git commit -m "v4.9.0"
 git push origin main
 ```
 
-- push のたびに `manifest.version = 4.9.0.<直近タグからのcommit数>`（例 `4.9.0.5`）で
-  ベータ版が更新される。表示名は `version_name = 4.9.0-beta.5`。
+- 毎朝 06:30 JST に、直近24時間で main に commit（`**/*.md` / `docs/**` / `design/**` を除く）
+  があれば `manifest.version = 4.9.0.<直近タグからのcommit数>`（例 `4.9.0.5`）でベータ版が
+  更新される。表示名は `version_name = 4.9.0-beta.5`。
 - Chrome Webstore は同じ version を再アップロードできないため、commit 数を第4成分にして
-  単調増加させている（だから push ごとに必ず version が上がる）。
-- `package.json` の version が直近タグと **同じ** 間は、ベータ公開はスキップされる
-  （= 未公開の変更が無い状態）。
+  単調増加させている。
+- `package.json` の version が直近タグと **同じ** 間、または直近24時間に対象 commit が無い間は、
+  ベータ公開はスキップされる。
+- 今すぐベータ公開したい場合は、GitHub Actions の `Release BETA` ワークフローを
+  `workflow_dispatch` で手動実行する。
 
 > BETA リスティング（Chrome拡張ID: `egkgleinehaapbpijnlpbllfeejjpceb`）で動作確認する。
 
@@ -133,7 +138,7 @@ main 1本で開発（develop は廃止）
     │      ↓
     │   commit & push to main
     │      ↓
-    │   🚀 BETA 自動公開（version 4.9.0.N）   ← push のたびに繰り返す
+    │   🚀 BETA 自動公開（version 4.9.0.N）   ← 毎朝06:30 JST、直近24hにcommitがあれば繰り返す
     │      ↓
     │   ベータ版で動作確認
     │


### PR DESCRIPTION
Closes #1834

## 背景

`release-beta.yaml` は現状 `push: branches: [main]` トリガーで、main への push のたびに Chrome Webstore の BETA リスティングへ公開している。ベータサイクル中に同日に小さい commit を複数回 push すると、その回数分だけ Webstore への公開申請が走り、manifest version が `4.9.0.1`, `4.9.0.2` ... と細かく積み上がってしまう（メンテナの手間、ベータテスターへの過剰な更新通知）。

## 目的

ベータ公開の頻度を「push のたびに毎回」から「毎朝1回」に落とし、Webstore への提出回数と、ベータテスターが受け取る更新の頻度を、意味のある単位に集約する。緊急時は手動でも公開できるようにする。

## 方針

「前回ベータ公開時点からの差分」を厳密に記憶する仕組みは持たず、24時間サイクルの運用に合わせて「直近24時間の commit 有無」で近似する（Issue で確定した簡略化をそのまま採用）。既存の「`package.json` version が直近タグと同じなら skip」というゲートは、cadence とは独立した「そもそも未公開の変更があるか」の判定なので変更しない。

トリガーを `push` から `schedule`（cron）に変えたことで、既存の `cycle_start`（ベータ開始告知ツイート）判定が「厳密に HEAD commit のメッセージだけを見る」実装だったため、日次バッチ化すると壊れる懸念があった。版上げ commit の後に同日中の別 commit が push されると、次回の定期実行時点の HEAD はもう版上げ commit ではなく、告知が永久に飛ばなくなる。これは「直近24時間の commit 群」から探す方式に変えることで予防した。

また `schedule` トリガーには `push` の `paths-ignore` に相当する機能が無いため、「直近24時間 commit 有無」の判定自体に同じパス除外（`**/*.md` / `docs/**` / `design/**`）を組み込み、ドキュメントのみの日に無意味な再公開が起きないようにした。

<details>
<summary>実装中に気づいた注意点（shell の挙動）</summary>

GitHub Actions のデフォルト shell（`bash -eo pipefail`）下では、`grep` がマッチ無しで終了コード 1 を返すと、後段に `head -1` を挟んでいてもパイプライン全体が失敗としてステップごと落ちることをローカルで確認した（`CYCLE_COMMIT=$(... | grep ... | head -1)` は「マッチが無い」＝日常的なケースで毎回ステップが失敗する）。既存コードが `LASTTAG=$(git describe ... || echo "")` で同じ問題を回避していたのと同じパターンで `|| true` を付けて対処した。

</details>

## 設計

| 変更 | 内容 | AC |
|---|---|---|
| `.github/workflows/release-beta.yaml` トリガー | `push` を削除し、`schedule`（`cron: "30 21 * * *"` = 06:30 JST 毎朝）+ `workflow_dispatch: {}` に変更 | AC-2 |
| `.github/workflows/release-beta.yaml` `ver` ステップ | 先頭に「直近24時間・対象パス限定の commit 有無」ゲートを追加（無ければ `skip=true` で即終了） | AC-3, AC-4 |
| `.github/workflows/release-beta.yaml` `ver` ステップ | `cycle_start` 判定を「HEAD commit のみ」から「直近24時間の commit 群から版上げ commit を検索」に変更 | AC-5 |
| `README.md` / `CLAUDE.md` | 「push のたびに自動公開」という記述を、日次cronモデル＋`workflow_dispatch`の説明に更新 | AC-7 |

## 受入条件

- [x] [BUILD] `actionlint .github/workflows/release-beta.yaml`（または同等のYAML検証）がエラーなく通ること
  - 実行結果: 既存の `SC2129`（個別リダイレクトの style 警告）が1件出るが、`origin/main` の変更前ファイルにも同一の警告が存在することを確認済み（今回の差分に起因する新規の指摘ではない）
- [x] [LOGIC] `.github/workflows/release-beta.yaml` の `on:` に `push:` が存在せず、`schedule:`（cron）と `workflow_dispatch:` が定義されていること
- [x] [LOGIC] 直近24時間に対象パス（`**/*.md` / `docs/**` / `design/**` 以外）への commit が無い状態を模したローカル検証で、`ver` ステップの新ロジックが `skip=true` を出力すること
  - `ver` ステップのロジックを抽出したテストハーネスで、`--since` window に commit が無いケース、および README のみを変更した過去 commit のみを含む window で `skip=true` を確認
- [x] [LOGIC] 直近24時間に対象パスへの commit がある状態で、かつ `package.json` version が直近タグと異なる場合に `skip=false` になること（両ゲートが AND 条件で効くこと）
  - 実リポジトリの現状態（`package.json` = 4.8.3、直近タグ = v4.8.2）で確認
- [x] [LOGIC] 版上げ commit（`vX.Y.Z` という commit message）が直近24時間のウィンドウ内にある場合のみ `cycle_start=true` になり、翌日以降（そのウィンドウから外れた後）は `cycle_start=false` になること
  - 実際の `v4.8.3` 版上げ commit（2026-06-05）を含む window では `cycle_start=true`、含まない window（今日時点の実際の24h）では `cycle_start=false` を確認
- [ ] [MANUAL][SIDE-EFFECT] `workflow_dispatch` で手動実行し、push トリガー時と同様にビルド〜Webstore公開までのジョブが正常に完走すること
  - 未実施。実行すると実際に Chrome Webstore BETA へ公開申請が飛ぶ副作用があるため、レビュアー承認の上でマージ後に実施することを推奨
- [x] [MANUAL] README.md「リリースフロー」節および CLAUDE.md のベータリリース説明が、日次cronモデルの挙動と一致する記述に更新されていること

## 評価観点

- cron 時刻は `30 21 * * *`（06:30 JST）としたが、この時刻自体に強い理由は無い（Issue でユーザ確定済みの値）。運用上問題無いか
- `workflow_dispatch` を追加で用意したが、これは Issue の必須要件ではなく「push トリガー廃止に伴う緊急手動公開の手段」として `/tackle` 側の判断で加えたもの。この設計判断への同意を求めたい
- `paths-ignore` 相当のパス除外先（`**/*.md` / `docs/**` / `design/**`）を「直近24時間 commit 有無」判定に埋め込んだが、この一致で十分か（今後 exclude 対象を増減する場合、`ver` ステップ内の直書きを更新する必要がある）

## 発見

なし
