### PR TITLE
Config の既定値を一元化し共通基底 UserConfig を導入する

### DIFF
--- a/src/models/configs/BehaviorConfig.ts
+++ b/src/models/configs/BehaviorConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 
 // タイマー監視間隔（秒）の選択肢
 export const QueueWatchIntervalOptions = [5, 10, 20, 30] as const;
@@ -23,8 +23,8 @@ const DEFAULTS = {
 };
 
 // 細かい挙動設定。独立したセクションを設けるほどではない挙動の設定をまとめて持つ。
-export class BehaviorConfig extends Model {
-  static override _namespace_ = "BehaviorConfig";
+export class BehaviorConfig extends UserConfig {
+  static override readonly _namespace_ = "BehaviorConfig";
 
   // /cron/queues アラームの周期（秒）。chrome.alarms の periodInMinutes 下限 0.5 に相当する。
   public static readonly ALARM_PERIOD_SECONDS = 30;
@@ -38,10 +38,6 @@ export class BehaviorConfig extends Model {
   public restackFatigueOnSortie: boolean = DEFAULTS.restackFatigueOnSortie;
   public queueWatchIntervalSeconds: number = DEFAULTS.queueWatchIntervalSeconds;
   public logbookRetentionDays: number | null = DEFAULTS.logbookRetentionDays;
-
-  public static async user(): Promise<BehaviorConfig> {
-    return (await this.find("user"))!;
-  }
 
   /**
    * タイマー監視間隔（秒）を選択肢のいずれかに正規化して返す。

--- a/src/models/configs/BehaviorConfig.ts
+++ b/src/models/configs/BehaviorConfig.ts
@@ -9,6 +9,19 @@ const DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS: QueueWatchIntervalSeconds = 30;
 // 出撃記録（Logbook）の既定保存期間（日数）。未設定(null)時に自動確定する値。
 const DEFAULT_LOGBOOK_RETENTION_DAYS = 7;
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  // 出撃時に同じ艦隊の疲労タイマー（FATIGUE の Queue）を削除して積み直すか。
+  // 既定 false（出撃ごとにタイマーが並ぶ。連続出撃の回数把握に使える）。
+  restackFatigueOnSortie: false,
+  // Queue の期限を確認する間隔（秒）。短いほど予定時刻に近いタイミングで通知される。
+  queueWatchIntervalSeconds: DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS,
+  // 出撃記録（Logbook）の保存期間（日数）。0は無期限。null は未設定を表し、
+  // Logbook.record() が初回に既存記録の有無を見て自動確定する（Logbook.ts 参照）。
+  logbookRetentionDays: null as number | null,
+};
+
 // 細かい挙動設定。独立したセクションを設けるほどではない挙動の設定をまとめて持つ。
 export class BehaviorConfig extends Model {
   static override _namespace_ = "BehaviorConfig";
@@ -19,21 +32,12 @@ export class BehaviorConfig extends Model {
   public static readonly DEFAULT_LOGBOOK_RETENTION_DAYS = DEFAULT_LOGBOOK_RETENTION_DAYS;
 
   static override default = {
-    "user": {
-      // 出撃時に同じ艦隊の疲労タイマー（FATIGUE の Queue）を削除して積み直すか。
-      // 既定 false（出撃ごとにタイマーが並ぶ。連続出撃の回数把握に使える）。
-      "restackFatigueOnSortie": false,
-      // Queue の期限を確認する間隔（秒）。短いほど予定時刻に近いタイミングで通知される。
-      "queueWatchIntervalSeconds": DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS,
-      // 出撃記録（Logbook）の保存期間（日数）。0は無期限。null は未設定を表し、
-      // Logbook.record() が初回に既存記録の有無を見て自動確定する（Logbook.ts 参照）。
-      "logbookRetentionDays": null as number | null,
-    },
+    "user": { ...DEFAULTS },
   };
 
-  public restackFatigueOnSortie: boolean = false;
-  public queueWatchIntervalSeconds: number = DEFAULT_QUEUE_WATCH_INTERVAL_SECONDS;
-  public logbookRetentionDays: number | null = null;
+  public restackFatigueOnSortie: boolean = DEFAULTS.restackFatigueOnSortie;
+  public queueWatchIntervalSeconds: number = DEFAULTS.queueWatchIntervalSeconds;
+  public logbookRetentionDays: number | null = DEFAULTS.logbookRetentionDays;
 
   public static async user(): Promise<BehaviorConfig> {
     return (await this.find("user"))!;

--- a/src/models/configs/DamageSnapshotConfig.ts
+++ b/src/models/configs/DamageSnapshotConfig.ts
@@ -19,26 +19,34 @@ export const DamageSnapshotModeDictionary = {
   },
 };
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  mode: DamageSnapshotMode.INAPP,
+  position: { left: 0, top: 0 },
+  size: { width: 160, height: 260 },
+  heightRatio: 40,
+  // 海域名ラベルの表記（番号 "1-1" / 日本語名）。既定は番号。 @see #1764
+  areaLabelFormat: "number" as AreaLabelFormat,
+  // 次の窓が表示されるまで前の窓を消さない（戦闘開始時の自動消去を抑制）。既定 false。母港帰投では消す。
+  keepUntilNextShow: false,
+};
+
 export class DamageSnapshotConfig extends Model {
   static override _namespace_ = "DamageSnapshotConfig";
   static override default = {
     "user": {
-      "mode": DamageSnapshotMode.INAPP,
-      "position": { left: 0, top: 0 },
-      "size": { width: 160, height: 260 },
-      "heightRatio": 40,
-      "areaLabelFormat": "number" as AreaLabelFormat,
-      "keepUntilNextShow": false,
+      ...DEFAULTS,
+      position: { ...DEFAULTS.position },
+      size: { ...DEFAULTS.size },
     },
   }
-  public mode: DamageSnapshotMode = DamageSnapshotMode.INAPP;
-  public position = { left: 0, top: 0 };
-  public size = { width: 160, height: 260};
-  public heightRatio: number = 40;
-  // 海域名ラベルの表記（番号 "1-1" / 日本語名）。既定は番号。 @see #1764
-  public areaLabelFormat: AreaLabelFormat = "number";
-  // 次の窓が表示されるまで前の窓を消さない（戦闘開始時の自動消去を抑制）。既定 false。母港帰投では消す。
-  public keepUntilNextShow: boolean = false;
+  public mode: DamageSnapshotMode = DEFAULTS.mode;
+  public position = { ...DEFAULTS.position };
+  public size = { ...DEFAULTS.size };
+  public heightRatio: number = DEFAULTS.heightRatio;
+  public areaLabelFormat: AreaLabelFormat = DEFAULTS.areaLabelFormat;
+  public keepUntilNextShow: boolean = DEFAULTS.keepUntilNextShow;
 
   public static async user(): Promise<DamageSnapshotConfig> {
     return (await DamageSnapshotConfig.find("user"))!;

--- a/src/models/configs/DamageSnapshotConfig.ts
+++ b/src/models/configs/DamageSnapshotConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 import type { AreaLabelFormat } from "../sortieLabel";
 
 export enum DamageSnapshotMode {
@@ -32,23 +32,19 @@ const DEFAULTS = {
   keepUntilNextShow: false,
 };
 
-export class DamageSnapshotConfig extends Model {
-  static override _namespace_ = "DamageSnapshotConfig";
+export class DamageSnapshotConfig extends UserConfig {
+  static override readonly _namespace_ = "DamageSnapshotConfig";
   static override default = {
     "user": {
       ...DEFAULTS,
       position: { ...DEFAULTS.position },
       size: { ...DEFAULTS.size },
     },
-  }
+  };
   public mode: DamageSnapshotMode = DEFAULTS.mode;
   public position = { ...DEFAULTS.position };
   public size = { ...DEFAULTS.size };
   public heightRatio: number = DEFAULTS.heightRatio;
   public areaLabelFormat: AreaLabelFormat = DEFAULTS.areaLabelFormat;
   public keepUntilNextShow: boolean = DEFAULTS.keepUntilNextShow;
-
-  public static async user(): Promise<DamageSnapshotConfig> {
-    return (await DamageSnapshotConfig.find("user"))!;
-  }
 }

--- a/src/models/configs/DashboardConfig.ts
+++ b/src/models/configs/DashboardConfig.ts
@@ -22,8 +22,8 @@ export class DashboardConfig extends Model {
 
   public width: number = 320;
   public height: number = 220;
-  public left: number = 100;
-  public top: number = 100;
+  public left: number = 10;
+  public top: number = 10;
   public openWithGame: boolean = false;
   public manualTimerInput: ManualTimerInputStyle = "split";
 

--- a/src/models/configs/DashboardConfig.ts
+++ b/src/models/configs/DashboardConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 
 // タイマー手入力モーダルの残り時間入力欄の形式
 // - "split": 時・分を別々の数値ボックスで入力する（24時間以上も入力できる）
@@ -17,10 +17,10 @@ const DEFAULTS = {
   manualTimerInput: "split" as ManualTimerInputStyle,
 };
 
-export class DashboardConfig extends Model {
-  public static readonly _namespace_ = "DashboardConfig";
+export class DashboardConfig extends UserConfig {
+  static override readonly _namespace_ = "DashboardConfig";
 
-  static default = {
+  static override default = {
     "user": { ...DEFAULTS },
   };
 
@@ -30,10 +30,6 @@ export class DashboardConfig extends Model {
   public top: number = DEFAULTS.top;
   public openWithGame: boolean = DEFAULTS.openWithGame;
   public manualTimerInput: ManualTimerInputStyle = DEFAULTS.manualTimerInput;
-
-  static async user(): Promise<DashboardConfig> {
-    return (await this.find("user"))!;
-  }
 
   /**
    * ゲーム窓の起動に合わせてダッシュボードを自動で開くべきかを判定する（#1216）。

--- a/src/models/configs/DashboardConfig.ts
+++ b/src/models/configs/DashboardConfig.ts
@@ -5,27 +5,31 @@ import { Model } from "jstorm/chrome/local";
 // - "time": HH:MM の time input 1つで入力する（"0130" のようにキーボードで一括入力できる。上限 23:59）
 export type ManualTimerInputStyle = "split" | "time";
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  width: 320,
+  height: 220,
+  left: 10,
+  top: 10,
+  // ゲーム窓を新規に開いたとき、ダッシュボードも同時に開くか（#1216）。既定は false（従来どおり手動）。
+  openWithGame: false,
+  manualTimerInput: "split" as ManualTimerInputStyle,
+};
+
 export class DashboardConfig extends Model {
   public static readonly _namespace_ = "DashboardConfig";
 
   static default = {
-    "user": {
-      "width": 320,
-      "height": 220,
-      "left": 10,
-      "top": 10,
-      // ゲーム窓を新規に開いたとき、ダッシュボードも同時に開くか（#1216）。既定は false（従来どおり手動）。
-      "openWithGame": false,
-      "manualTimerInput": "split" as ManualTimerInputStyle,
-    },
+    "user": { ...DEFAULTS },
   };
 
-  public width: number = 320;
-  public height: number = 220;
-  public left: number = 10;
-  public top: number = 10;
-  public openWithGame: boolean = false;
-  public manualTimerInput: ManualTimerInputStyle = "split";
+  public width: number = DEFAULTS.width;
+  public height: number = DEFAULTS.height;
+  public left: number = DEFAULTS.left;
+  public top: number = DEFAULTS.top;
+  public openWithGame: boolean = DEFAULTS.openWithGame;
+  public manualTimerInput: ManualTimerInputStyle = DEFAULTS.manualTimerInput;
 
   static async user(): Promise<DashboardConfig> {
     return (await this.find("user"))!;

--- a/src/models/configs/FileSaveConfig.ts
+++ b/src/models/configs/FileSaveConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 
 // スクリーンショットの保存画像フォーマット
 // chrome.tabs.captureVisibleTab の format に渡せる値と一致させる
@@ -14,17 +14,12 @@ const DEFAULTS = {
   editBeforeSave: false,
 };
 
-export class FileSaveConfig extends Model {
-  public static readonly _namespace_ = "FileSaveConfig";
+export class FileSaveConfig extends UserConfig {
+  static override readonly _namespace_ = "FileSaveConfig";
 
-  static default = {
+  static override default = {
     "user": { ...DEFAULTS },
   };
-
-  static async user(): Promise<FileSaveConfig> {
-    const config = (await this.find("user"))!;
-    return await config.migrateFilenameExtension();
-  }
 
   // 保存前に毎回ファイル保存先を指定すべきか
   // chrome.downloads API の saveAs オプションに対応
@@ -50,7 +45,7 @@ export class FileSaveConfig extends Model {
    * 移行して保存し直す。format 導入以前の設定は拡張子込みテンプレートだったため、その互換処理。
    * @returns 移行後（または移行不要ならそのまま）の設定
    */
-  private async migrateFilenameExtension(): Promise<FileSaveConfig> {
+  protected override async migrate(): Promise<FileSaveConfig> {
     const matched = this.filenameTemplate.match(/\.(png|jpe?g)$/i);
     if (!matched) return this;
     const format: ImageFormat = matched[1].toLowerCase() === "png" ? "png" : "jpeg";

--- a/src/models/configs/FileSaveConfig.ts
+++ b/src/models/configs/FileSaveConfig.ts
@@ -4,17 +4,21 @@ import { Model } from "jstorm/chrome/local";
 // chrome.tabs.captureVisibleTab の format に渡せる値と一致させる
 export type ImageFormat = "png" | "jpeg";
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  askAlways: false,
+  folder: "艦これ",
+  filenameTemplate: "%Y%m%d_%H%M%S",
+  format: "png" as ImageFormat,
+  editBeforeSave: false,
+};
+
 export class FileSaveConfig extends Model {
   public static readonly _namespace_ = "FileSaveConfig";
 
   static default = {
-    "user": {
-      askAlways: false,
-      folder: "艦これ",
-      filenameTemplate: "%Y%m%d_%H%M%S",
-      format: "png" as ImageFormat,
-      editBeforeSave: false,
-    }
+    "user": { ...DEFAULTS },
   };
 
   static async user(): Promise<FileSaveConfig> {
@@ -24,22 +28,22 @@ export class FileSaveConfig extends Model {
 
   // 保存前に毎回ファイル保存先を指定すべきか
   // chrome.downloads API の saveAs オプションに対応
-  public askAlways: boolean = false;
+  public askAlways: boolean = DEFAULTS.askAlways;
 
   // 保存先フォルダ名 ~/Downloads/ 以下のフォルダ
   // デフォルト: "艦これ" (= "~/Downloads/艦これ")
-  public folder: string = "艦これ";
+  public folder: string = DEFAULTS.folder;
 
   // 保存ファイル名テンプレート（拡張子なし、拡張子は format から付与される）
   // %Y: 年(4桁), %m: 月(2桁), %d: 日(2桁), %H: 時(2桁), %M: 分(2桁), %S: 秒(2桁)
   // デフォルト: "%Y%m%d_%H%M%S" (例: "20240615_134501.png")
-  public filenameTemplate: string = "%Y%m%d_%H%M%S";
+  public filenameTemplate: string = DEFAULTS.filenameTemplate;
 
   // 保存画像フォーマット。ファイル名の拡張子もこれに従う
-  public format: ImageFormat = "png";
+  public format: ImageFormat = DEFAULTS.format;
 
   // 撮影後すぐダウンロードせず、編集ページを開いてそこの保存操作でダウンロードするか
-  public editBeforeSave: boolean = false;
+  public editBeforeSave: boolean = DEFAULTS.editBeforeSave;
 
   /**
    * filenameTemplate 末尾に拡張子を含む設定を、拡張子なしテンプレートと format の組に

--- a/src/models/configs/FleetCaptureConfig.ts
+++ b/src/models/configs/FleetCaptureConfig.ts
@@ -3,6 +3,12 @@ import { Model } from "jstorm/chrome/local";
 // エクスポート画像で空白セルを塗る際の透明指定値
 export const TransparentBackground = "transparent";
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  background: "#ffffff",
+};
+
 /**
  * 編成キャプチャの設定
  */
@@ -10,14 +16,12 @@ export class FleetCaptureConfig extends Model {
   public static readonly _namespace_ = "FleetCaptureConfig";
 
   static default = {
-    "user": {
-      background: "#ffffff",
-    },
+    "user": { ...DEFAULTS },
   };
 
   // エクスポート画像の下地色（CSSカラー）
   // TransparentBackground のときは塗らない（png保存時のみ透明が有効。jpegでは黒になる）
-  public background: string = "#ffffff";
+  public background: string = DEFAULTS.background;
 
   static async user(): Promise<FleetCaptureConfig> {
     return (await this.find("user"))!;

--- a/src/models/configs/FleetCaptureConfig.ts
+++ b/src/models/configs/FleetCaptureConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 
 // エクスポート画像で空白セルを塗る際の透明指定値
 export const TransparentBackground = "transparent";
@@ -12,18 +12,14 @@ const DEFAULTS = {
 /**
  * 編成キャプチャの設定
  */
-export class FleetCaptureConfig extends Model {
-  public static readonly _namespace_ = "FleetCaptureConfig";
+export class FleetCaptureConfig extends UserConfig {
+  static override readonly _namespace_ = "FleetCaptureConfig";
 
-  static default = {
+  static override default = {
     "user": { ...DEFAULTS },
   };
 
   // エクスポート画像の下地色（CSSカラー）
   // TransparentBackground のときは塗らない（png保存時のみ透明が有効。jpegでは黒になる）
   public background: string = DEFAULTS.background;
-
-  static async user(): Promise<FleetCaptureConfig> {
-    return (await this.find("user"))!;
-  }
 }

--- a/src/models/configs/GameWindowConfig.ts
+++ b/src/models/configs/GameWindowConfig.ts
@@ -1,25 +1,29 @@
 import { Model } from "jstorm/chrome/local";
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  alertBeforeClose: true,
+  showMuteButton: true,
+  showScreenshotButton: true,
+  // 既定は小(4vw)。Issue #1763「ボタンを縮小」に沿い、ORIGINAL 窓(1200px)では現行の 48px と同等の見た目。
+  buttonSize: 50,
+  // ポップアップで最後に選択（起動）した Frame の id を記憶し、次回の初期選択にする（#1236）。
+  // 既定は "__memory__"（従来挙動）。指定 Frame が存在しない場合は表示側で MEMORY にフォールバックする。
+  lastSelectedFrameId: "__memory__",
+};
+
 export class GameWindowConfig extends Model {
   static override _namespace_ = "GameWindowConfig";
   static override default = {
-    "user": {
-      alertBeforeClose: true,
-      showMuteButton: true,
-      showScreenshotButton: true,
-      // 既定は小(4vw)。Issue #1763「ボタンを縮小」に沿い、ORIGINAL 窓(1200px)では現行の 48px と同等の見た目。
-      buttonSize: 50,
-      // ポップアップで最後に選択（起動）した Frame の id を記憶し、次回の初期選択にする（#1236）。
-      // 既定は "__memory__"（従来挙動）。指定 Frame が存在しない場合は表示側で MEMORY にフォールバックする。
-      lastSelectedFrameId: "__memory__",
-    },
+    "user": { ...DEFAULTS },
   }
   public static async user(): Promise<GameWindowConfig> {
     return (await GameWindowConfig.find("user"))!;
   }
-  public alertBeforeClose: boolean = true;
-  public showMuteButton: boolean = true;
-  public showScreenshotButton: boolean = true;
-  public buttonSize: number = 50;
-  public lastSelectedFrameId: string = "__memory__";
+  public alertBeforeClose: boolean = DEFAULTS.alertBeforeClose;
+  public showMuteButton: boolean = DEFAULTS.showMuteButton;
+  public showScreenshotButton: boolean = DEFAULTS.showScreenshotButton;
+  public buttonSize: number = DEFAULTS.buttonSize;
+  public lastSelectedFrameId: string = DEFAULTS.lastSelectedFrameId;
 }

--- a/src/models/configs/GameWindowConfig.ts
+++ b/src/models/configs/GameWindowConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 
 // 既定値の単一定義。static default（未保存時のレコード）と
 // プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
@@ -13,14 +13,11 @@ const DEFAULTS = {
   lastSelectedFrameId: "__memory__",
 };
 
-export class GameWindowConfig extends Model {
-  static override _namespace_ = "GameWindowConfig";
+export class GameWindowConfig extends UserConfig {
+  static override readonly _namespace_ = "GameWindowConfig";
   static override default = {
     "user": { ...DEFAULTS },
-  }
-  public static async user(): Promise<GameWindowConfig> {
-    return (await GameWindowConfig.find("user"))!;
-  }
+  };
   public alertBeforeClose: boolean = DEFAULTS.alertBeforeClose;
   public showMuteButton: boolean = DEFAULTS.showMuteButton;
   public showScreenshotButton: boolean = DEFAULTS.showScreenshotButton;

--- a/src/models/configs/QuestTrackerConfig.ts
+++ b/src/models/configs/QuestTrackerConfig.ts
@@ -1,4 +1,4 @@
-import { Model } from "jstorm/chrome/local";
+import { UserConfig } from "./UserConfig";
 
 // 既定値の単一定義。static default（未保存時のレコード）と
 // プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
@@ -9,15 +9,11 @@ const DEFAULTS = {
 
 // 任務トラッカー機能そのものの設定。通知の有効/無効やアイコン・音は
 // NotificationConfig の "/quest-alert/start" エントリが別途持つ。
-export class QuestTrackerConfig extends Model {
-  static override _namespace_ = "QuestTrackerConfig";
+export class QuestTrackerConfig extends UserConfig {
+  static override readonly _namespace_ = "QuestTrackerConfig";
   static override default = {
     "user": { ...DEFAULTS },
   };
 
   public showOnDashboard: boolean = DEFAULTS.showOnDashboard;
-
-  public static async user(): Promise<QuestTrackerConfig> {
-    return (await this.find("user"))!;
-  }
 }

--- a/src/models/configs/QuestTrackerConfig.ts
+++ b/src/models/configs/QuestTrackerConfig.ts
@@ -1,17 +1,21 @@
 import { Model } from "jstorm/chrome/local";
 
+// 既定値の単一定義。static default（未保存時のレコード）と
+// プロパティ初期値（保存済みレコードに無いフィールドの補完）は必ずここから導出する。
+const DEFAULTS = {
+  // ダッシュボードにも一覧を表示するか。既定はfalse（独立タブが既定の導線）
+  showOnDashboard: false,
+};
+
 // 任務トラッカー機能そのものの設定。通知の有効/無効やアイコン・音は
 // NotificationConfig の "/quest-alert/start" エントリが別途持つ。
 export class QuestTrackerConfig extends Model {
   static override _namespace_ = "QuestTrackerConfig";
   static override default = {
-    "user": {
-      // ダッシュボードにも一覧を表示するか。既定はfalse（独立タブが既定の導線）
-      "showOnDashboard": false,
-    },
+    "user": { ...DEFAULTS },
   };
 
-  public showOnDashboard: boolean = false;
+  public showOnDashboard: boolean = DEFAULTS.showOnDashboard;
 
   public static async user(): Promise<QuestTrackerConfig> {
     return (await this.find("user"))!;

--- a/src/models/configs/UserConfig.ts
+++ b/src/models/configs/UserConfig.ts
@@ -1,0 +1,17 @@
+import { Model } from "jstorm/chrome/local";
+
+// ユーザー設定シングルトン（キー "user"）を持つ Config モデルの共通基底。
+// 派生クラスは static default に "user" キーの初期値を必ず定義する。
+// このクラス自体を直接ストレージ操作に使わないこと（_namespace_ を持たない）。
+export class UserConfig extends Model {
+  /** キー "user" のシングルトン設定を取得し、migrate() を通して返す。 */
+  public static async user<T extends typeof UserConfig>(this: T): Promise<InstanceType<T>> {
+    const config = (await this.find("user"))! as InstanceType<T>;
+    return (await config.migrate()) as InstanceType<T>;
+  }
+
+  /** 保存形式の移行フック。user() での取得直後に呼ばれる。既定では何もしない。 */
+  protected async migrate(): Promise<UserConfig> {
+    return this;
+  }
+}

--- a/tests/config-defaults.spec.ts
+++ b/tests/config-defaults.spec.ts
@@ -1,0 +1,58 @@
+import { expect, describe, it, vi } from "vitest";
+
+// NotificationConfig は static default の初期化で chrome.runtime.getURL を参照するため、
+// import より前にスタブする（model-namespace.spec.ts と同じ手当て）
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+});
+
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+import { GameWindowConfig } from "../src/models/configs/GameWindowConfig";
+import { DamageSnapshotConfig } from "../src/models/configs/DamageSnapshotConfig";
+import { FleetCaptureConfig } from "../src/models/configs/FleetCaptureConfig";
+import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
+import { QuestTrackerConfig } from "../src/models/configs/QuestTrackerConfig";
+import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+
+// jstorm の Model.find(id) は storage にレコードが無ければ static default[id] を、
+// レコードはあるがフィールドが無ければプロパティ初期値を既定として使う。
+// つまり static default は未保存ユーザーの既定、プロパティ初期値は旧ビルドで保存された
+// レコードに無いフィールドの既定であり、食い違うとユーザーの状態によって異なる既定値が
+// 適用される。ここでは全 Config について両者の一致を機械検証する。
+const configs = [
+  DashboardConfig,
+  GameWindowConfig,
+  DamageSnapshotConfig,
+  FleetCaptureConfig,
+  BehaviorConfig,
+  FileSaveConfig,
+  QuestTrackerConfig,
+] as const;
+
+describe("Config の static default とプロパティ初期値の一致", () => {
+  it.each(configs.map((c) => [c.name, c] as const))("%s", (_name, Config) => {
+    const instance = new Config() as unknown as Record<string, unknown>;
+    const record = (Config.default as Record<string, Record<string, unknown>>)["user"];
+    expect(record).toBeDefined();
+    for (const [key, value] of Object.entries(record)) {
+      expect(instance[key], key).toEqual(value);
+    }
+  });
+
+  // /default/{start,end} の icon だけは意図的な差分: 旧ビルド保存のレコードに icon が
+  // 無い場合は null（Chrome 既定アイコン）にフォールバックするのが現行挙動のため除外する。
+  it("NotificationConfig は全レコードで一致（/default/* の icon を除く）", () => {
+    const instance = new NotificationConfig() as unknown as Record<string, unknown>;
+    const defaults = NotificationConfig.default as Record<string, Record<string, unknown>>;
+    for (const [id, record] of Object.entries(defaults)) {
+      for (const [key, value] of Object.entries(record)) {
+        if (id.startsWith("/default/") && key === "icon") continue;
+        expect(instance[key], `${id} ${key}`).toEqual(value);
+      }
+    }
+  });
+});

--- a/tests/user-config.spec.ts
+++ b/tests/user-config.spec.ts
@@ -1,0 +1,76 @@
+import { expect, describe, it } from "vitest";
+
+import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+import { DamageSnapshotConfig } from "../src/models/configs/DamageSnapshotConfig";
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
+import { FleetCaptureConfig } from "../src/models/configs/FleetCaptureConfig";
+import { GameWindowConfig } from "../src/models/configs/GameWindowConfig";
+import { QuestTrackerConfig } from "../src/models/configs/QuestTrackerConfig";
+import { UserConfig } from "../src/models/configs/UserConfig";
+
+// UserConfig を継承する7クラスが、共通基底の static user() をそのまま使えることを検証する。
+// 各クラス固有の設定項目・移行ロジックは個別 spec（behavior-config.spec.ts 等）が担当する。
+const derivedConfigs = [
+  BehaviorConfig,
+  DamageSnapshotConfig,
+  DashboardConfig,
+  FileSaveConfig,
+  FleetCaptureConfig,
+  GameWindowConfig,
+  QuestTrackerConfig,
+] as const;
+
+describe("UserConfig 派生クラス", () => {
+  it.each(derivedConfigs.map((config) => [config.name, config] as const))(
+    "%s の static default はキー user の初期値を持つ",
+    (_name, config) => {
+      expect(config.default.user).toBeTypeOf("object");
+      expect(config.default.user).not.toBeNull();
+    },
+  );
+
+  it.each(derivedConfigs.map((config) => [config.name, config] as const))(
+    "%s.user() は既定値の入ったインスタンスを返す",
+    async (_name, config) => {
+      const instance = await config.user();
+      expect(instance).toMatchObject(config.default.user);
+    },
+  );
+});
+
+describe("UserConfig.user() と migrate() の配線", () => {
+  // user() は取得したインスタンスに対して migrate() を呼び、その戻り値をそのまま返す
+  // （テンプレートメソッドの配線）ことを、テスト内で定義した派生クラスで検証する。
+  it("migrate() を override すると、その戻り値が user() の結果になる", async () => {
+    class MigratingConfig extends UserConfig {
+      static override readonly _namespace_ = "MigratingConfig";
+      static override default = {
+        "user": { migrated: false },
+      };
+
+      public migrated: boolean = false;
+
+      protected override async migrate(): Promise<MigratingConfig> {
+        return await this.update({ migrated: true });
+      }
+    }
+
+    const config = await MigratingConfig.user();
+    expect(config.migrated).toBe(true);
+  });
+
+  it("migrate() を override しなければ、取得したインスタンスがそのまま返る", async () => {
+    class PlainConfig extends UserConfig {
+      static override readonly _namespace_ = "PlainConfig";
+      static override default = {
+        "user": { value: 1 },
+      };
+
+      public value: number = 1;
+    }
+
+    const config = await PlainConfig.user();
+    expect(config.value).toBe(1);
+  });
+});


### PR DESCRIPTION
リファクタリング4本の2本目です（監査の背景は #1840 参照）。configs 配下の二重管理と定型コピーを解消します。

## 全体構成とマージ順

- **PR-1**: background 層の規約・定型集約（#1840）
- **PR-2（本PR）**: configs の既定値一元化と UserConfig 基底（**#1840 と独立・並行レビュー可**）
- **PR-3**: UI 層の定型統一（#1842。#1840 に依存）
- **PR-4**: サービス層・メッセージング集約（#1843。#1842 に依存）

## マージ前提

以下のマージ後に rebase して ready 化します。それまで draft です。

- [ ] #1838
- [ ] #1839

## 変更点

1. **既定値ドリフトの修正と機械検証**: jstorm では static default（未保存ユーザーの既定）と TS プロパティ初期値（保存済みレコードに無いフィールドの既定）の両方が生きており同値である必要がありますが、DashboardConfig の left/top が 10 と 100 に食い違っていました（e79651db で default 側のみ変更）。修正し、全 Config の両者一致を機械検証するテストを追加
2. **DEFAULTS 定数化**: 7クラスの既定値をファイル先頭の単一定数から導出し、片側だけ変更するドリフトを構造的に防止（値の変更なし）
3. **UserConfig 基底**: 7クラスが同文コピーしていた `static user()` を共通基底に集約。FileSaveConfig の取得時マイグレーションは `migrate()` フックとして基底に配線

## 挙動への影響

なし（left/top の初期値修正は、保存済みレコードに left/top が欠けるケースが実在しないため実挙動に影響しないデッドバリューの是正です）。NotificationConfig はキー体系が異なるため対象外（#1840 側で整理済み）。

## テスト

typecheck / lint / vitest 611件 全パス。実機で設定画面の全項目の変更・保存・リロード保持を一巡検証済みです。
