### PR TITLE
手動登録した遠征タイマーの通知が「undefined」と表示されるのを修正

### DIFF
--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -35,7 +35,13 @@ export async function onMissionStart([details]: chrome.webRequest.OnBeforeReques
   const data: MissionStartFormData = details.requestBody?.formData as unknown as MissionStartFormData;
   const did = data.api_deck_id[0];
   const mid = data.api_mission_id[0];
-  const m = new Mission(did, mid, missions[mid]);
+  const spec = missions[mid];
+  // カタログ未収録の遠征は所要時間が不明で終了時刻を算出できないため、タイマーを積まない
+  if (!spec) {
+    log.warn("onMissionStart: カタログ未収録の遠征ID", mid);
+    return;
+  }
+  const m = new Mission(did, mid, spec);
   // 遠征は残り1分を切ると母港復帰で即完了する仕様のため、通知を一律で1分早める（#1811, Mission.EARLY_RETURN_MARGIN）。
   // 入渠・建造はOCRで実時刻を読むためこの補正は不要。
   const scheduled = Date.now() + Math.max(0, m.time - Mission.EARLY_RETURN_MARGIN);

--- a/src/models/entry/Mission.ts
+++ b/src/models/entry/Mission.ts
@@ -17,14 +17,16 @@ export class Mission extends NotificationEntryBase {
   public id: number | string = 0; // 遠征ID
 
   // カタログから来る基本情報 (idさえあればcatalogからひける)
-  public title: string = "UNKNOWN"; // 遠征タイトル
+  public title: string = "知らないやつ"; // 遠征タイトル
   public time: number = 0; // 所要時間（ミリ秒）
 
-  constructor(deckId: string, missionId: number | string, mission: MissionSpec) {
+  // specやtitleを持たないQueue（種別切替や過去の手動登録で保存されたもの等）でも
+  // 通知を組み立てられるよう、欠けている値はフィールドの既定値のままにする
+  constructor(deckId: string, missionId: number | string, mission?: MissionSpec) {
     super();
     this.id = missionId;
-    this.title = mission.title;
-    this.time = mission.time;
+    this.title = mission?.title ?? this.title;
+    this.time = mission?.time ?? this.time;
     this.deck = deckId;
   }
 

--- a/src/page/components/dashboard/CustomQueueModal.tsx
+++ b/src/page/components/dashboard/CustomQueueModal.tsx
@@ -64,7 +64,13 @@ export function CustomQueueModal({
         <div className="flex space-x-2">
           <label>種別</label>
           <select defaultValue={queue.type} className={`kcw-custom-queue-select kcw-${queue.type} flex-1 rounded-md`}
-            onChange={e => { queue.type = e.target.value as EntryType; update(queue) }}
+            onChange={e => {
+              queue.type = e.target.value as EntryType;
+              // API傍受で作られたQueueは deck / dock の一方しか持たないため、種別切替時にもう一方へ引き継ぐ
+              queue.params["deck"] ??= queue.params["dock"];
+              queue.params["dock"] ??= queue.params["deck"];
+              update(queue);
+            }}
           >
             <option value={EntryType.MISSION}>遠征</option>
             <option value={EntryType.RECOVERY}>修復</option>

--- a/src/page/components/dashboard/QueuesView.tsx
+++ b/src/page/components/dashboard/QueuesView.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { EntryType, Fatigue, Mission, Recovery, Shipbuild } from "../../../models/entry";
+import { missions } from "../../../catalog";
 import { ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
 import Queue from "../../../models/Queue";
 import { KCWDate } from "../../../utils";
@@ -15,8 +16,9 @@ function QueueItemView({
   edit: (q: Queue | null) => void,
 }) {
   if (!queue) {
+    // 手動登録はカタログの遠征ID 0「マニュアル登録されたやつ」として名前を持たせる
     return <div className="flex text-gray-400 cursor-pointer"
-      onClick={() => edit(Queue.new({ type, scheduled: Date.now(), params: { deck: index + 1, dock: index + 1 } }))}>
+      onClick={() => edit(Queue.new({ type, scheduled: Date.now(), params: { deck: index + 1, dock: index + 1, id: 0, title: missions["0"].title } }))}>
       <div className="mr-1">第{index + 1}{label}</div>
       <div>--:--</div>
     </div>

--- a/tests/custom-queue-modal.spec.tsx
+++ b/tests/custom-queue-modal.spec.tsx
@@ -60,6 +60,17 @@ describe("CustomQueueModal (split)", () => {
   });
 });
 
+// 種別切替: params のスロットキー（deck / dock）の引き継ぎ。
+describe("CustomQueueModal 種別切替", () => {
+  it("dock しか持たないQueue（API傍受由来）を遠征へ切り替えると deck に引き継がれる", () => {
+    const queue = Queue.new({ type: EntryType.RECOVERY, scheduled: Date.now(), params: { dock: 3 } });
+    render(<CustomQueueModal queue={queue} close={() => {}} update={() => {}} />);
+    const [typeSelect] = screen.getAllByRole("combobox");
+    fireEvent.change(typeSelect, { target: { value: EntryType.MISSION } });
+    expect(queue.params["deck"]).toBe(3);
+  });
+});
+
 // time モード: HH:MM の time input 1つで入力する。
 describe("CustomQueueModal (time)", () => {
   function renderTimeMode(queue: Queue, close: () => void = () => {}) {

--- a/tests/manual-queue-mission-title.spec.ts
+++ b/tests/manual-queue-mission-title.spec.ts
@@ -1,0 +1,43 @@
+import { expect, describe, it, vi } from "vitest";
+
+// Queue の import 連鎖（logger 経由の chromite）がモジュール読み込み時に chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+  };
+});
+
+import Queue from "../src/models/Queue";
+import { EntryType, Mission, TriggerType } from "../src/models/entry";
+import { missions } from "../src/catalog";
+
+// 手動登録した遠征タイマーの通知に表示する名前の扱い。
+describe("手動登録の遠征タイマーの表示名", () => {
+  it("カタログに遠征ID 0（手動登録用の名前）が収録されている", () => {
+    expect(missions["0"].title).toBe("マニュアル登録されたやつ");
+  });
+
+  it("手動登録のQueue（カタログID 0 スタンプ付き）の完了通知に名前が入る", () => {
+    // Dashboard の手動登録（QueuesView）が作る params と同じ形
+    const q = Queue.new({
+      type: EntryType.MISSION,
+      scheduled: Date.now(),
+      params: { deck: 2, dock: 2, id: 0, title: missions["0"].title },
+    });
+    const options = q.entry<Mission>().$n.options(TriggerType.END);
+    expect(options.message).toContain("第2艦隊");
+    expect(options.message).toContain("「マニュアル登録されたやつ」");
+  });
+
+  it("title を持たないQueue（過去に保存された手動登録等）は「知らないやつ」にフォールバックする", () => {
+    const q = Queue.new({
+      type: EntryType.MISSION,
+      scheduled: Date.now(),
+      params: { deck: 3 },
+    });
+    const options = q.entry<Mission>().$n.options(TriggerType.END);
+    expect(options.message).toContain("「知らないやつ」");
+    expect(options.message).not.toContain("undefined");
+  });
+});

--- a/tests/queue-dedupe-on-speedchange-and-start.spec.ts
+++ b/tests/queue-dedupe-on-speedchange-and-start.spec.ts
@@ -72,6 +72,21 @@ describe("遠征開始時の重複排除", () => {
   });
 });
 
+describe("カタログ未収録の遠征ID", () => {
+  beforeEach(() => {
+    deleteSlot.mockClear();
+    create.mockClear();
+    notify.mockClear();
+  });
+
+  it("onMissionStart: 所要時間が不明なためタイマーを積まず通知もしない", async () => {
+    await onMissionStart(details({ api_deck_id: ["2"], api_mission_id: ["123"], api_mission: ["93"] }));
+    expect(deleteSlot).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});
+
 describe("疲労Queueの積み直し設定(restackFatigueOnSortie)", () => {
   beforeEach(() => {
     deleteSlot.mockClear();


### PR DESCRIPTION
## Summary
- Dashboard から手動登録した遠征タイマーの完了通知が「まもなく第N艦隊が「undefined」から帰投します」と表示される不具合を修正
  - 手動登録時にカタログの遠征ID 0「マニュアル登録されたやつ」を params にスタンプして名前を持たせる（v3 と同等の挙動）
  - あわせて、title を持たない既存の Queue でも `Mission` のフィールド既定値によるフォールバックが機能するようコンストラクタを修正し、既定値を「知らないやつ」とした
- Queue 編集モーダルで種別を切り替えたとき、通知の艦隊/ドック番号が undefined になるのを修正（API 傍受由来の Queue は deck / dock の一方しか持たないため、切替時にもう一方へ引き継ぐ）
- カタログ未収録の遠征IDを検知した場合、`Mission` コンストラクタの例外でハンドラが黙って落ちていたのを、警告ログを残してタイマーを積まない明示的な挙動に変更（所要時間が不明で終了時刻を算出できないため）

## Test plan
- [x] kcw-debug で実機検証: 手動登録した遠征の完了通知に「マニュアル登録されたやつ」が表示されることを確認
- [x] ユニットテスト追加（手動登録 Queue の通知文言 / title 欠落時のフォールバック / 種別切替時の deck 引き継ぎ / 未収録IDでタイマーを積まないこと）
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test`（569件）実行済み