### PR TITLE
出撃記録（ログブック）の保存期間設定・自動削除とエクスポート機能を追加

### DIFF
--- a/src/models/Logbook.ts
+++ b/src/models/Logbook.ts
@@ -1,4 +1,7 @@
 import { Model } from "jstorm/chrome/local";
+import { BehaviorConfig } from "./configs/BehaviorConfig";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export enum BattleResult {
   SS = "完全勝利S",
@@ -105,13 +108,42 @@ export class Logbook {
 
   public static async record(): Promise<SortieContext | null> {
     if (!this._context) return null;
+    // 記録の有無を見て保存期間を確定するため、必ず保存前に判定する
+    const retentionDays = await this.resolveRetentionDays();
     this._context._id = this._context.started.toString();
     const saved = await this._context.save();
     this._context = null;
+    await this.prune(retentionDays);
     return saved;
   }
 
   public static async list(): Promise<SortieContext[]> {
     return SortieContext.list();
+  }
+
+  /**
+   * 出撃記録の保存期間（日数）を決定する。BehaviorConfig.logbookRetentionDays が
+   * 未設定（null）の場合、既存の出撃記録が1件でもあれば無期限（0）、無ければ
+   * 既定値（7日）として確定し、以降のために保存する。
+   * これにより、自動削除機能の導入以前から使っているユーザーの記録がいきなり
+   * 削除されるのを防ぐ（記録が既にある = 既存ユーザーとみなす）。
+   */
+  private static async resolveRetentionDays(): Promise<number> {
+    const config = await BehaviorConfig.user();
+    if (config.logbookRetentionDays !== null) return config.logbookRetentionDays;
+    const hasExisting = (await this.list()).length > 0;
+    const initial = hasExisting ? 0 : BehaviorConfig.DEFAULT_LOGBOOK_RETENTION_DAYS;
+    await config.update({ logbookRetentionDays: initial });
+    return initial;
+  }
+
+  // 保存期間（日数）より古い出撃記録を削除する。0以下は無期限を意味し、何もしない。
+  private static async prune(retentionDays: number): Promise<void> {
+    if (retentionDays <= 0) return;
+    const threshold = Date.now() - retentionDays * MS_PER_DAY;
+    const sorties = await this.list();
+    await Promise.all(
+      sorties.filter((sortie) => sortie.started < threshold).map((sortie) => sortie.delete()),
+    );
   }
 }

--- a/src/models/configs/BehaviorConfig.ts
+++ b/src/models/configs/BehaviorConfig.ts
@@ -6,12 +6,17 @@ export type QueueWatchIntervalSeconds = (typeof QueueWatchIntervalOptions)[numbe
 
 const DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS: QueueWatchIntervalSeconds = 30;
 
+// 出撃記録（Logbook）の既定保存期間（日数）。未設定(null)時に自動確定する値。
+const DEFAULT_LOGBOOK_RETENTION_DAYS = 7;
+
 // 細かい挙動設定。独立したセクションを設けるほどではない挙動の設定をまとめて持つ。
 export class BehaviorConfig extends Model {
   static override _namespace_ = "BehaviorConfig";
 
   // /cron/queues アラームの周期（秒）。chrome.alarms の periodInMinutes 下限 0.5 に相当する。
   public static readonly ALARM_PERIOD_SECONDS = 30;
+
+  public static readonly DEFAULT_LOGBOOK_RETENTION_DAYS = DEFAULT_LOGBOOK_RETENTION_DAYS;
 
   static override default = {
     "user": {
@@ -20,11 +25,15 @@ export class BehaviorConfig extends Model {
       "restackFatigueOnSortie": false,
       // Queue の期限を確認する間隔（秒）。短いほど予定時刻に近いタイミングで通知される。
       "queueWatchIntervalSeconds": DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS,
+      // 出撃記録（Logbook）の保存期間（日数）。0は無期限。null は未設定を表し、
+      // Logbook.record() が初回に既存記録の有無を見て自動確定する（Logbook.ts 参照）。
+      "logbookRetentionDays": null as number | null,
     },
   };
 
   public restackFatigueOnSortie: boolean = false;
   public queueWatchIntervalSeconds: number = DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS;
+  public logbookRetentionDays: number | null = null;
 
   public static async user(): Promise<BehaviorConfig> {
     return (await this.find("user"))!;

--- a/src/page/components/options/BehaviorSettingView.tsx
+++ b/src/page/components/options/BehaviorSettingView.tsx
@@ -10,6 +10,9 @@ export function BehaviorSettingView({
   const [config] = useState<BehaviorConfig>(_config);
   const [restackFatigueOnSortie, setRestackFatigueOnSortie] = useState<boolean>(config.restackFatigueOnSortie ?? false);
   const [queueWatchIntervalSeconds, setQueueWatchIntervalSeconds] = useState<QueueWatchIntervalSeconds>(config.normalizedQueueWatchIntervalSeconds());
+  const [logbookRetentionDays, setLogbookRetentionDays] = useState<number>(
+    config.logbookRetentionDays ?? BehaviorConfig.DEFAULT_LOGBOOK_RETENTION_DAYS,
+  );
 
   return (
     <FoldableSection title="細かい挙動設定" id="behavior">
@@ -52,6 +55,29 @@ export function BehaviorSettingView({
         </select>
         <div className="text-sm text-gray-600 mt-1">
           遠征・入渠・建造などのタイマーの期限を確認する間隔です。短くするほど予定時刻に近いタイミングで通知されますが、30秒より短い間隔では拡張機能が休止できなくなるため、バッテリー消費がわずかに増えます。ノートPCなど電力が気になる環境では既定の30秒のままをおすすめします。
+        </div>
+      </div>
+      <div>
+        <label className="block mb-2">
+          <span className="font-bold">出撃記録の保存期間</span>
+        </label>
+        <div className="flex items-center space-x-2">
+          <input
+            type="number"
+            min={0}
+            aria-label="出撃記録の保存期間"
+            value={logbookRetentionDays}
+            onChange={async (e) => {
+              const next = Math.max(0, Math.trunc(Number(e.target.value) || 0));
+              await config.update({ logbookRetentionDays: next });
+              setLogbookRetentionDays(next);
+            }}
+            className="border rounded p-2 w-24"
+          />
+          <span>日（0で無期限）</span>
+        </div>
+        <div className="text-sm text-gray-600 mt-1">
+          出撃記録ページに残す記録の日数です。この日数より古い記録は、次に出撃して母港に戻ったタイミングで削除されます。
         </div>
       </div>
     </FoldableSection>

--- a/src/page/logbook/LogbookPage.tsx
+++ b/src/page/logbook/LogbookPage.tsx
@@ -1,11 +1,27 @@
 import { useEffect, useState } from "react";
 import { useLoaderData, useRevalidator } from "react-router-dom";
-import { ArrowPathIcon, BookOpenIcon } from "@heroicons/react/24/outline";
+import { ArrowDownTrayIcon, ArrowPathIcon, BookOpenIcon } from "@heroicons/react/24/outline";
 import { SortieContext } from "../../models/Logbook";
 import { describeBattles, formatStarted } from "./format";
+import { logbookExportFilename, toCSV, toDataUrl, toJSONL } from "./export";
+import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
+import { DownloadService } from "../../services/DownloadService";
 
 // 自動更新オン時の再読込間隔（ミリ秒）
 const RELOAD_INTERVAL_MS = 5 * 1000;
+
+// CSV は Excel で開いたときに文字化けしないよう BOM を付ける
+const CSV_BOM = String.fromCharCode(0xfeff);
+
+// スクリーンショット保存先（FileSaveConfig）とは独立して、システムのダウンロードフォルダ直下に保存する
+async function downloadLogbook(sorties: SortieContext[], format: "csv" | "jsonl") {
+  const content = format === "csv" ? CSV_BOM + toCSV(sorties) : toJSONL(sorties);
+  const mimeType = format === "csv" ? "text/csv" : "application/x-ndjson";
+  await new DownloadService(new FileSaveConfig()).download(
+    toDataUrl(content, mimeType),
+    logbookExportFilename(format),
+  );
+}
 
 export function LogbookPage() {
   const { sorties } = useLoaderData() as { sorties: SortieContext[] };
@@ -43,6 +59,22 @@ export function LogbookPage() {
           />
           <span>自動更新</span>
         </label>
+        <button
+          onClick={() => downloadLogbook(sorted, "csv")}
+          disabled={sorted.length === 0}
+          className="flex items-center space-x-1 border rounded px-2 py-1 text-sm text-slate-600 hover:bg-slate-50 disabled:opacity-40 disabled:hover:bg-transparent"
+        >
+          <ArrowDownTrayIcon className="w-4 h-4" />
+          <span>CSV</span>
+        </button>
+        <button
+          onClick={() => downloadLogbook(sorted, "jsonl")}
+          disabled={sorted.length === 0}
+          className="flex items-center space-x-1 border rounded px-2 py-1 text-sm text-slate-600 hover:bg-slate-50 disabled:opacity-40 disabled:hover:bg-transparent"
+        >
+          <ArrowDownTrayIcon className="w-4 h-4" />
+          <span>JSONL</span>
+        </button>
       </div>
 
       {sorted.length === 0 ? (

--- a/src/page/logbook/export.ts
+++ b/src/page/logbook/export.ts
@@ -1,0 +1,56 @@
+import { SortieContext } from "../../models/Logbook";
+import { describeBattles, formatStarted } from "./format";
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+// ダウンロードファイル名用のタイムスタンプ（例: 20260707_153000）
+function filenameTimestamp(date: Date): string {
+  const Y = date.getFullYear();
+  const m = pad2(date.getMonth() + 1);
+  const d = pad2(date.getDate());
+  const H = pad2(date.getHours());
+  const M = pad2(date.getMinutes());
+  const S = pad2(date.getSeconds());
+  return `${Y}${m}${d}_${H}${M}${S}`;
+}
+
+export function logbookExportFilename(extension: "csv" | "jsonl", date: Date = new Date()): string {
+  return `出撃記録_${filenameTimestamp(date)}.${extension}`;
+}
+
+function csvField(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+const CSV_HEADER = ["出撃日時", "艦隊", "海域", "戦闘数", "戦闘"];
+
+// 出撃記録一覧の表示列と同じ内容をCSVにする（1行1出撃）
+export function toCSV(sorties: SortieContext[]): string {
+  const rows = sorties.map((sortie) => [
+    formatStarted(sortie.started),
+    sortie.deck ?? "",
+    sortie.map ? `${sortie.map.area}-${sortie.map.info}` : "",
+    String(sortie.battles.length),
+    describeBattles(sortie),
+  ]);
+  return [CSV_HEADER, ...rows].map((row) => row.map(csvField).join(",")).join("\r\n") + "\r\n";
+}
+
+// SortieContext には battle() 等のメソッドを積んだ battle プロパティが乗っているため、
+// そのまま JSON.stringify せずデータ項目だけを抜き出す
+export function toJSONL(sorties: SortieContext[]): string {
+  return sorties.map((sortie) => JSON.stringify({
+    id: sortie._id,
+    started: sortie.started,
+    deck: sortie.deck,
+    map: sortie.map,
+    cells: sortie.cells,
+    battles: sortie.battles,
+  })).join("\n") + "\n";
+}
+
+export function toDataUrl(content: string, mimeType: string): string {
+  return `data:${mimeType};charset=utf-8,${encodeURIComponent(content)}`;
+}

--- a/tests/behavior-setting-view.spec.tsx
+++ b/tests/behavior-setting-view.spec.tsx
@@ -1,0 +1,53 @@
+import { expect, describe, it, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+
+import { BehaviorSettingView } from "../src/page/components/options/BehaviorSettingView";
+import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
+// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
+const pristineDefaults = structuredClone(BehaviorConfig.default);
+
+beforeEach(() => {
+  BehaviorConfig.default = structuredClone(pristineDefaults);
+});
+
+async function renderView() {
+  const config = await BehaviorConfig.user();
+  // FoldableSection は ?open=<id> が付いていると開いた状態で描画される
+  const router = createMemoryRouter(
+    [{ path: "/", element: <BehaviorSettingView config={config} /> }],
+    { initialEntries: ["/?open=behavior"] },
+  );
+  render(<RouterProvider router={router} />);
+}
+
+// 「出撃記録の保存期間」設定欄の表示・保存ルール。
+describe("BehaviorSettingView 出撃記録の保存期間", () => {
+  it("未設定のときは既定の7を表示する", async () => {
+    await renderView();
+    expect(screen.getByLabelText("出撃記録の保存期間")).toHaveValue(7);
+  });
+
+  it("入力を変更すると即座に保存される", async () => {
+    await renderView();
+    const input = screen.getByLabelText("出撃記録の保存期間");
+    await userEvent.clear(input);
+    await userEvent.type(input, "30");
+
+    const reloaded = await BehaviorConfig.user();
+    expect(reloaded.logbookRetentionDays).toBe(30);
+  });
+
+  it("0を入力すると無期限として保存される", async () => {
+    await renderView();
+    const input = screen.getByLabelText("出撃記録の保存期間");
+    await userEvent.clear(input);
+    await userEvent.type(input, "0");
+
+    const reloaded = await BehaviorConfig.user();
+    expect(reloaded.logbookRetentionDays).toBe(0);
+  });
+});

--- a/tests/logbook-export.spec.ts
+++ b/tests/logbook-export.spec.ts
@@ -1,0 +1,82 @@
+import { expect, describe, it } from "vitest";
+
+import { SortieContext } from "../src/models/Logbook";
+import { logbookExportFilename, toCSV, toDataUrl, toJSONL } from "../src/page/logbook/export";
+
+// 出撃記録エクスポート機能のフォーマットルール。
+const sortieFixture = (over: Record<string, unknown> = {}) =>
+  ({
+    _id: "sortie-1",
+    started: new Date(2026, 6, 5, 12, 34, 0).getTime(),
+    deck: "1",
+    map: { area: 3, info: 2 },
+    cells: [{ id: "1" }],
+    battles: [
+      { formation: "1", midnight: false },
+      { formation: "2", midnight: true },
+    ],
+    ...over,
+  }) as unknown as SortieContext;
+
+describe("toCSV", () => {
+  it("ヘッダー行と出撃記録一覧の表示列を出力する", () => {
+    const csv = toCSV([sortieFixture()]);
+    const [header, row] = csv.trimEnd().split("\r\n");
+    expect(header).toBe("出撃日時,艦隊,海域,戦闘数,戦闘");
+    expect(row).toBe("2026/7/5 12:34,1,3-2,2,単縦陣 / 複縦陣(夜)");
+  });
+
+  it("海域未確定の出撃は空欄にする", () => {
+    const csv = toCSV([sortieFixture({ map: null })]);
+    const [, row] = csv.trimEnd().split("\r\n");
+    expect(row).toBe("2026/7/5 12:34,1,,2,単縦陣 / 複縦陣(夜)");
+  });
+
+  it("カンマや改行、ダブルクォートを含むフィールドはダブルクォートで囲みエスケープする", () => {
+    const csv = toCSV([sortieFixture({ deck: '1,"艦隊"\n' })]);
+    const [, row] = csv.trimEnd().split("\r\n");
+    expect(row).toContain('"1,""艦隊""\n"');
+  });
+});
+
+describe("toJSONL", () => {
+  it("1行1出撃のJSONを、データ項目だけで出力する（battle メソッドは含めない）", () => {
+    const jsonl = toJSONL([sortieFixture()]);
+    const lines = jsonl.trimEnd().split("\n");
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed).toEqual({
+      id: "sortie-1",
+      started: sortieFixture().started,
+      deck: "1",
+      map: { area: 3, info: 2 },
+      cells: [{ id: "1" }],
+      battles: [
+        { formation: "1", midnight: false },
+        { formation: "2", midnight: true },
+      ],
+    });
+    expect(parsed.battle).toBeUndefined();
+  });
+
+  it("複数の出撃記録を改行区切りで出力する", () => {
+    const jsonl = toJSONL([sortieFixture({ _id: "a" }), sortieFixture({ _id: "b" })]);
+    const lines = jsonl.trimEnd().split("\n");
+    expect(lines.map((line) => JSON.parse(line).id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("logbookExportFilename", () => {
+  it("拡張子とタイムスタンプ付きのファイル名を生成する", () => {
+    const date = new Date(2026, 6, 5, 15, 30, 5);
+    expect(logbookExportFilename("csv", date)).toBe("出撃記録_20260705_153005.csv");
+    expect(logbookExportFilename("jsonl", date)).toBe("出撃記録_20260705_153005.jsonl");
+  });
+});
+
+describe("toDataUrl", () => {
+  it("MIMEタイプと URL エンコード済みの内容を持つ data URL を生成する", () => {
+    const url = toDataUrl("あ,\n", "text/csv");
+    expect(url).toBe(`data:text/csv;charset=utf-8,${encodeURIComponent("あ,\n")}`);
+  });
+});

--- a/tests/logbook-page.spec.tsx
+++ b/tests/logbook-page.spec.tsx
@@ -1,8 +1,25 @@
-import { expect, describe, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 
+// chrome.downloads はダウンロードボタンのテストでのみ必要。呼び出された
+// filename/url を検証できるよう、DownloadService からの呼び出しをモックする。
+const { downloadMock } = vi.hoisted(() => {
+  const downloadMock = vi.fn((_options: unknown, cb: (id: number) => void) => cb(1));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { lastError: undefined },
+    downloads: { download: downloadMock },
+  };
+  return { downloadMock };
+});
+
 import { LogbookPage } from "../src/page/logbook/LogbookPage";
+
+beforeEach(() => {
+  downloadMock.mockClear();
+});
 
 // LogbookPage を loader データ付きで単体レンダリングする。
 // loader の非同期初期化を待たずに済むよう、hydrationData で初期データを与える。
@@ -59,5 +76,29 @@ describe("LogbookPage", () => {
     ]);
     expect(await screen.findByText("単縦陣 / 複縦陣(夜)")).toBeInTheDocument();
     expect(screen.getByText("2戦")).toBeInTheDocument();
+  });
+
+  it("出撃記録が無いときはダウンロードボタンが無効", async () => {
+    renderPage([]);
+    expect(await screen.findByRole("button", { name: "CSV" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "JSONL" })).toBeDisabled();
+  });
+
+  it("CSVボタンを押すと .csv ファイルをダウンロードする", async () => {
+    renderPage([sortie()]);
+    await userEvent.click(await screen.findByRole("button", { name: "CSV" }));
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledTimes(1));
+    const [options] = downloadMock.mock.calls[0] as [{ filename: string; url: string }];
+    expect(options.filename).toMatch(/\.csv$/);
+    expect(options.url).toMatch(/^data:text\/csv/);
+  });
+
+  it("JSONLボタンを押すと .jsonl ファイルをダウンロードする", async () => {
+    renderPage([sortie()]);
+    await userEvent.click(await screen.findByRole("button", { name: "JSONL" }));
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledTimes(1));
+    const [options] = downloadMock.mock.calls[0] as [{ filename: string; url: string }];
+    expect(options.filename).toMatch(/\.jsonl$/);
+    expect(options.url).toMatch(/^data:application\/x-ndjson/);
   });
 });

--- a/tests/logbook-retention.spec.ts
+++ b/tests/logbook-retention.spec.ts
@@ -1,0 +1,86 @@
+import { expect, describe, it, beforeEach } from "vitest";
+
+import { Logbook, SortieContext } from "../src/models/Logbook";
+import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
+// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
+const pristineBehaviorDefaults = structuredClone(BehaviorConfig.default);
+
+beforeEach(() => {
+  BehaviorConfig.default = structuredClone(pristineBehaviorDefaults);
+});
+
+async function saveSortieAt(id: string, started: number): Promise<void> {
+  const ctx = new SortieContext();
+  ctx._id = id;
+  ctx.started = started;
+  await ctx.save();
+}
+
+// 出撃記録（Logbook）の保存期間の自動確定と、期限切れ記録の削除ルール。
+describe("Logbook 保存期間の自動確定", () => {
+  it("出撃記録が無い状態で record() すると既定の7日として確定保存される", async () => {
+    Logbook.sortie.start("1", { area: "1", info: "1" });
+    await Logbook.record();
+
+    const config = await BehaviorConfig.user();
+    expect(config.logbookRetentionDays).toBe(7);
+  });
+
+  it("既存の出撃記録がある状態で record() すると無期限(0)として確定保存される", async () => {
+    await saveSortieAt("existing", Date.now() - 400 * DAY_MS);
+
+    Logbook.sortie.start("1", { area: "1", info: "1" });
+    await Logbook.record();
+
+    const config = await BehaviorConfig.user();
+    expect(config.logbookRetentionDays).toBe(0);
+    // 無期限なので古い記録も残っている
+    const ids = (await Logbook.list()).map((s) => s._id);
+    expect(ids).toContain("existing");
+  });
+
+  it("一度確定した保存期間は既存記録の増減に関わらず変わらない", async () => {
+    Logbook.sortie.start("1", { area: "1", info: "1" });
+    await Logbook.record(); // ここで7日に確定
+
+    Logbook.sortie.start("2", { area: "1", info: "1" });
+    await Logbook.record();
+
+    const config = await BehaviorConfig.user();
+    expect(config.logbookRetentionDays).toBe(7);
+  });
+});
+
+describe("Logbook 期限切れ記録の削除", () => {
+  it("保存期間より古い記録は record() 実行時に削除され、期間内の記録は残る", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ logbookRetentionDays: 7 });
+
+    await saveSortieAt("old", Date.now() - 8 * DAY_MS);
+    await saveSortieAt("recent", Date.now() - 1 * DAY_MS);
+
+    Logbook.sortie.start("1", { area: "1", info: "1" });
+    await Logbook.record();
+
+    const ids = (await Logbook.list()).map((s) => s._id);
+    expect(ids).not.toContain("old");
+    expect(ids).toContain("recent");
+  });
+
+  it("保存期間が0（無期限）なら古い記録も削除されない", async () => {
+    const config = await BehaviorConfig.user();
+    await config.update({ logbookRetentionDays: 0 });
+
+    await saveSortieAt("ancient", Date.now() - 1000 * DAY_MS);
+
+    Logbook.sortie.start("1", { area: "1", info: "1" });
+    await Logbook.record();
+
+    const ids = (await Logbook.list()).map((s) => s._id);
+    expect(ids).toContain("ancient");
+  });
+});


### PR DESCRIPTION
## 概要
出撃記録（ログブック）が際限なく溜まっていく問題に対応する。

## 変更内容
- 出撃記録ページにCSV / JSONLエクスポートボタンを追加
- 細かい挙動設定に「出撃記録の保存期間」（日数、0で無期限）を追加
- 保存期間を超えた記録は、次に出撃して母港に戻ったタイミングで自動削除
- 保存期間が未設定の場合、初回の記録保存時に既存記録の有無を見て自動確定する
  （既に記録があれば無期限、無ければ既定7日）。これにより、この機能の導入前から
  使っているユーザーの記録がいきなり削除されるのを防ぐ