### PR TITLE
background 層の規約・定型を集約する（slotKey / restack / formData / NotificationId）

### DIFF
--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -3,7 +3,7 @@ import { Logger } from "../logger";
 import { Frame } from "../models/Frame";
 import { type Page } from "tesseract.js";
 import { EntryType, Recovery, Shipbuild } from "../models/entry";
-import { H, M, S, sleep, WorkerImage } from "../utils";
+import { parseHMS, sleep, WorkerImage } from "../utils";
 import Queue from "../models/Queue";
 import { TriggerType } from "../models/entry";
 import { Launcher } from "../services/Launcher";
@@ -19,17 +19,6 @@ import { formatSortieLabel } from "../models/sortieLabel";
 
 const onMessage = new Router<typeof chrome.runtime.onMessage>();
 const log = Logger.get("Message");
-
-// OCRで読み取った "HH:MM:SS" 形式の文字列をミリ秒に変換する。時刻として解釈できなければ null。
-// Number() は空文字を 0 と解釈するため（"::" が 0ms になる等）、正規表現で形式を固定し、
-// 分・秒の範囲外も不正として弾く。呼び出し側は null のとき Queue を作ってはいけない。
-function parseOcrTime(text: string): number | null {
-  const matched = text.trim().match(/^(\d+):(\d+):(\d+)$/);
-  if (!matched) return null;
-  const [h, m, s] = matched.slice(1).map(Number);
-  if (m > 59 || s > 59) return null;
-  return h * H + m * M + s * S;
-}
 
 onMessage.on("/frame/open-or-focus", async (req) => {
   const launcher = new Launcher();
@@ -84,7 +73,7 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.RECOVERY}:result`, async (req) => {
   // 残っていても、次に同じドックで修復を始めた時点で重複が解消されるようにする保険）。
   // 修復が始まった事実に基づく掃除なので、OCR結果の成否に依らず行う。
   await Queue.deleteSlot(EntryType.RECOVERY, dock);
-  const time = parseOcrTime(data.text);
+  const time = parseHMS(data.text);
   if (time === null) {
     log.warn("修復時間のOCR結果を時刻として解釈できないため、タイマーを登録しない", data.text);
     return;
@@ -100,7 +89,7 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.SHIPBUILD}:result`, async (req) => {
   const dock = req[EntryType.SHIPBUILD].dock;
   // 建造が始まった事実に基づく掃除なので、OCR結果の成否に依らず行う。
   await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
-  const time = parseOcrTime(data.text);
+  const time = parseHMS(data.text);
   if (time === null) {
     log.warn("建造時間のOCR結果を時刻として解釈できないため、タイマーを登録しない", data.text);
     return;

--- a/src/controllers/WebRequest/datatypes.ts
+++ b/src/controllers/WebRequest/datatypes.ts
@@ -58,3 +58,13 @@ export interface GetShipFormData {
 export interface QuestActionFormData {
     api_quest_id: string[];
 }
+
+// 戦闘開始系 API の formData。パスにより形が揺らぐ（連合艦隊系は実データ未観測）ため
+// api_formation は optional で防御的に読む。
+export interface BattleStartFormData {
+    api_formation?: string[]; // 陣形
+}
+
+export interface MapNextFormData {
+    api_cell_id?: string[]; // たぶんここにマスIDが入ってる
+}

--- a/src/controllers/WebRequest/formdata.ts
+++ b/src/controllers/WebRequest/formdata.ts
@@ -1,0 +1,16 @@
+import { Logger } from "../../logger";
+
+const log = Logger.get("WebRequest");
+
+// webRequest details から formData を型付きで取り出す。
+// chrome の型 ({ [key: string]: string[] }) から API ごとの FormData 型への
+// アサーションをここに集約する。requestBody が欠落しているリクエストでは
+// warn ログを残して undefined を返すので、呼び出し側は early return すること。
+export function formData<T>(details: chrome.webRequest.OnBeforeRequestDetails): T | undefined {
+  const data = details.requestBody?.formData;
+  if (!data) {
+    log.warn("formData がありません", details.url, details);
+    return undefined;
+  }
+  return data as unknown as T;
+}

--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -24,6 +24,8 @@ import {
 } from "./kcsapi";
 import { onQuestStart, onQuestStop, onQuestComplete, onPracticePrepare, onSortiePrepare } from "./quest";
 import { ScriptingService } from "../../services/ScriptingService";
+import { NotificationService } from "../../services/NotificationService";
+import { EntryType, TriggerType } from "../../models/entry";
 
 const requestLogger = Logger.get("WebRequest");
 const completeLogger = Logger.get("WebRequest:onComplete");
@@ -98,11 +100,7 @@ onComplete.on(["/kcsapi/api_req_combined_battle/battleresult"], async ([details]
 // 開始通知とこのクリアが競合し、サーバ応答時間次第で開始通知が出た直後に消えてしまう。
 // 開始通知の後始末は NotificationService の自己消去（stay=false は10秒で消える）に任せる。
 onComplete.on(["/kcsapi/api_get_member/ndock"], async () => {
-  chrome.notifications.getAll((notifications) => {
-    for (const id in notifications) {
-      if (id.startsWith("/recovery/end/")) chrome.notifications.clear(id);
-    }
-  });
+  await NotificationService.new().clearBy({ type: EntryType.RECOVERY, trigger: TriggerType.END });
 })
 
 onComplete.on(["/kcsapi/api_get_member/practice"], onPracticePrepare); // 演習画面に遷移したとき

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -2,7 +2,8 @@ import { Logger } from "../../logger";
 import { missions } from "../../catalog";
 import { sleep, WorkerImage } from "../../utils";
 import Queue from "../../models/Queue";
-import { CreateShipFormData, GetShipFormData, MapStartFormData, MissionResultFormData, MissionStartFormData, RecoveryStartFormData, RecoverySpeedchangeFormData, ShipbuildSpeedchangeFormData } from "./datatypes";
+import { BattleStartFormData, CreateShipFormData, GetShipFormData, MapNextFormData, MapStartFormData, MissionResultFormData, MissionStartFormData, RecoveryStartFormData, RecoverySpeedchangeFormData, ShipbuildSpeedchangeFormData } from "./datatypes";
+import { formData } from "./formdata";
 import { EntryType, Fatigue, Mission } from "../../models/entry";
 import { TriggerType } from "../../models/entry";
 import { TabService } from "../../services/TabService";
@@ -32,7 +33,8 @@ export async function onPort([details]: chrome.webRequest.OnBeforeRequestDetails
 }
 
 export async function onMissionStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const data: MissionStartFormData = details.requestBody?.formData as unknown as MissionStartFormData;
+  const data = formData<MissionStartFormData>(details);
+  if (!data) return;
   const did = data.api_deck_id[0];
   const mid = data.api_mission_id[0];
   const spec = missions[mid];
@@ -68,13 +70,16 @@ async function clearNotificationsOf(type: EntryType, target: string) {
 
 // 遠征結果を回収したとき、その艦隊の遠征通知（開始・完了）を消す
 export async function onMissionResult([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_deck_id: [deck] } = details.requestBody?.formData as unknown as MissionResultFormData;
+  const data = formData<MissionResultFormData>(details);
+  if (!data) return;
+  const deck = data.api_deck_id[0];
   await clearNotificationsOf(EntryType.MISSION, deck);
 }
 
 export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   log.debug("onRecoveryStart", details);
-  const data = details.requestBody?.formData as unknown as RecoveryStartFormData;
+  const data = formData<RecoveryStartFormData>(details);
+  if (!data) return;
   const dock = data.api_ndock_id[0];
   // 高速修復材を同時使用した入渠は即完了するため、タイマーは積まない。
   // 同じドックに古いQueueが残っていた場合に備えて掃除だけ行う（onRecoveryHighspeedと同じ扱い）。
@@ -96,14 +101,17 @@ export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeReque
 // 修復中に高速修復剤を使って完了させたとき、そのドックの修復Queueと表示中の修復通知を消す。
 // この経路では完了通知が出ない（QueueWatcherを通らない）ため、開始通知の掃除もここで行う。
 export async function onRecoveryHighspeed([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_ndock_id: [dock] } = details.requestBody?.formData as unknown as RecoverySpeedchangeFormData;
+  const data = formData<RecoverySpeedchangeFormData>(details);
+  if (!data) return;
+  const dock = data.api_ndock_id[0];
   await Queue.deleteSlot(EntryType.RECOVERY, dock);
   await clearNotificationsOf(EntryType.RECOVERY, dock);
 }
 
 // 出撃開始時
 export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const data = details.requestBody?.formData as unknown as MapStartFormData;
+  const data = formData<MapStartFormData>(details);
+  if (!data) return;
   const deck = data.api_deck_id[0];
   const map = { area: data.api_maparea_id[0], info: data.api_mapinfo_no[0] };
   const fatigue = new Fatigue(parseInt(deck), map);
@@ -124,30 +132,31 @@ export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDet
 // マップ移動時
 export async function onMapNext([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   log.debug("onMapNext", details);
-  const data = details.requestBody?.formData as {
-    api_cell_id: string[]; // たぶんここにマスIDが入ってる
-  };
+  const data = formData<MapNextFormData>(details);
   if (!data?.api_cell_id) return log.warn("onMapNext: api_cell_id not found", details);
   Logbook.sortie.next(data.api_cell_id[0]);
 }
 
+// 戦闘開始系ハンドラの共通処理。大破進撃防止窓の除去と Logbook への連戦記録を行い、
+// midnight 指定時は開幕夜戦として夜戦フラグも立てる。api_formation は欠落時
+// 空文字で記録する（欠落してもマス数のカウントは落とさない）。
+async function startBattle(details: chrome.webRequest.OnBeforeRequestDetails, { midnight = false } = {}) {
+  await clearSnapshotOnBattleStart(details);
+  const data = formData<BattleStartFormData>(details);
+  Logbook.sortie.battle.start(data?.api_formation?.[0] ?? "");
+  if (midnight) Logbook.sortie.battle.midnight();
+}
+
 // 戦闘（昼戦）開始時
 export async function onBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  await clearSnapshotOnBattleStart(details);
-  const data = details.requestBody?.formData as {
-    api_formation: string[]; // 陣形
-    api_recovery_type: string[]; // なんだこれ
-  };
-  Logbook.sortie.battle.start(data.api_formation[0]);
+  await startBattle(details);
 }
 
 // 連合艦隊戦（昼戦）開始時。通常艦隊の onBattleStarted と同様に連戦数をカウントする（#1764）。
 // 連合艦隊では api_req_combined_battle/battle が飛ぶが従来ハンドラが無く連戦数が積まれなかった。
 // formData の形は実データ未観測のため api_formation を防御的に読む（揺らぎは許容）。
 export async function onCombinedBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  await clearSnapshotOnBattleStart(details);
-  const data = details.requestBody?.formData as { api_formation?: string[] } | undefined;
-  Logbook.sortie.battle.start(data?.api_formation?.[0] ?? "");
+  await startBattle(details);
 }
 
 // 夜戦（昼戦マスからの追撃夜戦）突入時。同じマスの戦闘の継続なので連戦数は増やさず、
@@ -162,20 +171,14 @@ export async function onMidnightBattleStarted([_details]: chrome.webRequest.OnBe
 // api_req_sortie/battleresult 側で返るため、大破進撃防止窓は既存の onComplete 経路で表示される。
 // 未ハンドルだと remove も push も起きず「前マスの窓が残り横並び増殖」「連戦数の数え漏れ」を招いていた。
 export async function onSpMidnightBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  await clearSnapshotOnBattleStart(details);
-  const data = details.requestBody?.formData as { api_formation?: string[] } | undefined;
-  Logbook.sortie.battle.start(data?.api_formation?.[0] ?? "");
-  Logbook.sortie.battle.midnight();
+  await startBattle(details, { midnight: true });
 }
 
 // 連合艦隊の開幕夜戦マス。api パス・formData 形ともに未観測（イベント期間外で実データ取得不可）の
 // ため予防的に用意し、通常版 sp_midnight と対にして連戦数漏れを防ぐ。実機で観測できたらパス名と
 // formData の形を確定すること（#1764）。
 export async function onCombinedSpMidnightBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  await clearSnapshotOnBattleStart(details);
-  const data = details.requestBody?.formData as { api_formation?: string[] } | undefined;
-  Logbook.sortie.battle.start(data?.api_formation?.[0] ?? "");
-  Logbook.sortie.battle.midnight();
+  await startBattle(details, { midnight: true });
 }
 
 // 戦闘終了時
@@ -186,12 +189,15 @@ export async function onBattleResulted([details]: chrome.webRequest.OnBeforeRequ
 
 // 建造した艦を受け取ったとき、そのドックの建造通知（開始・完了）を消す
 export async function onGetShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as GetShipFormData;
+  const data = formData<GetShipFormData>(details);
+  if (!data) return;
+  const dock = data.api_kdock_id[0];
   await clearNotificationsOf(EntryType.SHIPBUILD, dock);
 }
 
 export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const data = details.requestBody?.formData as unknown as CreateShipFormData; 
+  const data = formData<CreateShipFormData>(details);
+  if (!data) return;
   const dock = data.api_kdock_id[0];
   // このハンドラは [createship, kdock] のシーケンスマッチで発火し、details には先頭の
   // createship リクエスト（建造開始の formData）が渡される。
@@ -214,6 +220,8 @@ export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestD
 
 // 建造中に高速建造材を使って完了させたとき、そのドックの建造Queueを削除する
 export async function onShipbuildHighspeed([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as ShipbuildSpeedchangeFormData;
+  const data = formData<ShipbuildSpeedchangeFormData>(details);
+  if (!data) return;
+  const dock = data.api_kdock_id[0];
   await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
 }

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -47,8 +47,7 @@ export async function onMissionStart([details]: chrome.webRequest.OnBeforeReques
   const scheduled = Date.now() + Math.max(0, m.time - Mission.EARLY_RETURN_MARGIN);
   // 同じ艦隊の既存Queueを削除してから積み直す（他端末での帰投操作等、検知できない経路で
   // 古いQueueが残っていても、同じ艦隊で次の遠征を始めた時点で解消される）。
-  await Queue.deleteSlot(EntryType.MISSION, did);
-  const q = await Queue.create({ type: EntryType.MISSION, params: m, scheduled });
+  const q = await Queue.restack(EntryType.MISSION, did, m, scheduled);
   const e = q.entry();
   NotificationService.new().notify(e, TriggerType.START);
 }
@@ -114,10 +113,12 @@ export async function onMapStart([details]: chrome.webRequest.OnBeforeRequestDet
   // 設定が有効な場合のみ、同じ艦隊の既存の疲労Queueを削除して最新の1本に積み直す。
   // 既定では削除せず出撃ごとにタイマーが並ぶ（連続出撃の回数把握に使える）。
   const behavior = await BehaviorConfig.user();
+  const scheduled = Date.now() + fatigue.time;
   if (behavior.restackFatigueOnSortie) {
-    await Queue.deleteSlot(EntryType.FATIGUE, fatigue.deck);
+    await Queue.restack(EntryType.FATIGUE, fatigue.deck, fatigue, scheduled);
+  } else {
+    await Queue.create({ type: EntryType.FATIGUE, params: fatigue, scheduled });
   }
-  await Queue.create({ type: EntryType.FATIGUE, params: fatigue, scheduled: Date.now() + fatigue.time });
 }
 
 // マップ移動時

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -58,22 +58,12 @@ export async function onMissionReturnInstruction([details]: chrome.webRequest.On
   log.debug("onMissionReturnInstruction", details);
 }
 
-// 指定タイプ・指定艦隊(ドック)の通知を全トリガー分消す。
-// 通知IDは /{type}/{trigger}/{deck|dock} 形式（各 entry の $n.id 参照）。
-async function clearNotificationsOf(type: EntryType, target: string) {
-  const service = NotificationService.new();
-  const notifications = await service.getAll();
-  for (const id of Object.keys(notifications)) {
-    if (id.startsWith(`/${type}/`) && id.endsWith(`/${target}`)) await service.clear(id);
-  }
-}
-
 // 遠征結果を回収したとき、その艦隊の遠征通知（開始・完了）を消す
 export async function onMissionResult([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const data = formData<MissionResultFormData>(details);
   if (!data) return;
   const deck = data.api_deck_id[0];
-  await clearNotificationsOf(EntryType.MISSION, deck);
+  await NotificationService.new().clearBy({ type: EntryType.MISSION, target: deck });
 }
 
 export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
@@ -105,7 +95,7 @@ export async function onRecoveryHighspeed([details]: chrome.webRequest.OnBeforeR
   if (!data) return;
   const dock = data.api_ndock_id[0];
   await Queue.deleteSlot(EntryType.RECOVERY, dock);
-  await clearNotificationsOf(EntryType.RECOVERY, dock);
+  await NotificationService.new().clearBy({ type: EntryType.RECOVERY, target: dock });
 }
 
 // 出撃開始時
@@ -192,7 +182,7 @@ export async function onGetShip([details]: chrome.webRequest.OnBeforeRequestDeta
   const data = formData<GetShipFormData>(details);
   if (!data) return;
   const dock = data.api_kdock_id[0];
-  await clearNotificationsOf(EntryType.SHIPBUILD, dock);
+  await NotificationService.new().clearBy({ type: EntryType.SHIPBUILD, target: dock });
 }
 
 export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {

--- a/src/controllers/WebRequest/quest.ts
+++ b/src/controllers/WebRequest/quest.ts
@@ -3,21 +3,20 @@ import { QUEST_ALERT_NOTIFICATION_ID } from "../../models/configs/NotificationCo
 import { QuestProgress } from "../../models/QuestProgress";
 import { NotificationService } from "../../services/NotificationService";
 import { QuestActionFormData } from "./datatypes";
+import { formData } from "./formdata";
 
-export async function onQuestStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_quest_id: [id] } = details.requestBody?.formData as unknown as QuestActionFormData;
-  await (await QuestProgress.user()).start(parseInt(id, 10));
+// api_req_quest/{start,stop,clearitemget} 共通: formData の任務IDに
+// QuestProgress の指定メソッドを適用するハンドラを生成する
+function onQuestAction(action: "start" | "stop" | "complete") {
+  return async ([details]: chrome.webRequest.OnBeforeRequestDetails[]) => {
+    const data = formData<QuestActionFormData>(details);
+    if (!data) return;
+    await (await QuestProgress.user())[action](parseInt(data.api_quest_id[0], 10));
+  };
 }
-
-export async function onQuestStop([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_quest_id: [id] } = details.requestBody?.formData as unknown as QuestActionFormData;
-  await (await QuestProgress.user()).stop(parseInt(id, 10));
-}
-
-export async function onQuestComplete([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  const { api_quest_id: [id] } = details.requestBody?.formData as unknown as QuestActionFormData;
-  await (await QuestProgress.user()).complete(parseInt(id, 10));
-}
+export const onQuestStart = onQuestAction("start");
+export const onQuestStop = onQuestAction("stop");
+export const onQuestComplete = onQuestAction("complete");
 
 // 指定カテゴリに着手可能なのにまだ着手していない任務があれば、その一覧を通知する
 async function warnIfQuestNotAccepted(category: QuestCategory, notificationId: string, title: string) {

--- a/src/models/Queue.ts
+++ b/src/models/Queue.ts
@@ -19,6 +19,19 @@ export default class Queue extends Model {
     }
   }
 
+  // 同じ種別・同じスロットの既存Queueを削除してから新しいQueueを作成する（積み直し）。
+  // 削除が作成より先であることが不変条件（逆順だと作成したQueueごと削除されるため、
+  // 呼び出し側に分割せずここで順序を保証する）。
+  public static async restack(
+    type: EntryType,
+    slot: string | number,
+    params: Entry | Record<string, string | number>,
+    scheduled: number,
+  ): Promise<Queue> {
+    await this.deleteSlot(type, slot);
+    return await this.create({ type, params, scheduled });
+  }
+
   public type: EntryType = EntryType.UNKNOWN;
   public params: Record<string, string | number> = {};
   public scheduled: number = 0; // 予定時刻 (Epoch Time) [ms]

--- a/src/models/Queue.ts
+++ b/src/models/Queue.ts
@@ -1,5 +1,5 @@
 import { Model } from "jstorm/chrome/local";
-import { Entry, EntryType, Fatigue, Mission, Recovery, Shipbuild } from "./entry";
+import { Entry, EntryType, Fatigue, Mission, Recovery, Shipbuild, slotKey } from "./entry";
 import { MissionSpec } from "../catalog";
 import { Logger } from "../logger";
 import { H, M, S } from "../utils";
@@ -15,14 +15,19 @@ export default class Queue extends Model {
     const queues = await this.list();
     for (const q of queues) {
       if (q.type !== type) continue;
-      const entry = q.entry<Mission | Recovery | Shipbuild | Fatigue>() as { dock?: string | number, deck?: string | number };
-      if (String(entry.dock ?? entry.deck) === String(slot)) await q.delete();
+      if (String(q.slot) === String(slot)) await q.delete();
     }
   }
 
   public type: EntryType = EntryType.UNKNOWN;
   public params: Record<string, string | number> = {};
   public scheduled: number = 0; // 予定時刻 (Epoch Time) [ms]
+
+  // このQueueのスロット番号（艦隊/ドック）。EntryType に応じた params のキーから取り出す。
+  public get slot(): string | number | undefined {
+    return this.params[slotKey(this.type)];
+  }
+
   public entry<T extends Entry>(): T {
     switch (this.type) {
     case EntryType.MISSION:

--- a/src/models/configs/NotificationConfig.ts
+++ b/src/models/configs/NotificationConfig.ts
@@ -1,5 +1,5 @@
 import { Model } from "jstorm/chrome/local";
-import { EntryType, TriggerType } from "../entry";
+import { EntryType, NotificationId, TIMER_ENTRY_TYPES, TriggerType } from "../entry";
 
 export interface NotificationConfigData {
   enabled: boolean;
@@ -12,69 +12,40 @@ export interface NotificationConfigData {
 // NotificationConfig の1エントリとして直接キーを持つ（開始/完了のペアが無い一発通知）
 export const QUEST_ALERT_NOTIFICATION_ID = "/quest-alert/start";
 
+// タイマー系通知（種別×トリガー）の既定値。生成時はキーごとに spread で複製し共有参照を避ける。
+const TIMER_NOTIFICATION_DEFAULT: NotificationConfigData = {
+  enabled: true,
+  sound: null,
+  icon: null,
+  stay: false,
+};
+
 export class NotificationConfig extends Model {
   static override _namespace_ = "NotificationConfig";
   static override default = {
-    "/default/start": {
+    [NotificationId.configKey("default", TriggerType.START)]: {
       enabled: true,
       sound: null,
       icon: chrome.runtime.getURL("icons/128.png"),
       stay: false,
     },
-    "/default/end": {
+    [NotificationId.configKey("default", TriggerType.END)]: {
       enabled: true,
       sound: null,
       icon: chrome.runtime.getURL("icons/128.png"),
       stay: false,
     },
-    [`/${EntryType.MISSION}/${TriggerType.START}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.MISSION}/${TriggerType.END}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.RECOVERY}/${TriggerType.START}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.RECOVERY}/${TriggerType.END}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.SHIPBUILD}/${TriggerType.START}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.SHIPBUILD}/${TriggerType.END}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.FATIGUE}/${TriggerType.START}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
-    [`/${EntryType.FATIGUE}/${TriggerType.END}`]: {
-      enabled: true,
-      sound: null,
-      icon: null,
-      stay: false,
-    },
+    // タイマーEntryを持つ4種別 × [開始, 完了] の設定レコードを直積で生成する。
+    ...Object.fromEntries(
+      TIMER_ENTRY_TYPES.flatMap((type) =>
+        [TriggerType.START, TriggerType.END].map(
+          (trigger): [string, NotificationConfigData] => [
+            NotificationId.configKey(type, trigger),
+            { ...TIMER_NOTIFICATION_DEFAULT },
+          ],
+        ),
+      ),
+    ),
     [QUEST_ALERT_NOTIFICATION_ID]: {
       enabled: true,
       sound: null,
@@ -116,11 +87,11 @@ export class NotificationConfig extends Model {
    * @returns 指定されたIDに対応するNotificationConfigを返す
    */
   public static async get(id: string): Promise<NotificationConfigData> {
-    const [, type, trigger] = id.split("/");
-    const triggerKey = (Object.values(TriggerType) as string[]).includes(trigger ?? "")
-      ? trigger as TriggerType
+    const parsed = NotificationId.parse(id);
+    const triggerKey = (Object.values(TriggerType) as string[]).includes(parsed?.trigger ?? "")
+      ? parsed!.trigger as TriggerType
       : TriggerType.END;
-    const configKey = type ? `/${type}/${triggerKey}` : null;
+    const configKey = parsed ? NotificationId.configKey(parsed.type, triggerKey) : null;
     const config = configKey ? await this.find(configKey) as NotificationConfig | null : null;
     const def = (await this.user(triggerKey))!;
     return {
@@ -129,6 +100,25 @@ export class NotificationConfig extends Model {
       icon: config?.icon ?? def.icon,
       stay: config?.stay ?? def.stay,
     };
+  }
+
+  /**
+   * この設定レコードの _id から type セグメントを取り出す（例: /shipbuild/start → "shipbuild"）。
+   * 解析できない場合は UNKNOWN。
+   */
+  public get type(): string {
+    return NotificationId.parse(this._id ?? "")?.type ?? EntryType.UNKNOWN;
+  }
+
+  /**
+   * この設定レコードの _id から trigger セグメントを取り出す。
+   * TriggerType の値でない場合は END にフォールバックする。
+   */
+  public get trigger(): TriggerType {
+    const trigger = NotificationId.parse(this._id ?? "")?.trigger;
+    return (Object.values(TriggerType) as string[]).includes(trigger ?? "")
+      ? trigger as TriggerType
+      : TriggerType.END;
   }
 
   public static async user(trigger: TriggerType = TriggerType.START): Promise<NotificationConfig> {

--- a/src/models/entry/Fatigue.ts
+++ b/src/models/entry/Fatigue.ts
@@ -1,4 +1,4 @@
-import { TriggerType } from ".";
+import { NotificationId, TriggerType } from ".";
 import { M } from "../../utils";
 import { NotificationConfigData } from "../configs/NotificationConfig";
 import { NotificationEntryBase } from "./Base";
@@ -16,7 +16,7 @@ export class Fatigue extends NotificationEntryBase {
   // 疲労の場合は、STARTはたぶん使わないけど
   override $n = {
     id: (trigger: TriggerType = TriggerType.END): string => {
-      return `/${this.type}/${trigger}/${this.deck}`;
+      return NotificationId.build(this.type, trigger, this.deck);
     },
     options: (
       trigger: TriggerType = TriggerType.END,

--- a/src/models/entry/Mission.ts
+++ b/src/models/entry/Mission.ts
@@ -1,4 +1,4 @@
-import { TriggerType } from ".";
+import { NotificationId, TriggerType } from ".";
 import { MissionSpec } from "../../catalog";
 import { KCWDate } from "../../utils";
 import { NotificationConfigData } from "../configs/NotificationConfig";
@@ -32,7 +32,7 @@ export class Mission extends NotificationEntryBase {
 
   override $n = {
     id: (trigger: TriggerType = TriggerType.END): string => {
-      return `/${this.type}/${trigger}/${this.deck}`;
+      return NotificationId.build(this.type, trigger, this.deck);
     },
     options: (trigger: TriggerType = TriggerType.END, overwrite: Partial<NotificationConfigData> = {}): chrome.notifications.NotificationCreateOptions => {
       if (trigger === TriggerType.START) {

--- a/src/models/entry/NotificationId.ts
+++ b/src/models/entry/NotificationId.ts
@@ -1,0 +1,44 @@
+import { TriggerType } from ".";
+
+// 通知ID /{type}/{trigger}/{target} と設定レコードキー /{type}/{trigger} のコーデック。
+// CLAUDE.md 通知ID規約の単一実装。
+// type は "default"（EntryType.TEST_DEFAULT）や "quest-alert"（EntryType 外の単発通知）も
+// 通すため string で受ける。
+
+export interface ParsedNotificationId {
+  type: string;
+  trigger: string;
+  target?: string;
+}
+
+// 通知ID /{type}/{trigger}/{target} を組み立てる。
+function build(type: string, trigger: TriggerType, target: number | string): string {
+  return `/${type}/${trigger}/${target}`;
+}
+
+// 設定レコードキー /{type}/{trigger} を組み立てる。
+function configKey(type: string, trigger: TriggerType): string {
+  return `/${type}/${trigger}`;
+}
+
+// 通知ID・設定キーを type/trigger/target に分解する。
+// /{type}/{trigger} 未満の形式（先頭が / で始まらない、type または trigger が空）は null を返す。
+// フォールバック判断は呼び出し側の責務とし、ここでは分解できたものを正直に返す。
+function parse(id: string): ParsedNotificationId | null {
+  const [head, type, trigger, target] = id.split("/");
+  if (head !== "" || !type || !trigger) return null;
+  return target === undefined ? { type, trigger } : { type, trigger, target };
+}
+
+// parse 結果に対し、与えた条件（type/trigger/target）だけをセグメント単位で完全一致比較する。
+// 条件に無いセグメントは不問。target を見る/見ないの差はこの optional 条件で表現する。
+function matches(id: string, cond: { type?: string; trigger?: string; target?: string }): boolean {
+  const parsed = parse(id);
+  if (!parsed) return false;
+  if (cond.type !== undefined && parsed.type !== cond.type) return false;
+  if (cond.trigger !== undefined && parsed.trigger !== cond.trigger) return false;
+  if (cond.target !== undefined && parsed.target !== cond.target) return false;
+  return true;
+}
+
+export const NotificationId = { build, configKey, parse, matches };

--- a/src/models/entry/Recovery.ts
+++ b/src/models/entry/Recovery.ts
@@ -1,4 +1,4 @@
-import { TriggerType } from ".";
+import { NotificationId, TriggerType } from ".";
 import { KCWDate } from "../../utils";
 import { NotificationConfigData } from "../configs/NotificationConfig";
 import { NotificationEntryBase } from "./Base";
@@ -14,7 +14,7 @@ export class Recovery extends NotificationEntryBase {
 
   override $n = {
     id: (trigger: TriggerType = TriggerType.END): string => {
-      return `/${this.type}/${trigger}/${this.dock}`;
+      return NotificationId.build(this.type, trigger, this.dock);
     },
     options: (
       trigger: TriggerType = TriggerType.END,

--- a/src/models/entry/Shipbuild.ts
+++ b/src/models/entry/Shipbuild.ts
@@ -1,4 +1,4 @@
-import { TriggerType } from ".";
+import { NotificationId, TriggerType } from ".";
 import { KCWDate } from "../../utils";
 import { NotificationConfigData } from "../configs/NotificationConfig";
 import { NotificationEntryBase } from "./Base";
@@ -12,7 +12,7 @@ export class Shipbuild extends NotificationEntryBase {
 
   override $n = {
     id: (trigger: TriggerType = TriggerType.END): string => {
-      return `/${this.type}/${trigger}/${this.dock}`;
+      return NotificationId.build(this.type, trigger, this.dock);
     },
     options: (
       trigger: TriggerType = TriggerType.END,

--- a/src/models/entry/index.ts
+++ b/src/models/entry/index.ts
@@ -13,6 +13,12 @@ export enum EntryType {
     TEST_DEFAULT = "default",
 }
 
+// EntryType ごとに、スロット番号（艦隊/ドック）を保持する params のキーを返す。
+// 修復・建造はドック(dock)、それ以外（遠征・疲労）は艦隊(deck)を使う。
+export function slotKey(type: EntryType): "dock" | "deck" {
+  return type === EntryType.RECOVERY || type === EntryType.SHIPBUILD ? "dock" : "deck";
+}
+
 export enum TriggerType {
   START = "start",
   END = "end",

--- a/src/models/entry/index.ts
+++ b/src/models/entry/index.ts
@@ -25,4 +25,14 @@ export enum TriggerType {
   UNKNOWN = "unknown",
 }
 
+// タイマーQueueのEntryを持つ種別。通知設定レコードの直積生成にも使う。
+export const TIMER_ENTRY_TYPES = [
+  EntryType.MISSION,
+  EntryType.RECOVERY,
+  EntryType.SHIPBUILD,
+  EntryType.FATIGUE,
+] as const;
+
 export { Mission, Recovery, Shipbuild, Fatigue };
+export { NotificationId } from "./NotificationId";
+export type { ParsedNotificationId } from "./NotificationId";

--- a/src/page/components/dashboard/CustomQueueModal.tsx
+++ b/src/page/components/dashboard/CustomQueueModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Queue from "../../../models/Queue";
-import { EntryType } from "../../../models/entry";
+import { EntryType, slotKey } from "../../../models/entry";
 import { ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
 import { H, M } from "../../../utils";
 
@@ -65,10 +65,15 @@ export function CustomQueueModal({
           <label>種別</label>
           <select defaultValue={queue.type} className={`kcw-custom-queue-select kcw-${queue.type} flex-1 rounded-md`}
             onChange={e => {
+              const prev = slotKey(queue.type);
               queue.type = e.target.value as EntryType;
-              // API傍受で作られたQueueは deck / dock の一方しか持たないため、種別切替時にもう一方へ引き継ぐ
-              queue.params["deck"] ??= queue.params["dock"];
-              queue.params["dock"] ??= queue.params["deck"];
+              const next = slotKey(queue.type);
+              // 種別変更でスロットのキー（deck/dock）が変わる場合は値を移し替える
+              if (next !== prev) {
+                const slot = queue.params[prev];
+                delete queue.params[prev];
+                if (slot !== undefined) queue.params[next] = slot;
+              }
               update(queue);
             }}
           >
@@ -79,10 +84,10 @@ export function CustomQueueModal({
           </select>
         </div>
         <div className="flex space-x-2">
-          <label>{[EntryType.RECOVERY, EntryType.SHIPBUILD].includes(queue.type) ? "ドック" : "艦隊"}</label>
-          <select defaultValue={queue.params["deck"] || queue.params["dock"]} className="flex-1 rounded-md bg-slate-100"
+          <label>{slotKey(queue.type) === "dock" ? "ドック" : "艦隊"}</label>
+          <select defaultValue={queue.params[slotKey(queue.type)]} className="flex-1 rounded-md bg-slate-100"
             onChange={e => {
-              queue.params[[EntryType.RECOVERY, EntryType.SHIPBUILD].includes(queue.type) ? "dock" : "deck"] = e.target.value;
+              queue.params[slotKey(queue.type)] = e.target.value;
               update(queue);
             }}
           >

--- a/src/page/components/dashboard/QueuesView.tsx
+++ b/src/page/components/dashboard/QueuesView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { EntryType, Fatigue, Mission, Recovery, Shipbuild } from "../../../models/entry";
+import { EntryType, slotKey } from "../../../models/entry";
 import { missions } from "../../../catalog";
 import { ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
 import Queue from "../../../models/Queue";
@@ -18,7 +18,7 @@ function QueueItemView({
   if (!queue) {
     // 手動登録はカタログの遠征ID 0「マニュアル登録されたやつ」として名前を持たせる
     return <div className="flex text-gray-400 cursor-pointer"
-      onClick={() => edit(Queue.new({ type, scheduled: Date.now(), params: { deck: index + 1, dock: index + 1, id: 0, title: missions["0"].title } }))}>
+      onClick={() => edit(Queue.new({ type, scheduled: Date.now(), params: { [slotKey(type)]: index + 1, id: 0, title: missions["0"].title } }))}>
       <div className="mr-1">第{index + 1}{label}</div>
       <div>--:--</div>
     </div>
@@ -39,13 +39,18 @@ function QueueTableView({
   queues: Queue[],
   edit: (q: Queue | null) => void,
 }) {
+  const slots = (type: EntryType): (Queue | null)[] =>
+    queues.filter(q => q.type === type).reduce<(Queue | null)[]>((acc, q) => {
+      acc[Number(q.slot ?? 1) - 1] = q;
+      return acc;
+    }, new Array(4).fill(null));
   const table: { [key in EntryType]: (Queue | null)[] } = {
-    mission: queues.filter(q => q.type === "mission").reduce((acc, q) => { const entry = q.entry<Mission>(); acc[Number(entry.deck ?? 1) - 1] = q; return acc }, new Array(4).fill(null)),
-    recovery: queues.filter(q => q.type === "recovery").reduce((acc, q) => { const entry = q.entry<Recovery>(); acc[Number(entry.dock ?? 1) - 1] = q; return acc }, new Array(4).fill(null)),
-    shipbuild: queues.filter(q => q.type === "shipbuild").reduce((acc, q) => { const entry = q.entry<Shipbuild>(); acc[Number(entry.dock ?? 1) - 1] = q; return acc }, new Array(4).fill(null)),
-    fatigue: queues.filter(q => q.type === "fatigue").reduce((acc, q) => { const entry = q.entry<Fatigue>(); acc[Number(entry.deck ?? 1) - 1] = q; return acc }, new Array(4).fill(null)),
-    "unknown": [],
-    "default": [],
+    mission: slots(EntryType.MISSION),
+    recovery: slots(EntryType.RECOVERY),
+    shipbuild: slots(EntryType.SHIPBUILD),
+    fatigue: slots(EntryType.FATIGUE),
+    unknown: [],
+    default: [],
   }
   return (
     <div className="flex space-x-4">

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,5 +1,5 @@
 import { NotificationConfig, NotificationConfigData } from "../models/configs/NotificationConfig";
-import { Entry, TriggerType } from "../models/entry";
+import { Entry, NotificationId, TriggerType } from "../models/entry";
 import { SoundPlayer } from "./SoundService";
 
 export class NotificationService {
@@ -23,6 +23,15 @@ export class NotificationService {
 
   public clear(id: string): Promise<boolean> {
     return new Promise((resolve) => this.mod.clear(id, (wasCleared) => resolve(wasCleared)));
+  }
+
+  // 表示中の通知のうち条件に一致するものをすべて消す。
+  // 通知IDは /{type}/{trigger}/{target} 形式で、NotificationId.matches でセグメント照合する。
+  public async clearBy(cond: { type: string; trigger?: TriggerType; target?: string }): Promise<void> {
+    const all = await this.getAll();
+    for (const id of Object.keys(all)) {
+      if (NotificationId.matches(id, cond)) await this.clear(id);
+    }
   }
 
   public create(id: string, options: chrome.notifications.NotificationCreateOptions): Promise<string> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,6 +72,17 @@ export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// "h:m:s" 形式の時刻文字列をミリ秒に換算する（OCR結果の時刻パース用）。
+// 時刻として解釈できない場合は null。Number("") が 0 になる罠を避けるため正規表現で形式を固定し、
+// 分・秒の範囲外も弾く。呼び出し側は null のとき Queue を作ってはいけない。
+export function parseHMS(text: string): number | null {
+  const matched = text.trim().match(/^(\d+):(\d+):(\d+)$/);
+  if (!matched) return null;
+  const [h, m, s] = matched.slice(1).map(Number);
+  if (m > 59 || s > 59) return null;
+  return h * H + m * M + s * S;
+}
+
 export {
   S, M, H, D
 }

--- a/tests/battle-start-handlers.spec.ts
+++ b/tests/battle-start-handlers.spec.ts
@@ -1,0 +1,66 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// kcsapi.ts の import 連鎖が chrome.tabs / chrome.runtime を参照するため、import より前にスタブする
+const { sendMessage } = vi.hoisted(() => ({ sendMessage: vi.fn() }));
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+    tabs: { sendMessage },
+  };
+});
+
+const { start, midnight } = vi.hoisted(() => ({ start: vi.fn(), midnight: vi.fn() }));
+vi.mock("../src/models/Logbook", () => ({ Logbook: { sortie: { battle: { start, midnight } } } }));
+
+const { damageSnapshotUser } = vi.hoisted(() => ({ damageSnapshotUser: vi.fn() }));
+vi.mock("../src/models/configs/DamageSnapshotConfig", () => ({
+  DamageSnapshotConfig: { user: damageSnapshotUser },
+}));
+
+import {
+  onBattleStarted,
+  onCombinedBattleStarted,
+  onSpMidnightBattleStarted,
+} from "../src/controllers/WebRequest/kcsapi";
+
+// ハンドラに渡す webRequest details の最小構成。formData を省略すると requestBody 欠落を表す
+const details = (formData?: Record<string, string[]>) =>
+  [{
+    tabId: 1,
+    frameId: 0,
+    requestBody: formData ? { formData } : undefined,
+  }] as unknown as chrome.webRequest.OnBeforeRequestDetails[];
+
+describe("戦闘開始系ハンドラ", () => {
+  beforeEach(() => {
+    start.mockClear();
+    midnight.mockClear();
+    sendMessage.mockClear();
+    damageSnapshotUser.mockReset();
+    damageSnapshotUser.mockResolvedValue({ keepUntilNextShow: false });
+  });
+
+  it("onBattleStarted: 陣形付きでLogbookに戦闘開始を記録する", async () => {
+    await onBattleStarted(details({ api_formation: ["1"] }));
+    expect(start).toHaveBeenCalledWith("1");
+    expect(midnight).not.toHaveBeenCalled();
+  });
+
+  it("onSpMidnightBattleStarted: 戦闘開始を記録した後に夜戦フラグを立てる", async () => {
+    await onSpMidnightBattleStarted(details({ api_formation: ["2"] }));
+    expect(start).toHaveBeenCalledWith("2");
+    expect(midnight).toHaveBeenCalledTimes(1);
+  });
+
+  it("onCombinedBattleStarted: formData欠落時は空文字でstartを呼び、例外にならない", async () => {
+    await expect(onCombinedBattleStarted(details())).resolves.not.toThrow();
+    expect(start).toHaveBeenCalledWith("");
+  });
+
+  it("keepUntilNextShowが有効なとき、大破進撃防止窓の除去メッセージを送らない", async () => {
+    damageSnapshotUser.mockResolvedValue({ keepUntilNextShow: true });
+    await onBattleStarted(details({ api_formation: ["1"] }));
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/battle-start-handlers.spec.ts
+++ b/tests/battle-start-handlers.spec.ts
@@ -10,8 +10,8 @@ vi.hoisted(() => {
   };
 });
 
-const { start, midnight } = vi.hoisted(() => ({ start: vi.fn(), midnight: vi.fn() }));
-vi.mock("../src/models/Logbook", () => ({ Logbook: { sortie: { battle: { start, midnight } } } }));
+const { start, midnight, next } = vi.hoisted(() => ({ start: vi.fn(), midnight: vi.fn(), next: vi.fn() }));
+vi.mock("../src/models/Logbook", () => ({ Logbook: { sortie: { battle: { start, midnight }, next } } }));
 
 const { damageSnapshotUser } = vi.hoisted(() => ({ damageSnapshotUser: vi.fn() }));
 vi.mock("../src/models/configs/DamageSnapshotConfig", () => ({
@@ -22,6 +22,7 @@ import {
   onBattleStarted,
   onCombinedBattleStarted,
   onSpMidnightBattleStarted,
+  onMapNext,
 } from "../src/controllers/WebRequest/kcsapi";
 
 // ハンドラに渡す webRequest details の最小構成。formData を省略すると requestBody 欠落を表す
@@ -62,5 +63,28 @@ describe("戦闘開始系ハンドラ", () => {
     damageSnapshotUser.mockResolvedValue({ keepUntilNextShow: true });
     await onBattleStarted(details({ api_formation: ["1"] }));
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// マップ移動時のマスID記録。api_cell_id はゲーム側の都合で欠落することがあるため、
+// 欠落時は Logbook に記録せず警告のみで抜ける契約を検証する。
+describe("onMapNext", () => {
+  beforeEach(() => {
+    next.mockClear();
+  });
+
+  it("api_cell_id があれば Logbook にマス移動を記録する", async () => {
+    await onMapNext(details({ api_cell_id: ["5"] }));
+    expect(next).toHaveBeenCalledWith("5");
+  });
+
+  it("api_cell_id が欠落していれば記録しない", async () => {
+    await onMapNext(details({ api_recovery_type: ["0"] }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("requestBody が欠落していても例外にならない", async () => {
+    await expect(onMapNext(details())).resolves.not.toThrow();
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/tests/custom-queue-modal.spec.tsx
+++ b/tests/custom-queue-modal.spec.tsx
@@ -60,14 +60,15 @@ describe("CustomQueueModal (split)", () => {
   });
 });
 
-// 種別切替: params のスロットキー（deck / dock）の引き継ぎ。
+// 種別切替: params のスロットキー（deck / dock）の移し替え（旧キーは残さない）。
 describe("CustomQueueModal 種別切替", () => {
-  it("dock しか持たないQueue（API傍受由来）を遠征へ切り替えると deck に引き継がれる", () => {
+  it("dock しか持たないQueue（API傍受由来）を遠征へ切り替えると deck に移し替えられる", () => {
     const queue = Queue.new({ type: EntryType.RECOVERY, scheduled: Date.now(), params: { dock: 3 } });
     render(<CustomQueueModal queue={queue} close={() => {}} update={() => {}} />);
     const [typeSelect] = screen.getAllByRole("combobox");
     fireEvent.change(typeSelect, { target: { value: EntryType.MISSION } });
     expect(queue.params["deck"]).toBe(3);
+    expect(queue.params["dock"]).toBeUndefined();
   });
 });
 

--- a/tests/entry-slot-key.spec.ts
+++ b/tests/entry-slot-key.spec.ts
@@ -1,0 +1,37 @@
+import { expect, describe, it, vi } from "vitest";
+
+// jstorm の Model が chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = { runtime: { getURL: (p: string) => p } };
+});
+
+import Queue from "../src/models/Queue";
+import { EntryType, slotKey } from "../src/models/entry";
+
+// EntryType ごとに、スロット番号（艦隊/ドック）を保持する params のキーが
+// 規約（修復・建造は dock、それ以外は deck）どおりに決まることを検証する。
+describe("slotKey", () => {
+  it.each([
+    [EntryType.MISSION, "deck"],
+    [EntryType.FATIGUE, "deck"],
+    [EntryType.RECOVERY, "dock"],
+    [EntryType.SHIPBUILD, "dock"],
+    [EntryType.UNKNOWN, "deck"],
+  ] as const)("%s → %s", (type, expected) => {
+    expect(slotKey(type)).toBe(expected);
+  });
+});
+
+// Queue#slot は type に応じた規約キーで params からスロット値を取り出す。
+describe("Queue#slot", () => {
+  it("params に規約キーの値があればそれを返す", () => {
+    const queue = Queue.new({ type: EntryType.RECOVERY, params: { dock: 3 } });
+    expect(queue.slot).toBe(3);
+  });
+
+  it("規約キーが無ければ undefined を返す", () => {
+    const queue = Queue.new({ type: EntryType.RECOVERY, params: { deck: 2 } });
+    expect(queue.slot).toBeUndefined();
+  });
+});

--- a/tests/notification-clear-on-recovery.spec.ts
+++ b/tests/notification-clear-on-recovery.spec.ts
@@ -26,6 +26,9 @@ const displaying = (ids: string[]) => {
   getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
     cb(Object.fromEntries(ids.map((id) => [id, true])));
   });
+  // clearBy は NotificationService.clear（コールバックを Promise 解決に使う）経由で消すため、
+  // コールバックを呼ばないと await が解決せずテストがタイムアウトする。
+  clear.mockImplementation((_id: string, cb?: (wasCleared: boolean) => void) => cb?.(true));
 };
 
 const clearedIds = () => clear.mock.calls.map(([id]) => id);

--- a/tests/notification-config-default.spec.ts
+++ b/tests/notification-config-default.spec.ts
@@ -1,0 +1,67 @@
+import { expect, describe, it, vi } from "vitest";
+
+// NotificationConfig は static default の初期化で chrome.runtime.getURL を参照するため、
+// import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+});
+
+import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+
+// static default のキー集合は jstorm の find() フォールバックの根拠となる。1文字でも欠けると
+// 保存済み設定が読めなくなるため、直積生成の結果を固定キー集合として検証する。
+describe("NotificationConfig.default のキー集合", () => {
+  it("/default/{start,end} + 4種別×2 + /quest-alert/start の11キーちょうどを持つ", () => {
+    const keys = Object.keys(NotificationConfig.default!).sort();
+    expect(keys).toEqual([
+      "/default/end",
+      "/default/start",
+      "/fatigue/end",
+      "/fatigue/start",
+      "/mission/end",
+      "/mission/start",
+      "/quest-alert/start",
+      "/recovery/end",
+      "/recovery/start",
+      "/shipbuild/end",
+      "/shipbuild/start",
+    ]);
+  });
+
+  it("直積で生成した各レコードは共有参照でなく独立オブジェクトである", () => {
+    const def = NotificationConfig.default!;
+    expect(def["/mission/start"]).not.toBe(def["/mission/end"]);
+    expect(def["/mission/start"]).not.toBe(def["/recovery/start"]);
+    expect(def["/mission/start"]).toEqual({ enabled: true, sound: null, icon: null, stay: false });
+  });
+});
+
+// get() は id をパースして設定を引くが、trigger が不正なときは END に、type を解析できないときは
+// default のみにフォールバックする。この挙動を保つことを検証する。
+describe("NotificationConfig.get のフォールバック", () => {
+  it("trigger が TriggerType 外なら END の設定を引く", async () => {
+    // /mission/end だけに区別可能な値(stay:true)を保存し、END 経由で引かれることを確認する
+    await NotificationConfig.new({ enabled: true, sound: null, icon: null, stay: true }, "/mission/end").save();
+
+    const bogus = await NotificationConfig.get("/mission/bogus/2");
+    expect(bogus.stay).toBe(true); // END の /mission/end を引いた
+
+    const start = await NotificationConfig.get("/mission/start/2");
+    expect(start.stay).toBe(false); // START はデフォルトのまま
+  });
+
+  it("2セグメントの設定キーIDもそのまま引ける", async () => {
+    const config = await NotificationConfig.get("/quest-alert/start");
+    expect(config.enabled).toBe(true);
+  });
+
+  it("パースできないIDでは default（END）のみを参照して落ちない", async () => {
+    const config = await NotificationConfig.get("");
+    expect(config.enabled).toBe(true);
+    // /default/end のアイコン（getURL 由来）にフォールバックする
+    expect(config.icon).toBe("chrome-extension://test/icons/128.png");
+  });
+});

--- a/tests/notification-config-getters.spec.ts
+++ b/tests/notification-config-getters.spec.ts
@@ -1,0 +1,41 @@
+import { expect, describe, it, vi } from "vitest";
+
+// NotificationConfig は static default の初期化で chrome.runtime.getURL を参照するため、
+// import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+});
+
+import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+import { EntryType, TriggerType } from "../src/models/entry";
+
+// 設定レコードの _id から type / trigger セグメントを取り出す getter の契約を検証する。
+// ビュー側はこの getter に依存して _id の分解知識を持たない設計のため、
+// フォールバック（解析不能→UNKNOWN / trigger 不正→END）も含めて固定する。
+describe("NotificationConfig の type / trigger getter", () => {
+  it("設定キー形式の _id から type と trigger を取り出す", () => {
+    const config = NotificationConfig.new({}, "/shipbuild/start");
+    expect(config.type).toBe(EntryType.SHIPBUILD);
+    expect(config.trigger).toBe(TriggerType.START);
+  });
+
+  it("EntryType 外の type セグメント（quest-alert）もそのまま返す", () => {
+    const config = NotificationConfig.new({}, "/quest-alert/start");
+    expect(config.type).toBe("quest-alert");
+    expect(config.trigger).toBe(TriggerType.START);
+  });
+
+  it("解析できない _id では type は UNKNOWN、trigger は END にフォールバックする", () => {
+    const config = NotificationConfig.new({});
+    expect(config.type).toBe(EntryType.UNKNOWN);
+    expect(config.trigger).toBe(TriggerType.END);
+  });
+
+  it("trigger セグメントが TriggerType 外の値なら END にフォールバックする", () => {
+    const config = NotificationConfig.new({}, "/mission/bogus");
+    expect(config.trigger).toBe(TriggerType.END);
+  });
+});

--- a/tests/notification-id-codec.spec.ts
+++ b/tests/notification-id-codec.spec.ts
@@ -1,0 +1,89 @@
+import { expect, describe, it } from "vitest";
+
+import { missions } from "../src/catalog";
+import { Fatigue, Mission, NotificationId, Recovery, Shipbuild, TriggerType } from "../src/models/entry";
+
+// NotificationId は通知ID /{type}/{trigger}/{target} と設定キー /{type}/{trigger} の唯一のコーデック。
+// 生成文字列は保存済み設定・表示中の通知の照合に使われるため、byte 単位で契約を固定する。
+describe("NotificationId コーデック", () => {
+  describe("build", () => {
+    it("通知ID /{type}/{trigger}/{target} を組み立てる", () => {
+      expect(NotificationId.build("mission", TriggerType.END, "2")).toBe("/mission/end/2");
+      expect(NotificationId.build("shipbuild", TriggerType.START, 3)).toBe("/shipbuild/start/3");
+    });
+
+    it("各 entry クラスの $n.id と byte 同一の文字列を返す", () => {
+      const mission = new Mission("2", 5, missions["5"]);
+      expect(NotificationId.build("mission", TriggerType.START, "2")).toBe(mission.$n.id(TriggerType.START));
+      expect(NotificationId.build("mission", TriggerType.END, "2")).toBe(mission.$n.id(TriggerType.END));
+
+      const recovery = new Recovery(1, 0);
+      expect(NotificationId.build("recovery", TriggerType.END, 1)).toBe(recovery.$n.id(TriggerType.END));
+
+      const shipbuild = new Shipbuild(3, 0);
+      expect(NotificationId.build("shipbuild", TriggerType.END, 3)).toBe(shipbuild.$n.id(TriggerType.END));
+
+      const fatigue = new Fatigue(4, { area: 1, info: 1 });
+      expect(NotificationId.build("fatigue", TriggerType.END, 4)).toBe(fatigue.$n.id(TriggerType.END));
+    });
+  });
+
+  describe("configKey", () => {
+    it("設定レコードキー /{type}/{trigger} を byte 同一で組み立てる", () => {
+      expect(NotificationId.configKey("mission", TriggerType.START)).toBe("/mission/start");
+      expect(NotificationId.configKey("fatigue", TriggerType.END)).toBe("/fatigue/end");
+      // EntryType 外のキーも通す
+      expect(NotificationId.configKey("default", TriggerType.END)).toBe("/default/end");
+      expect(NotificationId.configKey("quest-alert", TriggerType.START)).toBe("/quest-alert/start");
+    });
+  });
+
+  describe("parse", () => {
+    it("通知ID（3セグメント）を type/trigger/target に分解する", () => {
+      expect(NotificationId.parse("/mission/end/2")).toEqual({ type: "mission", trigger: "end", target: "2" });
+    });
+
+    it("設定キー（2セグメント）は target を持たない", () => {
+      expect(NotificationId.parse("/quest-alert/start")).toEqual({ type: "quest-alert", trigger: "start" });
+      expect(NotificationId.parse("/default/end")).toEqual({ type: "default", trigger: "end" });
+    });
+
+    it("build の結果を parse で往復できる", () => {
+      const id = NotificationId.build("mission", TriggerType.END, "2");
+      expect(NotificationId.parse(id)).toEqual({ type: "mission", trigger: "end", target: "2" });
+    });
+
+    it("/{type}/{trigger} 未満の不正な形式は null", () => {
+      expect(NotificationId.parse("")).toBeNull();
+      expect(NotificationId.parse("/")).toBeNull();
+      expect(NotificationId.parse("/mission")).toBeNull(); // trigger が無い
+      expect(NotificationId.parse("mission/end")).toBeNull(); // 先頭が / で始まらない
+      expect(NotificationId.parse("//end")).toBeNull(); // type が空
+    });
+  });
+
+  describe("matches", () => {
+    it("type だけの条件は type セグメントの一致で判定する", () => {
+      expect(NotificationId.matches("/recovery/start/1", { type: "recovery" })).toBe(true);
+      expect(NotificationId.matches("/recovery/end/2", { type: "recovery" })).toBe(true);
+      expect(NotificationId.matches("/mission/start/1", { type: "recovery" })).toBe(false);
+    });
+
+    it("type と target の条件は両セグメントの一致で判定する（trigger は不問）", () => {
+      expect(NotificationId.matches("/mission/end/2", { type: "mission", target: "2" })).toBe(true);
+      expect(NotificationId.matches("/mission/start/2", { type: "mission", target: "2" })).toBe(true);
+      expect(NotificationId.matches("/mission/end/3", { type: "mission", target: "2" })).toBe(false);
+    });
+
+    it("target はセグメント完全一致で、部分一致では誤マッチしない", () => {
+      // target "1" が "/mission/end/11" に誤マッチしないこと
+      expect(NotificationId.matches("/mission/end/11", { type: "mission", target: "1" })).toBe(false);
+      expect(NotificationId.matches("/mission/end/1", { type: "mission", target: "1" })).toBe(true);
+    });
+
+    it("不正な形式の通知IDにはどの条件でも一致しない", () => {
+      expect(NotificationId.matches("/mission", { type: "mission" })).toBe(false);
+      expect(NotificationId.matches("", { type: "mission" })).toBe(false);
+    });
+  });
+});

--- a/tests/notification-service-clearby.spec.ts
+++ b/tests/notification-service-clearby.spec.ts
@@ -1,0 +1,76 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// NotificationService が chrome.notifications / chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+    notifications: {
+      getAll: vi.fn(),
+      clear: vi.fn(),
+    },
+  };
+});
+
+import { NotificationService } from "../src/services/NotificationService";
+import { EntryType, TriggerType } from "../src/models/entry";
+
+const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
+const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
+
+// 表示中の通知IDを与えてスタブを構成する（どちらもコールバック形式のAPI）
+const displaying = (ids: string[]) => {
+  getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
+    cb(Object.fromEntries(ids.map((id) => [id, true])));
+  });
+  clear.mockImplementation((_id: string, cb?: (wasCleared: boolean) => void) => cb?.(true));
+};
+
+const clearedIds = () => clear.mock.calls.map(([id]) => id).sort();
+
+// clearBy は表示中の通知を走査し、NotificationId.matches の条件に一致するものだけを消す。
+// 条件の粒度（type のみ / type+trigger / type+target）で絞り込みが変わることを検証する。
+describe("NotificationService.clearBy による通知の絞り込み消去", () => {
+  beforeEach(() => {
+    getAll.mockReset();
+    clear.mockReset();
+  });
+
+  it("type と target を指定すると、そのドックの開始・完了通知だけを消し他は残す", async () => {
+    displaying([
+      "/recovery/start/2",
+      "/recovery/end/2",
+      "/recovery/start/1",
+      "/mission/end/2",
+    ]);
+    await NotificationService.new().clearBy({ type: EntryType.RECOVERY, target: "2" });
+    expect(clearedIds()).toEqual(["/recovery/end/2", "/recovery/start/2"]);
+  });
+
+  it("target を 1 にしても /recovery/start/11 のような部分一致は消さない", async () => {
+    displaying(["/recovery/start/1", "/recovery/start/11"]);
+    await NotificationService.new().clearBy({ type: EntryType.RECOVERY, target: "1" });
+    expect(clearedIds()).toEqual(["/recovery/start/1"]);
+  });
+
+  it("type と trigger を指定すると、その種別の完了通知だけを消す（開始通知は残す）", async () => {
+    displaying([
+      "/recovery/start/1",
+      "/recovery/end/1",
+      "/recovery/end/2",
+      "/mission/end/1",
+    ]);
+    await NotificationService.new().clearBy({ type: EntryType.RECOVERY, trigger: TriggerType.END });
+    expect(clearedIds()).toEqual(["/recovery/end/1", "/recovery/end/2"]);
+  });
+
+  it("type だけを指定すると、その種別の通知を全トリガー・全対象で消す", async () => {
+    displaying([
+      "/mission/start/2",
+      "/mission/end/2",
+      "/recovery/end/2",
+    ]);
+    await NotificationService.new().clearBy({ type: EntryType.MISSION });
+    expect(clearedIds()).toEqual(["/mission/end/2", "/mission/start/2"]);
+  });
+});

--- a/tests/queue-dedupe-on-speedchange-and-start.spec.ts
+++ b/tests/queue-dedupe-on-speedchange-and-start.spec.ts
@@ -16,13 +16,14 @@ const { deleteSlot, create, restack } = vi.hoisted(() => ({
 }));
 vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create, restack } }));
 
-const { notify, clear, getAll } = vi.hoisted(() => ({
+const { notify, clear, getAll, clearBy } = vi.hoisted(() => ({
   notify: vi.fn().mockResolvedValue(""),
   clear: vi.fn().mockResolvedValue(true),
   getAll: vi.fn().mockResolvedValue({}),
+  clearBy: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("../src/services/NotificationService", () => ({
-  NotificationService: { new: () => ({ notify, clear, getAll }) },
+  NotificationService: { new: () => ({ notify, clear, getAll, clearBy }) },
 }));
 
 vi.mock("../src/models/Logbook", () => ({ Logbook: { sortie: { start: vi.fn() } } }));
@@ -35,6 +36,7 @@ vi.mock("../src/catalog", () => ({
 }));
 
 import { onRecoveryHighspeed, onShipbuildHighspeed, onMissionStart, onMapStart } from "../src/controllers/WebRequest/kcsapi";
+import { EntryType } from "../src/models/entry";
 
 // ハンドラに渡す webRequest details の最小構成
 const details = (formData: Record<string, string[]>) =>
@@ -45,6 +47,7 @@ describe("修復・建造の高速化剤使用(speedchange)検知", () => {
     deleteSlot.mockClear();
     clear.mockClear();
     getAll.mockClear();
+    clearBy.mockClear();
   });
 
   it("onRecoveryHighspeed: 対象ドックの修復Queueを削除する", async () => {
@@ -54,16 +57,12 @@ describe("修復・建造の高速化剤使用(speedchange)検知", () => {
   });
 
   // speedchange 経路では完了通知が出ない（QueueWatcherを通らない）ため、
-  // 表示中の修復通知（開始・完了）の掃除もこのハンドラが担う
-  it("onRecoveryHighspeed: 対象ドックの表示中の修復通知を消し、他は消さない", async () => {
-    getAll.mockResolvedValueOnce({
-      "/recovery/start/2": true,
-      "/recovery/end/2": true,
-      "/recovery/start/1": true,
-      "/mission/end/2": true,
-    });
+  // 表示中の修復通知（開始・完了）の掃除もこのハンドラが担う。ここではハンドラが
+  // 正しい条件（対象ドックの全トリガー）で clearBy を呼ぶことだけを検証し、
+  // 「一致するものだけ消し他を残す」具体挙動は NotificationService.clearBy の単体テストで担保する。
+  it("onRecoveryHighspeed: 対象ドックの修復通知を clearBy で消す", async () => {
     await onRecoveryHighspeed(details({ api_ndock_id: ["2"] }));
-    expect(clear.mock.calls.map(([id]) => id).sort()).toEqual(["/recovery/end/2", "/recovery/start/2"]);
+    expect(clearBy).toHaveBeenCalledWith({ type: EntryType.RECOVERY, target: "2" });
   });
 
   it("onShipbuildHighspeed: 対象ドックの建造Queueを削除する", async () => {

--- a/tests/queue-dedupe-on-speedchange-and-start.spec.ts
+++ b/tests/queue-dedupe-on-speedchange-and-start.spec.ts
@@ -9,11 +9,12 @@ vi.hoisted(() => {
   };
 });
 
-const { deleteSlot, create } = vi.hoisted(() => ({
+const { deleteSlot, create, restack } = vi.hoisted(() => ({
   deleteSlot: vi.fn().mockResolvedValue(undefined),
   create: vi.fn().mockResolvedValue({ entry: () => ({}) }),
+  restack: vi.fn().mockResolvedValue({ entry: () => ({}) }),
 }));
-vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create } }));
+vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create, restack } }));
 
 const { notify, clear, getAll } = vi.hoisted(() => ({
   notify: vi.fn().mockResolvedValue(""),
@@ -74,17 +75,14 @@ describe("修復・建造の高速化剤使用(speedchange)検知", () => {
 
 describe("遠征開始時の重複排除", () => {
   beforeEach(() => {
-    deleteSlot.mockClear();
-    create.mockClear();
+    restack.mockClear();
   });
 
+  // 削除→作成の順序保証はモデル層(Queue.restack)の契約になったため、ここでは
+  // コントローラが正しい type/slot で restack を呼ぶことだけを検証する（tests/queue-restack.spec.ts参照）。
   it("onMissionStart: 同じ艦隊の既存Queueを削除してから積み直す", async () => {
     await onMissionStart(details({ api_deck_id: ["4"], api_mission_id: ["999"], api_mission: ["93"] }));
-    expect(deleteSlot).toHaveBeenCalledWith("mission", "4");
-    // 削除は新規作成より前に行う（作成後に削除すると新しいQueueごと消える恐れがあるため）
-    const deleteOrder = deleteSlot.mock.invocationCallOrder[0];
-    const createOrder = create.mock.invocationCallOrder[0];
-    expect(deleteOrder).toBeLessThan(createOrder);
+    expect(restack).toHaveBeenCalledWith("mission", "4", expect.anything(), expect.any(Number));
   });
 });
 
@@ -92,6 +90,7 @@ describe("カタログ未収録の遠征ID", () => {
   beforeEach(() => {
     deleteSlot.mockClear();
     create.mockClear();
+    restack.mockClear();
     notify.mockClear();
   });
 
@@ -99,28 +98,30 @@ describe("カタログ未収録の遠征ID", () => {
     await onMissionStart(details({ api_deck_id: ["2"], api_mission_id: ["123"], api_mission: ["93"] }));
     expect(deleteSlot).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
+    expect(restack).not.toHaveBeenCalled();
     expect(notify).not.toHaveBeenCalled();
   });
 });
 
 describe("疲労Queueの積み直し設定(restackFatigueOnSortie)", () => {
   beforeEach(() => {
-    deleteSlot.mockClear();
     create.mockClear();
+    restack.mockClear();
     behaviorUser.mockReset();
   });
 
   const mapStartDetails = () => details({ api_deck_id: ["1"], api_maparea_id: ["1"], api_mapinfo_no: ["1"] });
 
-  it("設定が有効なら同じ艦隊の既存の疲労Queueを削除する", async () => {
+  it("設定が有効なら同じ艦隊の既存の疲労Queueを削除して積み直す", async () => {
     behaviorUser.mockResolvedValue({ restackFatigueOnSortie: true });
     await onMapStart(mapStartDetails());
-    expect(deleteSlot).toHaveBeenCalledWith("fatigue", 1);
+    expect(restack).toHaveBeenCalledWith("fatigue", 1, expect.anything(), expect.any(Number));
   });
 
   it("設定が無効なら既存の疲労Queueを削除しない（出撃ごとに積み上がる仕様）", async () => {
     behaviorUser.mockResolvedValue({ restackFatigueOnSortie: false });
     await onMapStart(mapStartDetails());
-    expect(deleteSlot).not.toHaveBeenCalled();
+    expect(restack).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/queue-dedupe-on-speedchange-and-start.spec.ts
+++ b/tests/queue-dedupe-on-speedchange-and-start.spec.ts
@@ -84,6 +84,11 @@ describe("遠征開始時の重複排除", () => {
     await onMissionStart(details({ api_deck_id: ["4"], api_mission_id: ["999"], api_mission: ["93"] }));
     expect(restack).toHaveBeenCalledWith("mission", "4", expect.anything(), expect.any(Number));
   });
+
+  it("onMissionStart: requestBodyが欠落していても例外を投げず、restackを呼ばない", async () => {
+    await expect(onMissionStart([{ requestBody: undefined }] as unknown as chrome.webRequest.OnBeforeRequestDetails[])).resolves.not.toThrow();
+    expect(restack).not.toHaveBeenCalled();
+  });
 });
 
 describe("カタログ未収録の遠征ID", () => {

--- a/tests/queue-delete-slot.spec.ts
+++ b/tests/queue-delete-slot.spec.ts
@@ -9,12 +9,12 @@ vi.hoisted(() => {
 import Queue from "../src/models/Queue";
 import { EntryType } from "../src/models/entry";
 
-// Queue.deleteSlot が読む entry() の戻り値だけを持つ疑似Queue
-const fakeQueue = (type: EntryType, key: "dock" | "deck", slot: string | number) => ({
-  type,
-  entry: () => ({ [key]: slot }),
-  delete: vi.fn().mockResolvedValue(undefined),
-});
+// Queue.deleteSlot の判定対象となる type と params だけを持つ Queue
+const fakeQueue = (type: EntryType, key: "dock" | "deck", slot: string | number) => {
+  const q = Queue.new({ type, params: { [key]: slot } });
+  vi.spyOn(q, "delete").mockResolvedValue(undefined);
+  return q;
+};
 
 // 同じスロット（艦隊/ドック）は同時に1件しか進行しないため、Queue.deleteSlot は
 // 「同じ種別・同じスロット」の既存Queueだけを削除し、他は一切触らない契約であることを検証する。
@@ -27,7 +27,7 @@ describe("Queue.deleteSlot", () => {
     const target = fakeQueue(EntryType.RECOVERY, "dock", "2");
     const otherDock = fakeQueue(EntryType.RECOVERY, "dock", "3");
     const otherType = fakeQueue(EntryType.SHIPBUILD, "dock", "2");
-    vi.spyOn(Queue, "list").mockResolvedValue([target, otherDock, otherType] as unknown as Queue[]);
+    vi.spyOn(Queue, "list").mockResolvedValue([target, otherDock, otherType]);
 
     await Queue.deleteSlot(EntryType.RECOVERY, "2");
 
@@ -39,7 +39,7 @@ describe("Queue.deleteSlot", () => {
   it("deck系（遠征・疲労）のスロットも同様に判定できる", async () => {
     const target = fakeQueue(EntryType.MISSION, "deck", "4");
     const other = fakeQueue(EntryType.MISSION, "deck", "1");
-    vi.spyOn(Queue, "list").mockResolvedValue([target, other] as unknown as Queue[]);
+    vi.spyOn(Queue, "list").mockResolvedValue([target, other]);
 
     await Queue.deleteSlot(EntryType.MISSION, "4");
 
@@ -49,7 +49,7 @@ describe("Queue.deleteSlot", () => {
 
   it("保存されている値が数値でも文字列指定と同一スロットとして判定する", async () => {
     const target = fakeQueue(EntryType.SHIPBUILD, "dock", 2);
-    vi.spyOn(Queue, "list").mockResolvedValue([target] as unknown as Queue[]);
+    vi.spyOn(Queue, "list").mockResolvedValue([target]);
 
     await Queue.deleteSlot(EntryType.SHIPBUILD, "2");
 
@@ -58,7 +58,7 @@ describe("Queue.deleteSlot", () => {
 
   it("該当するQueueが無ければ何も削除しない", async () => {
     const other = fakeQueue(EntryType.RECOVERY, "dock", "3");
-    vi.spyOn(Queue, "list").mockResolvedValue([other] as unknown as Queue[]);
+    vi.spyOn(Queue, "list").mockResolvedValue([other]);
 
     await Queue.deleteSlot(EntryType.RECOVERY, "2");
 

--- a/tests/queue-restack.spec.ts
+++ b/tests/queue-restack.spec.ts
@@ -1,0 +1,58 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// jstorm の Model が chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = { runtime: { getURL: (p: string) => p } };
+});
+
+import Queue from "../src/models/Queue";
+import { EntryType } from "../src/models/entry";
+
+// Queue.restack は「削除→作成」の定型を1箇所に集約したもの。逆順だと作成した
+// Queue ごと削除されてしまうため、順序保証がこのメソッドの契約の中心になる。
+describe("Queue.restack", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("deleteSlot を (type, slot) で呼ぶ", async () => {
+    const deleteSlot = vi.spyOn(Queue, "deleteSlot").mockResolvedValue(undefined);
+    vi.spyOn(Queue, "create").mockResolvedValue(Queue.new({ type: EntryType.RECOVERY }));
+
+    await Queue.restack(EntryType.RECOVERY, "2", { dock: "2" }, 12345);
+
+    expect(deleteSlot).toHaveBeenCalledWith(EntryType.RECOVERY, "2");
+  });
+
+  it("create を { type, params, scheduled } で呼ぶ", async () => {
+    vi.spyOn(Queue, "deleteSlot").mockResolvedValue(undefined);
+    const create = vi.spyOn(Queue, "create").mockResolvedValue(Queue.new({ type: EntryType.RECOVERY }));
+    const params = { dock: "2" };
+
+    await Queue.restack(EntryType.RECOVERY, "2", params, 12345);
+
+    expect(create).toHaveBeenCalledWith({ type: EntryType.RECOVERY, params, scheduled: 12345 });
+  });
+
+  it("削除は作成より先に行う（逆順だと作成したQueueごと消えるため）", async () => {
+    const deleteSlot = vi.spyOn(Queue, "deleteSlot").mockResolvedValue(undefined);
+    const create = vi.spyOn(Queue, "create").mockResolvedValue(Queue.new({ type: EntryType.RECOVERY }));
+
+    await Queue.restack(EntryType.RECOVERY, "2", { dock: "2" }, 12345);
+
+    const deleteOrder = deleteSlot.mock.invocationCallOrder[0];
+    const createOrder = create.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(createOrder);
+  });
+
+  it("create の戻り値をそのまま返す", async () => {
+    vi.spyOn(Queue, "deleteSlot").mockResolvedValue(undefined);
+    const created = Queue.new({ type: EntryType.RECOVERY });
+    vi.spyOn(Queue, "create").mockResolvedValue(created);
+
+    const result = await Queue.restack(EntryType.RECOVERY, "2", { dock: "2" }, 12345);
+
+    expect(result).toBe(created);
+  });
+});

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from "vitest";
 
-import { KCWDate } from "../src/utils";
+import { KCWDate, parseHMS } from "../src/utils";
 
 describe("format", () => {
   it("should format date correctly", () => {
@@ -47,5 +47,27 @@ describe("dayOfMonth", () => {
   it("朝5時より前は前日の日付を返す", () => {
     const epoch = new KCWDate("August 8, 2024 04:59:59").getTime();
     expect(KCWDate.dayOfMonth(epoch)).toBe(7);
+  });
+});
+
+describe("parseHMS", () => {
+  it("h:m:s形式の時刻文字列をミリ秒に換算する", () => {
+    expect(parseHMS("01:23:45")).toBe(5025000);
+  });
+
+  it("0埋めの時刻文字列もミリ秒に換算する", () => {
+    expect(parseHMS("00:30:00")).toBe(1800000);
+  });
+
+  it("数値として解釈できない文字列を渡すとnullを返す", () => {
+    expect(parseHMS("xx:30:00")).toBeNull();
+  });
+
+  it("空文字を渡すとnullを返す", () => {
+    expect(parseHMS("")).toBeNull();
+  });
+
+  it("分・秒が範囲外(60以上)の場合はnullを返す", () => {
+    expect(parseHMS("0:99:99")).toBeNull();
   });
 });

--- a/tests/webrequest-formdata.spec.ts
+++ b/tests/webrequest-formdata.spec.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it, vi } from "vitest";
+
+// formdata.ts の import 連鎖(chromite)が chrome.runtime を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+  };
+});
+
+import { formData } from "../src/controllers/WebRequest/formdata";
+
+interface SampleFormData {
+  api_id: string[];
+}
+
+// webRequest details から formData<T>() が型付きで取り出せるか、
+// requestBody/formData 欠落時に undefined を返すかを検証する。
+describe("formData", () => {
+  it("formDataがある場合、型付きで取り出せる", () => {
+    const details = { requestBody: { formData: { api_id: ["1"] } } } as unknown as chrome.webRequest.OnBeforeRequestDetails;
+    expect(formData<SampleFormData>(details)).toEqual({ api_id: ["1"] });
+  });
+
+  it("requestBodyが欠落している場合、undefinedを返す", () => {
+    const details = { requestBody: undefined } as unknown as chrome.webRequest.OnBeforeRequestDetails;
+    expect(formData<SampleFormData>(details)).toBeUndefined();
+  });
+
+  it("requestBodyはあるがformDataが欠落している場合、undefinedを返す", () => {
+    const details = { requestBody: {} } as unknown as chrome.webRequest.OnBeforeRequestDetails;
+    expect(formData<SampleFormData>(details)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
コードベース横断の重複監査に基づくリファクタリング4本の1本目です。「同じ規約の再実装」「呼ぶ側が毎回手書きする定型」が改修漏れの温床になっているのを、単一実装への集約で解消します。

## 全体構成とマージ順

- **PR-1（本PR）**: background 層の規約・定型集約
- **PR-2**: configs の既定値一元化と UserConfig 基底（#1841。本PRと独立・並行レビュー可）
- **PR-3**: UI 層の定型統一（#1842。本PRに依存。マージ後に ready 化します）
- **PR-4**: サービス層・メッセージング集約（#1843。PR-3 に依存）

## マージ前提

以下のマージ後に rebase して ready 化します。それまで draft です。

- [ ] #1838
- [ ] #1839

## 変更点

1. **スロットキー規約の一本化**: 「修復・建造は dock、遠征・疲労は deck」の規約が4箇所で再実装されていたのを `slotKey(type)` と `Queue#slot` に集約
2. **Queue.restack**: 「deleteSlot→create」の順序不変条件（逆順だと作成した Queue ごと消える）をモデルに封入。OCR 時刻パースは検証付き `parseHMS` として utils へ一本化
3. **formData\<T\>() ヘルパー**: requestBody 取り出しの二段キャスト16箇所と、欠落時挙動（クラッシュ/警告/黙殺が混在）を「warn＋early return」に統一。任務3ハンドラ・戦闘開始系4ハンドラの同型コピーもパラメータ化
4. **NotificationId コーデック**: 通知ID `/{type}/{trigger}/{target}` と設定キーの生成・解析・照合が7系統に分散していたのを一本化し、照合系は `NotificationService.clearBy(cond)` に集約

## 挙動への影響

原則挙動不変の集約です。例外として以下を意図的に修正しています:

- 手動タイマーで修復/建造のスロットを変更→保存後に開き直すと旧スロットが表示されるバグ
- requestBody 欠落時のクラッシュ（Service Worker の unhandled rejection）

通知ID・設定キーの生成文字列は従来と byte 同一で、保存済みのユーザー設定に影響しません（テストで文字列を固定）。

## テスト

typecheck / lint / vitest 631件 全パス。実機（dev ビルド＋デバッグ環境）で遠征・入渠・建造・疲労のタイマー一巡、バケツ即完了、手動タイマーの種別切替、通知の生成・消去を検証済みです。
