### PR TITLE
UI 層の設定編集定型・loader 型付け・テスト基盤を統一する

### DIFF
--- a/src/models/configs/NotificationConfig.ts
+++ b/src/models/configs/NotificationConfig.ts
@@ -104,11 +104,14 @@ export class NotificationConfig extends Model {
   }
 
   /**
-   * この設定レコードの _id から type セグメントを取り出す（例: /shipbuild/start → "shipbuild"）。
-   * 解析できない場合は UNKNOWN。
+   * この設定レコードの _id から type セグメントを取り出す（例: /shipbuild/start → EntryType.SHIPBUILD）。
+   * 解析できない場合、または EntryType のいずれにも一致しない場合（quest-alert 等）は UNKNOWN。
    */
-  public get type(): string {
-    return NotificationId.parse(this._id ?? "")?.type ?? EntryType.UNKNOWN;
+  public get type(): EntryType {
+    const type = NotificationId.parse(this._id ?? "")?.type;
+    return (Object.values(EntryType) as string[]).includes(type ?? "")
+      ? type as EntryType
+      : EntryType.UNKNOWN;
   }
 
   /**

--- a/src/models/configs/NotificationConfig.ts
+++ b/src/models/configs/NotificationConfig.ts
@@ -77,8 +77,9 @@ export class NotificationConfig extends Model {
    * この通知が画面に表示され続けるかどうか
    * trueの場合、ユーザーが手動で閉じるまで表示され続ける
    * falseの場合、一定時間後に自動的に閉じられる
+   * nullの場合、default.stayが使われる
    */
-  public stay: boolean = false;
+  public stay: boolean | null = false;
 
   /**
    * NotificationConfigを $n.id 形式から取得する
@@ -98,7 +99,7 @@ export class NotificationConfig extends Model {
       enabled: config?.enabled ?? def.enabled,
       sound: config?.sound ?? def.sound,
       icon: config?.icon ?? def.icon,
-      stay: config?.stay ?? def.stay,
+      stay: config?.stay ?? def.stay ?? false,
     };
   }
 

--- a/src/page/Dashboard.tsx
+++ b/src/page/Dashboard.tsx
@@ -1,24 +1,14 @@
-import { useLoaderData, useRevalidator } from "react-router-dom";
+import { useRevalidator } from "react-router-dom";
 import { ActionsView } from "./components/dashboard/ActionsView";
 import { ClockView } from "./components/dashboard/ClockView";
 import { QueuesView } from "./components/dashboard/QueuesView";
 import { QuestTrackerList } from "./components/quest-tracker/QuestTrackerList";
-import type Queue from "../models/Queue";
-import type { QuestTrackerConfig } from "../models/configs/QuestTrackerConfig";
-import type { QuestProgress } from "../models/QuestProgress";
-import type { DashboardConfig } from "../models/configs/DashboardConfig";
+import { dashboard } from "./loader";
+import { useTypedLoaderData } from "./loader/useTypedLoaderData";
 import { useEffect } from "react";
 
 export function DashboardPage() {
-  const { window, queues, time, frameId, questTrackerConfig, questProgress, config } = useLoaderData() as {
-    window: chrome.windows.Window,
-    queues: Queue[],
-    time: Date,
-    frameId: string,
-    questTrackerConfig: QuestTrackerConfig,
-    questProgress: QuestProgress,
-    config: DashboardConfig,
-  };
+  const { window, queues, time, frameId, questTrackerConfig, questProgress, config } = useTypedLoaderData<typeof dashboard>();
   const revalidater = useRevalidator();
 
   // 1秒ごとにデータを再検証

--- a/src/page/PopupPage.tsx
+++ b/src/page/PopupPage.tsx
@@ -1,7 +1,7 @@
-import { useLoaderData } from "react-router-dom"
 import { Launcher } from "../services/Launcher"
-import { type Frame } from "../models/Frame"
 import { GameWindowConfig } from "../models/configs/GameWindowConfig"
+import { popup } from "./loader"
+import { useTypedLoaderData } from "./loader/useTypedLoaderData"
 
 import { useState, type ReactNode } from "react";
 import { ClockIcon, SquaresPlusIcon, Cog6ToothIcon, BookOpenIcon, ClipboardDocumentCheckIcon } from "@heroicons/react/24/outline";
@@ -19,7 +19,7 @@ function ShortCutIcon({icon, title, action}: {
 }
 
 export function PopupPage() {
-  const { frames, defaultFrameId } = useLoaderData() as { frames: Frame[]; defaultFrameId: string }
+  const { frames, defaultFrameId } = useTypedLoaderData<typeof popup>()
   // 前回起動した Frame を初期選択として復元する（#1236）。
   const [selectedId, selectId] = useState<string>(defaultFrameId);
 

--- a/src/page/components/options/BehaviorSettingView.tsx
+++ b/src/page/components/options/BehaviorSettingView.tsx
@@ -1,17 +1,30 @@
-import { useState } from "react";
 import { BehaviorConfig, QueueWatchIntervalOptions, QueueWatchIntervalSeconds } from "../../../models/configs/BehaviorConfig";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function BehaviorSettingView({
-  config: _config,
+  config,
 }: {
   config: BehaviorConfig;
 }) {
-  const [config] = useState<BehaviorConfig>(_config);
-  const [restackFatigueOnSortie, setRestackFatigueOnSortie] = useState<boolean>(config.restackFatigueOnSortie ?? false);
-  const [queueWatchIntervalSeconds, setQueueWatchIntervalSeconds] = useState<QueueWatchIntervalSeconds>(config.normalizedQueueWatchIntervalSeconds());
-  const [logbookRetentionDays, setLogbookRetentionDays] = useState<number>(
+  const [restackFatigueOnSortie, saveRestackFatigueOnSortie] = useConfigField(
+    config,
+    "restackFatigueOnSortie",
+    config.restackFatigueOnSortie ?? false,
+  );
+  const [queueWatchIntervalSeconds, saveQueueWatchIntervalSeconds] = useConfigField(
+    config,
+    "queueWatchIntervalSeconds",
+    config.normalizedQueueWatchIntervalSeconds(),
+  );
+  const [logbookRetentionDays, saveLogbookRetentionDays] = useConfigField(
+    config,
+    "logbookRetentionDays",
     config.logbookRetentionDays ?? BehaviorConfig.DEFAULT_LOGBOOK_RETENTION_DAYS,
+    {
+      // 0（無期限）が有効値のため NaN は 0 に落とし、負数は 0 にクランプする
+      normalize: (v) => (Number.isFinite(v) ? Math.max(0, Math.trunc(v)) : 0),
+    },
   );
 
   return (
@@ -21,11 +34,7 @@ export function BehaviorSettingView({
           <input
             type="checkbox"
             checked={restackFatigueOnSortie}
-            onChange={async (e) => {
-              const next = e.target.checked;
-              await config.update({ restackFatigueOnSortie: next });
-              setRestackFatigueOnSortie(next);
-            }}
+            onChange={(e) => void saveRestackFatigueOnSortie(e.target.checked)}
             className="w-4 h-4"
           />
           <span className="font-bold">出撃時に同じ艦隊の疲労タイマーを積み直す</span>
@@ -40,11 +49,7 @@ export function BehaviorSettingView({
         </label>
         <select
           value={queueWatchIntervalSeconds}
-          onChange={async (e) => {
-            const next = Number(e.target.value) as QueueWatchIntervalSeconds;
-            await config.update({ queueWatchIntervalSeconds: next });
-            setQueueWatchIntervalSeconds(next);
-          }}
+          onChange={(e) => void saveQueueWatchIntervalSeconds(Number(e.target.value) as QueueWatchIntervalSeconds)}
           className="border rounded p-2"
         >
           {QueueWatchIntervalOptions.map((seconds) => (
@@ -67,11 +72,7 @@ export function BehaviorSettingView({
             min={0}
             aria-label="出撃記録の保存期間"
             value={logbookRetentionDays}
-            onChange={async (e) => {
-              const next = Math.max(0, Math.trunc(Number(e.target.value) || 0));
-              await config.update({ logbookRetentionDays: next });
-              setLogbookRetentionDays(next);
-            }}
+            onChange={(e) => void saveLogbookRetentionDays(Number(e.target.value))}
             className="border rounded p-2 w-24"
           />
           <span>日（0で無期限）</span>

--- a/src/page/components/options/DamageSnapshotSettingView.tsx
+++ b/src/page/components/options/DamageSnapshotSettingView.tsx
@@ -1,18 +1,17 @@
-import { useState } from "react";
 import { DamageSnapshotConfig, DamageSnapshotMode, DamageSnapshotModeDictionary } from "../../../models/configs/DamageSnapshotConfig";
 import type { AreaLabelFormat } from "../../../models/sortieLabel";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function DamageSnapshotSettingView({
-  config: _config,
+  config,
 }: {
   config: DamageSnapshotConfig;
 }) {
-  const [config] = useState<DamageSnapshotConfig>(_config);
-  const [mode, setMode] = useState<DamageSnapshotMode>(config.mode);
-  const [heightRatio, setHeightRatio] = useState<number>(config.heightRatio);
-  const [areaLabelFormat, setAreaLabelFormat] = useState<AreaLabelFormat>(config.areaLabelFormat ?? "number");
-  const [keepUntilNextShow, setKeepUntilNextShow] = useState<boolean>(config.keepUntilNextShow ?? false);
+  const [mode, saveMode] = useConfigField(config, "mode", config.mode);
+  const [heightRatio, saveHeightRatio] = useConfigField(config, "heightRatio", config.heightRatio);
+  const [areaLabelFormat, saveAreaLabelFormat] = useConfigField(config, "areaLabelFormat", config.areaLabelFormat ?? "number");
+  const [keepUntilNextShow, saveKeepUntilNextShow] = useConfigField(config, "keepUntilNextShow", config.keepUntilNextShow ?? false);
 
   return (
     <FoldableSection title="大破進撃防止の設定" id="damage-snapshot">
@@ -26,16 +25,12 @@ export function DamageSnapshotSettingView({
         </label>
         <select
           value={mode}
-          onChange={async (e) => {
-            const newMode = e.target.value as DamageSnapshotMode;
-            await config.update({ mode: newMode });
-            setMode(newMode);
-          }}
+          onChange={(e) => void saveMode(e.target.value as DamageSnapshotMode)}
           className="border rounded p-2 w-full max-w-md"
         >
-          {Object.entries(DamageSnapshotModeDictionary).map(([key, config]) => (
+          {Object.entries(DamageSnapshotModeDictionary).map(([key, entry]) => (
             <option key={key} value={key}>
-              {config.label}
+              {entry.label}
             </option>
           ))}
         </select>
@@ -52,11 +47,7 @@ export function DamageSnapshotSettingView({
             min="10"
             max="60"
             value={heightRatio}
-            onChange={async (e) => {
-              const newHeightRatio = Number(e.target.value);
-              await config.update({ heightRatio: newHeightRatio });
-              setHeightRatio(newHeightRatio);
-            }}
+            onChange={(e) => void saveHeightRatio(Number(e.target.value))}
             className="w-full max-w-md"
           />
           <div className="flex justify-between text-xs text-gray-500 max-w-md mt-1">
@@ -74,11 +65,7 @@ export function DamageSnapshotSettingView({
           </label>
           <select
             value={areaLabelFormat}
-            onChange={async (e) => {
-              const next = e.target.value as AreaLabelFormat;
-              await config.update({ areaLabelFormat: next });
-              setAreaLabelFormat(next);
-            }}
+            onChange={(e) => void saveAreaLabelFormat(e.target.value as AreaLabelFormat)}
             className="border rounded p-2 w-full max-w-md"
           >
             <option value="number">番号で表示（例: 1-1 (2)）</option>
@@ -94,11 +81,7 @@ export function DamageSnapshotSettingView({
             <input
               type="checkbox"
               checked={keepUntilNextShow}
-              onChange={async (e) => {
-                const next = e.target.checked;
-                await config.update({ keepUntilNextShow: next });
-                setKeepUntilNextShow(next);
-              }}
+              onChange={(e) => void saveKeepUntilNextShow(e.target.checked)}
             />
             <span className="font-bold">次の窓が出るまで前の窓を消さない</span>
           </label>

--- a/src/page/components/options/DashboardSettingView.tsx
+++ b/src/page/components/options/DashboardSettingView.tsx
@@ -1,20 +1,30 @@
-import { useState } from "react";
-import { DashboardConfig, ManualTimerInputStyle } from "../../../models/configs/DashboardConfig";
+import { DashboardConfig } from "../../../models/configs/DashboardConfig";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function DashboardSettingView({
-  config: _config,
+  config,
 }: {
   config: DashboardConfig;
 }) {
-  const [config] = useState<DashboardConfig>(_config);
-  const [openWithGame, setOpenWithGame] = useState<boolean>(config.openWithGame ?? false);
-  const [manualTimerInput, setManualTimerInput] = useState<ManualTimerInputStyle>(config.manualTimerInput ?? "split");
-
-  const selectManualTimerInput = async (style: ManualTimerInputStyle) => {
-    await config.update({ manualTimerInput: style });
-    setManualTimerInput(style);
-  };
+  const [openWithGame, saveOpenWithGame] = useConfigField(config, "openWithGame", config.openWithGame ?? false);
+  const [manualTimerInput, saveManualTimerInput] = useConfigField(
+    config,
+    "manualTimerInput",
+    config.manualTimerInput ?? "split",
+  );
+  const [width, saveWidth] = useConfigField(config, "width", config.width, {
+    normalize: (v) => (Number.isFinite(v) ? Math.trunc(v) : 600),
+  });
+  const [height, saveHeight] = useConfigField(config, "height", config.height, {
+    normalize: (v) => (Number.isFinite(v) ? Math.trunc(v) : 400),
+  });
+  const [left, saveLeft] = useConfigField(config, "left", config.left, {
+    normalize: (v) => (Number.isFinite(v) ? Math.trunc(v) : 100),
+  });
+  const [top, saveTop] = useConfigField(config, "top", config.top, {
+    normalize: (v) => (Number.isFinite(v) ? Math.trunc(v) : 100),
+  });
 
   return (
     <FoldableSection title="ダッシュボードの設定" id="dashboard">
@@ -27,11 +37,7 @@ export function DashboardSettingView({
           <input
             type="checkbox"
             checked={openWithGame}
-            onChange={async (e) => {
-              const next = e.target.checked;
-              await config.update({ openWithGame: next });
-              setOpenWithGame(next);
-            }}
+            onChange={(e) => void saveOpenWithGame(e.target.checked)}
             className="w-4 h-4"
           />
           <span className="font-bold">ゲーム起動と同時にダッシュボードを開く</span>
@@ -45,10 +51,8 @@ export function DashboardSettingView({
           </label>
           <input
             type="number"
-            defaultValue={config.width}
-            onChange={async (e) => {
-              await config.update({ width: parseInt(e.target.value, 10) });
-            }}
+            value={width}
+            onChange={(e) => void saveWidth(parseInt(e.target.value, 10))}
             className="border rounded p-2 w-full"
             placeholder="600"
             min="200"
@@ -61,10 +65,8 @@ export function DashboardSettingView({
           </label>
           <input
             type="number"
-            defaultValue={config.height}
-            onChange={async (e) => {
-              await config.update({ height: parseInt(e.target.value, 10) });
-            }}
+            value={height}
+            onChange={(e) => void saveHeight(parseInt(e.target.value, 10))}
             className="border rounded p-2 w-full"
             placeholder="400"
             min="150"
@@ -77,10 +79,8 @@ export function DashboardSettingView({
           </label>
           <input
             type="number"
-            defaultValue={config.left}
-            onChange={async (e) => {
-              await config.update({ left: parseInt(e.target.value, 10) });
-            }}
+            value={left}
+            onChange={(e) => void saveLeft(parseInt(e.target.value, 10))}
             className="border rounded p-2 w-full"
             placeholder="100"
           />
@@ -92,10 +92,8 @@ export function DashboardSettingView({
           </label>
           <input
             type="number"
-            defaultValue={config.top}
-            onChange={async (e) => {
-              await config.update({ top: parseInt(e.target.value, 10) });
-            }}
+            value={top}
+            onChange={(e) => void saveTop(parseInt(e.target.value, 10))}
             className="border rounded p-2 w-full"
             placeholder="100"
           />
@@ -114,7 +112,7 @@ export function DashboardSettingView({
               type="radio"
               name="manual-timer-input"
               checked={manualTimerInput === "split"}
-              onChange={() => selectManualTimerInput("split")}
+              onChange={() => void saveManualTimerInput("split")}
               className="w-4 h-4"
             />
             <span>時間と分を分けて入力</span>
@@ -124,7 +122,7 @@ export function DashboardSettingView({
               type="radio"
               name="manual-timer-input"
               checked={manualTimerInput === "time"}
-              onChange={() => selectManualTimerInput("time")}
+              onChange={() => void saveManualTimerInput("time")}
               className="w-4 h-4"
             />
             <span>HH:MM 形式でまとめて入力</span>

--- a/src/page/components/options/FileSaveSettingView.tsx
+++ b/src/page/components/options/FileSaveSettingView.tsx
@@ -1,15 +1,18 @@
-import { useState } from "react";
 import { FileSaveConfig, type ImageFormat } from "../../../models/configs/FileSaveConfig";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function FileSaveSettingView({
-  config: _config,
+  config,
 }: {
   config: FileSaveConfig;
 }) {
-  const [config] = useState<FileSaveConfig>(_config);
-  const [folder, setFolder] = useState<string>(_config.folder);
-  const [preview, setPreview] = useState<string>(_config.getFilename(new Date()));
+  const [askAlways, saveAskAlways] = useConfigField(config, "askAlways", config.askAlways);
+  const [editBeforeSave, saveEditBeforeSave] = useConfigField(config, "editBeforeSave", config.editBeforeSave);
+  const [folder, saveFolder] = useConfigField(config, "folder", config.folder || "");
+  const [filenameTemplate, saveFilenameTemplate] = useConfigField(config, "filenameTemplate", config.filenameTemplate || "");
+  const [format, saveFormat] = useConfigField(config, "format", config.format);
+  const preview = config.getFilename(new Date());
 
   return (
     <FoldableSection title="スクショ保存の設定" id="file-save">
@@ -22,11 +25,8 @@ export function FileSaveSettingView({
           <input
             type="checkbox"
             className="h-4 w-4"
-            defaultChecked={config.askAlways}
-            onChange={async (e) => {
-              const next = e.target.checked;
-              await config.update({ askAlways: next });
-            }}
+            checked={askAlways}
+            onChange={(e) => void saveAskAlways(e.target.checked)}
           />
           <div>
             <div className="font-bold">毎回保存先を確認する</div>
@@ -42,10 +42,8 @@ export function FileSaveSettingView({
           <input
             type="checkbox"
             className="h-4 w-4"
-            defaultChecked={config.editBeforeSave}
-            onChange={async (e) => {
-              await config.update({ editBeforeSave: e.target.checked });
-            }}
+            checked={editBeforeSave}
+            onChange={(e) => void saveEditBeforeSave(e.target.checked)}
           />
           <div>
             <div className="font-bold">保存前に編集画面を開く</div>
@@ -64,11 +62,8 @@ export function FileSaveSettingView({
           </label>
           <input
             type="text"
-            defaultValue={config.folder || ""}
-            onChange={async (e) => {
-              await config.update({ folder: e.target.value });
-              setFolder(e.target.value);
-            }}
+            value={folder}
+            onChange={(e) => void saveFolder(e.target.value)}
             className="border rounded p-2 w-full max-w-md"
             placeholder="艦これ"
           />
@@ -85,20 +80,14 @@ export function FileSaveSettingView({
           <div className="flex items-center gap-2 w-full max-w-md">
             <input
               type="text"
-              defaultValue={config.filenameTemplate || ""}
-              onChange={async (e) => {
-                await config.update({ filenameTemplate: e.target.value });
-                setPreview(config!.getFilename(new Date()));
-              }}
+              value={filenameTemplate}
+              onChange={(e) => void saveFilenameTemplate(e.target.value)}
               className="border rounded p-2 flex-1 font-mono"
               placeholder="%Y%m%d_%H%M%S"
             />
             <select
-              defaultValue={config.format}
-              onChange={async (e) => {
-                await config.update({ format: e.target.value as ImageFormat });
-                setPreview(config!.getFilename(new Date()));
-              }}
+              value={format}
+              onChange={(e) => void saveFormat(e.target.value as ImageFormat)}
               className="border rounded p-2 font-mono"
             >
               <option value="png">.png</option>

--- a/src/page/components/options/FleetCaptureSettingView.tsx
+++ b/src/page/components/options/FleetCaptureSettingView.tsx
@@ -4,6 +4,7 @@ import { CapturePreset } from "../../../models/CapturePreset";
 import { FleetCaptureConfig, TransparentBackground } from "../../../models/configs/FleetCaptureConfig";
 import { Launcher } from "../../../services/Launcher";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function FleetCaptureSettingView({
   presets,
@@ -13,15 +14,10 @@ export function FleetCaptureSettingView({
   config: FleetCaptureConfig;
 }) {
   const revalidator = useRevalidator();
-  const [background, setBackground] = useState<string>(config.background);
+  const [background, applyBackground] = useConfigField(config, "background", config.background);
   const transparent = background === TransparentBackground;
   // 透明を解除したときに戻す色
   const [lastColor, setLastColor] = useState<string>(transparent ? "#ffffff" : config.background);
-
-  const applyBackground = async (next: string) => {
-    await config.update({ background: next });
-    setBackground(next);
-  };
 
   return (
     <FoldableSection title="編成キャプチャの設定" id="fleet-capture">

--- a/src/page/components/options/FrameSettingView.tsx
+++ b/src/page/components/options/FrameSettingView.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
 import { useNavigate, useRevalidator } from "react-router-dom";
 import { Frame } from "../../../models/Frame";
 import { GameWindowConfig } from "../../../models/configs/GameWindowConfig";
 import { Launcher } from "../../../services/Launcher";
 import { ScriptingService } from "../../../services/ScriptingService";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function FrameSettingView({
   frames,
@@ -17,7 +17,7 @@ export function FrameSettingView({
   const scripts = new ScriptingService();
   const navigate = useNavigate();
   const revalidator = useRevalidator();
-  const [alertBeforeClose, setAlertBeforeClose] = useState<boolean>(config.alertBeforeClose ?? true);
+  const [alertBeforeClose, saveAlertBeforeClose] = useConfigField(config, "alertBeforeClose", config.alertBeforeClose ?? true);
   return (
     <FoldableSection title="別窓化の設定" id="frames">
       <div className="mb-4">
@@ -25,11 +25,7 @@ export function FrameSettingView({
           <input
             type="checkbox"
             checked={alertBeforeClose}
-            onChange={async (event) => {
-              const next = event.target.checked;
-              await config.update({ alertBeforeClose: next });
-              setAlertBeforeClose(next);
-            }}
+            onChange={(event) => void saveAlertBeforeClose(event.target.checked)}
             className="w-4 h-4"
           />
           <span className="font-bold">閉じる前に確認ダイアログを表示する</span>

--- a/src/page/components/options/InAppSettingView.tsx
+++ b/src/page/components/options/InAppSettingView.tsx
@@ -1,16 +1,19 @@
-import { useState } from "react";
 import { GameWindowConfig } from "../../../models/configs/GameWindowConfig";
 import { FoldableSection } from "../FoldableSection";
+import { useConfigField } from "./useConfigField";
 
 export function InAppSettingView({
-  config: _config,
+  config,
 }: {
   config: GameWindowConfig;
 }) {
-  const [config] = useState<GameWindowConfig>(_config);
-  const [showMuteButton, setShowMuteButton] = useState<boolean>(config.showMuteButton ?? true);
-  const [showScreenshotButton, setShowScreenshotButton] = useState<boolean>(config.showScreenshotButton ?? true);
-  const [buttonSize, setButtonSize] = useState<number>(config.buttonSize ?? 50);
+  const [showMuteButton, saveShowMuteButton] = useConfigField(config, "showMuteButton", config.showMuteButton ?? true);
+  const [showScreenshotButton, saveShowScreenshotButton] = useConfigField(
+    config,
+    "showScreenshotButton",
+    config.showScreenshotButton ?? true,
+  );
+  const [buttonSize, saveButtonSize] = useConfigField(config, "buttonSize", config.buttonSize ?? 50);
 
   return (
     <FoldableSection title="ウィンドウ内表示設定" id="inapp">
@@ -23,11 +26,7 @@ export function InAppSettingView({
           <input
             type="checkbox"
             checked={showMuteButton}
-            onChange={async (e) => {
-              const next = e.target.checked;
-              await config.update({ showMuteButton: next });
-              setShowMuteButton(next);
-            }}
+            onChange={(e) => void saveShowMuteButton(e.target.checked)}
             className="w-4 h-4"
           />
           <span className="font-bold">ミュートボタンを表示</span>
@@ -37,11 +36,7 @@ export function InAppSettingView({
           <input
             type="checkbox"
             checked={showScreenshotButton}
-            onChange={async (e) => {
-              const next = e.target.checked;
-              await config.update({ showScreenshotButton: next });
-              setShowScreenshotButton(next);
-            }}
+            onChange={(e) => void saveShowScreenshotButton(e.target.checked)}
             className="w-4 h-4"
           />
           <span className="font-bold">スクショボタンを表示</span>
@@ -57,11 +52,7 @@ export function InAppSettingView({
           max="100"
           step="50"
           value={buttonSize}
-          onChange={async (e) => {
-            const newSize = Number(e.target.value);
-            await config.update({ buttonSize: newSize });
-            setButtonSize(newSize);
-          }}
+          onChange={(e) => void saveButtonSize(Number(e.target.value))}
           className="w-16"
         />
         <span className="text-xs text-gray-500">大</span>

--- a/src/page/components/options/NotificationSettingView.tsx
+++ b/src/page/components/options/NotificationSettingView.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 import { FoldableSection } from "../FoldableSection";
 import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../../../models/configs/NotificationConfig";
-import { Entry, EntryType, Fatigue, Mission, Recovery, Shipbuild, TriggerType } from "../../../models/entry";
+import { Entry, EntryType, Fatigue, Mission, Recovery, Shipbuild, TIMER_ENTRY_TYPES, TriggerType } from "../../../models/entry";
 import { NotificationService } from "../../../services/NotificationService";
 import { useConfigField } from "./useConfigField";
 
@@ -10,12 +10,6 @@ type NotificationConfigMap = Record<TriggerType.START | TriggerType.END, Notific
 type NotificationEntryType = Exclude<EntryType, EntryType.TEST_DEFAULT>;
 
 const TRIGGER_ORDER: Array<TriggerType.START | TriggerType.END> = [TriggerType.START, TriggerType.END];
-const ENTRY_ORDER: NotificationEntryType[] = [
-  EntryType.MISSION,
-  EntryType.RECOVERY,
-  EntryType.SHIPBUILD,
-  EntryType.FATIGUE,
-];
 const ENTRY_LABELS: Record<EntryType, string> = {
   [EntryType.MISSION]: "遠征",
   [EntryType.RECOVERY]: "入渠",
@@ -41,7 +35,7 @@ export function NotificationSettingView({
     TRIGGER_ORDER.forEach((trigger) => {
       map[`default-${trigger}`] = defaults[trigger].enabled ?? true;
     });
-    ENTRY_ORDER.forEach((type) => {
+    TIMER_ENTRY_TYPES.forEach((type) => {
       TRIGGER_ORDER.forEach((trigger) => {
         map[`${type}-${trigger}`] = entries[type][trigger].enabled ?? true;
       });
@@ -83,7 +77,7 @@ export function NotificationSettingView({
         updatedConfigs.push(config);
       }
     });
-    ENTRY_ORDER.forEach((type) => {
+    TIMER_ENTRY_TYPES.forEach((type) => {
       TRIGGER_ORDER.forEach((trigger) => {
         const config = entries[type][trigger];
         if (!seen.has(config)) {
@@ -135,7 +129,7 @@ export function NotificationSettingView({
           </div>
 
           <div className="space-y-4">
-            {ENTRY_ORDER.map((type) => (
+            {TIMER_ENTRY_TYPES.map((type) => (
               <div key={type} className="grid gap-4 md:grid-cols-2">
                 {TRIGGER_ORDER.map((trigger) => (
                   <NotificationConfigEditor
@@ -175,7 +169,7 @@ export function NotificationConfigEditor({
   configId: string;
   onEnabledChange: (id: string, next: boolean) => void;
 }) {
-  const [type, trigger] = config._id?.split("/").slice(1) as [EntryType, TriggerType];
+  const { type, trigger } = config;
   return (
     <div className="border border-slate-200 rounded-md p-2 space-y-2 bg-white">
       <div className="flex">
@@ -200,7 +194,7 @@ export function NotificationConfigEditor({
         <IconSettingView config={config} configId={configId} />
         <SoundSettingView config={config} configId={configId} />
         <StaySettingView config={config} />
-        {type !== "default" ?
+        {type !== EntryType.TEST_DEFAULT ?
           <div className="flex-1 flex justify-end">
             <TestPlayView config={config} type={type} trigger={trigger} />
           </div>

--- a/src/page/components/options/NotificationSettingView.tsx
+++ b/src/page/components/options/NotificationSettingView.tsx
@@ -4,6 +4,7 @@ import { FoldableSection } from "../FoldableSection";
 import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../../../models/configs/NotificationConfig";
 import { Entry, EntryType, Fatigue, Mission, Recovery, Shipbuild, TriggerType } from "../../../models/entry";
 import { NotificationService } from "../../../services/NotificationService";
+import { useConfigField } from "./useConfigField";
 
 type NotificationConfigMap = Record<TriggerType.START | TriggerType.END, NotificationConfig>;
 
@@ -299,14 +300,11 @@ function StaySettingView({
 }: {
   config: NotificationConfig;
 }) {
-  const [stay, setStay] = useState<boolean | null>(config.stay);
+  const [stay, saveStay] = useConfigField(config, "stay", config.stay);
   return (
     <CycleButton
       value={stay}
-      onChange={async (next) => {
-        setStay(next);
-        await config.update({ stay: next });
-      }}
+      onChange={(next) => void saveStay(next)}
       label={<span className="font-bold">通知消去</span>}
       buttonClassName="bg-white hover:bg-slate-50"
       options={[

--- a/src/page/components/options/NotificationSettingView.tsx
+++ b/src/page/components/options/NotificationSettingView.tsx
@@ -7,9 +7,10 @@ import { NotificationService } from "../../../services/NotificationService";
 import { useConfigField } from "./useConfigField";
 
 type NotificationConfigMap = Record<TriggerType.START | TriggerType.END, NotificationConfig>;
+type NotificationEntryType = Exclude<EntryType, EntryType.TEST_DEFAULT>;
 
 const TRIGGER_ORDER: Array<TriggerType.START | TriggerType.END> = [TriggerType.START, TriggerType.END];
-const ENTRY_ORDER: EntryType[] = [
+const ENTRY_ORDER: NotificationEntryType[] = [
   EntryType.MISSION,
   EntryType.RECOVERY,
   EntryType.SHIPBUILD,
@@ -33,7 +34,7 @@ export function NotificationSettingView({
   entries,
 }: {
   defaults: NotificationConfigMap;
-  entries: Record<EntryType, NotificationConfigMap>;
+  entries: Record<NotificationEntryType, NotificationConfigMap>;
 }) {
   const createInitialEnabledMap = () => {
     const map: Record<string, boolean> = {};

--- a/src/page/components/options/QuestTrackerSettingView.tsx
+++ b/src/page/components/options/QuestTrackerSettingView.tsx
@@ -3,17 +3,17 @@ import { NotificationConfig } from "../../../models/configs/NotificationConfig";
 import { QuestTrackerConfig } from "../../../models/configs/QuestTrackerConfig";
 import { FoldableSection } from "../FoldableSection";
 import { NotificationConfigEditor } from "./NotificationSettingView";
+import { useConfigField } from "./useConfigField";
 
 export function QuestTrackerSettingView({
-  notification: _notification, tracker: _tracker,
+  notification,
+  tracker,
 }: {
   notification: NotificationConfig;
   tracker: QuestTrackerConfig;
 }) {
-  const [notification] = useState<NotificationConfig>(_notification);
   const [enabled, setEnabled] = useState<boolean>(notification.enabled);
-  const [tracker] = useState<QuestTrackerConfig>(_tracker);
-  const [showOnDashboard, setShowOnDashboard] = useState<boolean>(tracker.showOnDashboard);
+  const [showOnDashboard, saveShowOnDashboard] = useConfigField(tracker, "showOnDashboard", tracker.showOnDashboard);
 
   return (
     <FoldableSection title="任務トラッカーの設定" id="quest-tracker">
@@ -35,11 +35,7 @@ export function QuestTrackerSettingView({
           <input
             type="checkbox"
             checked={showOnDashboard}
-            onChange={async (e) => {
-              const next = e.target.checked;
-              await tracker.update({ showOnDashboard: next });
-              setShowOnDashboard(next);
-            }}
+            onChange={(e) => void saveShowOnDashboard(e.target.checked)}
             className="w-4 h-4"
           />
           <span className="font-bold">ダッシュボードにも任務トラッカーを表示する</span>

--- a/src/page/components/options/useConfigField.ts
+++ b/src/page/components/options/useConfigField.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import type { Model } from "jstorm/chrome/local";
+
+/**
+ * 設定モデルの1フィールドをローカル state と chrome.storage の両方へ反映するフック。
+ * save(next) は normalize → config.update → setState の順で実行する。
+ */
+export function useConfigField<C extends Model, K extends keyof C & string, T extends C[K]>(
+  config: C,
+  key: K,
+  initialValue: T,
+  options?: {
+    /** 保存前の正規化（NaNガード・整数化等）。返り値が保存・表示される */
+    normalize?: (value: T) => T;
+  },
+): [T, (next: T) => Promise<void>] {
+  const [value, setValue] = useState<T>(initialValue);
+  const save = async (next: T) => {
+    const normalized = options?.normalize ? options.normalize(next) : next;
+    await config.update({ [key]: normalized });
+    setValue(normalized);
+  };
+  return [value, save];
+}

--- a/src/page/fleet-capture/FleetCapturePage.tsx
+++ b/src/page/fleet-capture/FleetCapturePage.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
-import { useLoaderData } from "react-router-dom";
 import { GameRawHeight, GameRawWidth } from "../../constants";
-import type { CapturePreset } from "../../models/CapturePreset";
 import { CapturePreviewThumbnail } from "../components/fleet-capture/CapturePreviewThumbnail";
 import { ExportButton } from "../components/fleet-capture/ExportButton";
 import { PresetActionButtons } from "../components/fleet-capture/PresetActionButtons";
@@ -9,9 +7,11 @@ import { PresetSelector } from "../components/fleet-capture/PresetSelector";
 import { RangeAdjuster } from "../components/fleet-capture/RangeAdjuster";
 import { ResultGrid } from "../components/fleet-capture/ResultGrid";
 import { useFleetCapture } from "./useFleetCapture";
+import { fleetcapture } from "../loader";
+import { useTypedLoaderData } from "../loader/useTypedLoaderData";
 
 export function FleetCapturePage() {
-  const { presets } = useLoaderData() as { presets: CapturePreset[] };
+  const { presets } = useTypedLoaderData<typeof fleetcapture>();
   const controller = useFleetCapture({ presets });
   // 調整モード（切り抜き範囲・グリッド構成・プリセットの編集）とキャプチャモードの切り替え
   const [adjusting, setAdjusting] = useState(false);

--- a/src/page/loader/index.ts
+++ b/src/page/loader/index.ts
@@ -10,12 +10,22 @@ import { DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig"
 import { BehaviorConfig } from "../../models/configs/BehaviorConfig";
 import { GameWindowConfig } from "../../models/configs/GameWindowConfig";
 import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../../models/configs/NotificationConfig";
-import { EntryType, TriggerType } from "../../models/entry";
+import { EntryType, NotificationId, TIMER_ENTRY_TYPES, TriggerType } from "../../models/entry";
 import { Logbook } from "../../models/Logbook";
 import { CapturePreset } from "../../models/CapturePreset";
 import { FleetCaptureConfig } from "../../models/configs/FleetCaptureConfig";
 import { QuestTrackerConfig } from "../../models/configs/QuestTrackerConfig";
 import { QuestProgress } from "../../models/QuestProgress";
+
+type NotificationConfigPair = Record<TriggerType.START | TriggerType.END, NotificationConfig>;
+
+// 種別1つ分の 開始/完了 通知設定レコードを取得する。
+async function notificationConfigPair(type: string): Promise<NotificationConfigPair> {
+  return {
+    [TriggerType.START]: (await NotificationConfig.find(NotificationId.configKey(type, TriggerType.START)))!,
+    [TriggerType.END]: (await NotificationConfig.find(NotificationId.configKey(type, TriggerType.END)))!,
+  };
+}
 
 export async function options() {
   const frames = await Frame.list();
@@ -24,31 +34,15 @@ export async function options() {
   const dashboard = await DashboardConfig.user();
   const damagesnapshot = await DamageSnapshotConfig.user();
   const behavior = await BehaviorConfig.user();
-  const notificationDefaults = {
-    [TriggerType.START]: (await NotificationConfig.find("/default/start"))!,
-    [TriggerType.END]: (await NotificationConfig.find("/default/end"))!,
-  };
+  const notificationDefaults = await notificationConfigPair(EntryType.TEST_DEFAULT);
+  const timerNotificationEntries = Object.fromEntries(
+    await Promise.all(
+      TIMER_ENTRY_TYPES.map(async (type) => [type, await notificationConfigPair(type)] as const),
+    ),
+  ) as Record<typeof TIMER_ENTRY_TYPES[number], NotificationConfigPair>;
   const notificationEntries = {
-    [EntryType.MISSION]: {
-      [TriggerType.START]: (await NotificationConfig.find("/mission/start"))!,
-      [TriggerType.END]: (await NotificationConfig.find("/mission/end"))!,
-    },
-    [EntryType.RECOVERY]: {
-      [TriggerType.START]: (await NotificationConfig.find("/recovery/start"))!,
-      [TriggerType.END]: (await NotificationConfig.find("/recovery/end"))!,
-    },
-    [EntryType.SHIPBUILD]: {
-      [TriggerType.START]: (await NotificationConfig.find("/shipbuild/start"))!,
-      [TriggerType.END]: (await NotificationConfig.find("/shipbuild/end"))!,
-    },
-    [EntryType.FATIGUE]: {
-      [TriggerType.START]: (await NotificationConfig.find("/fatigue/start"))!,
-      [TriggerType.END]: (await NotificationConfig.find("/fatigue/end"))!,
-    },
-    [EntryType.UNKNOWN]: {
-      [TriggerType.START]: (await NotificationConfig.find("/default/start"))!,
-      [TriggerType.END]: (await NotificationConfig.find("/default/end"))!,
-    },
+    ...timerNotificationEntries,
+    [EntryType.UNKNOWN]: await notificationConfigPair(EntryType.TEST_DEFAULT),
   };
   const releasenote = note as ReleaseNoteObject;
   return {

--- a/src/page/loader/useTypedLoaderData.ts
+++ b/src/page/loader/useTypedLoaderData.ts
@@ -1,0 +1,10 @@
+import { useLoaderData } from "react-router-dom";
+
+/**
+ * loader 関数の戻り値型から useLoaderData の結果を型付けするフック。
+ * 型の真実源を loader 関数本体に一元化し、ページ側の手書き型注釈との乖離を防ぐ。
+ * 使用例: const { sorties } = useTypedLoaderData<typeof logbook>();
+ */
+export function useTypedLoaderData<Loader extends (...args: never[]) => unknown>(): Awaited<ReturnType<Loader>> {
+  return useLoaderData() as Awaited<ReturnType<Loader>>;
+}

--- a/src/page/logbook/LogbookPage.tsx
+++ b/src/page/logbook/LogbookPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
-import { useLoaderData, useRevalidator } from "react-router-dom";
+import { useRevalidator } from "react-router-dom";
 import { ArrowDownTrayIcon, ArrowPathIcon, BookOpenIcon } from "@heroicons/react/24/outline";
 import { SortieContext } from "../../models/Logbook";
 import { describeBattles, formatStarted } from "./format";
 import { logbookExportFilename, toCSV, toDataUrl, toJSONL } from "./export";
 import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
 import { DownloadService } from "../../services/DownloadService";
+import { logbook } from "../loader";
+import { useTypedLoaderData } from "../loader/useTypedLoaderData";
 
 // 自動更新オン時の再読込間隔（ミリ秒）
 const RELOAD_INTERVAL_MS = 5 * 1000;
@@ -24,7 +26,7 @@ async function downloadLogbook(sorties: SortieContext[], format: "csv" | "jsonl"
 }
 
 export function LogbookPage() {
-  const { sorties } = useLoaderData() as { sorties: SortieContext[] };
+  const { sorties } = useTypedLoaderData<typeof logbook>();
   const revalidator = useRevalidator();
   const [autoReload, setAutoReload] = useState(false);
 

--- a/src/page/options/OptionsPage.tsx
+++ b/src/page/options/OptionsPage.tsx
@@ -1,4 +1,3 @@
-import { useLoaderData } from "react-router-dom";
 import { FrameSettingView } from "../components/options/FrameSettingView";
 import { FileSaveSettingView } from "../components/options/FileSaveSettingView";
 import { DashboardSettingView } from "../components/options/DashboardSettingView";
@@ -9,19 +8,10 @@ import { NotificationSettingView } from "../components/options/NotificationSetti
 import { InAppSettingView } from "../components/options/InAppSettingView";
 import { QuestTrackerSettingView } from "../components/options/QuestTrackerSettingView";
 
-import { type Frame } from "../../models/Frame";
-import { type CapturePreset } from "../../models/CapturePreset";
-import { type FileSaveConfig } from "../../models/configs/FileSaveConfig";
-import { type FleetCaptureConfig } from "../../models/configs/FleetCaptureConfig";
-import { type DashboardConfig } from "../../models/configs/DashboardConfig";
-import { type DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig";
-import { type BehaviorConfig } from "../../models/configs/BehaviorConfig";
 import { DevelopmentInfoView, type ReleaseNoteObject } from "../components/options/DevelopmentInfoView";
 import { VersionView } from "../components/options/VersionView";
-import { type GameWindowConfig } from "../../models/configs/GameWindowConfig";
-import { NotificationConfig } from "../../models/configs/NotificationConfig";
-import { type QuestTrackerConfig } from "../../models/configs/QuestTrackerConfig";
-import { EntryType, TriggerType } from "../../models/entry";
+import { options } from "../loader";
+import { useTypedLoaderData } from "../loader/useTypedLoaderData";
 
 const KCWidgetChanURL = "https://cloud.githubusercontent.com/assets/931554/26664134/361ee756-46ca-11e7-98f5-d99e95dd90b8.png";
 
@@ -39,23 +29,7 @@ export function OptionsPage() {
     fleetcapture,
     questAlert,
     questTracker,
-  } = useLoaderData() as {
-    frames: Frame[];
-    game: GameWindowConfig;
-    releasenote: ReleaseNoteObject;
-    filesave: FileSaveConfig;
-    dashboard: DashboardConfig;
-    damagesnapshot: DamageSnapshotConfig;
-    behavior: BehaviorConfig;
-    notification: {
-      defaults: Record<TriggerType.START | TriggerType.END, NotificationConfig>;
-      entries: Record<EntryType, Record<TriggerType.START | TriggerType.END, NotificationConfig>>;
-    };
-    capturePresets: CapturePreset[];
-    fleetcapture: FleetCaptureConfig;
-    questAlert: NotificationConfig;
-    questTracker: QuestTrackerConfig;
-  };
+  } = useTypedLoaderData<typeof options>();
   const manifest = chrome.runtime.getManifest();
   return (
     <div className="p-8">

--- a/src/page/quest-tracker/QuestTrackerPage.tsx
+++ b/src/page/quest-tracker/QuestTrackerPage.tsx
@@ -1,10 +1,11 @@
-import { useLoaderData, useRevalidator } from "react-router-dom";
+import { useRevalidator } from "react-router-dom";
 import { ArrowPathIcon, ClipboardDocumentCheckIcon } from "@heroicons/react/24/outline";
-import { QuestProgress } from "../../models/QuestProgress";
 import { QuestTrackerList } from "../components/quest-tracker/QuestTrackerList";
+import { questTracker } from "../loader";
+import { useTypedLoaderData } from "../loader/useTypedLoaderData";
 
 export function QuestTrackerPage() {
-  const { progress } = useLoaderData() as { progress: QuestProgress };
+  const { progress } = useTypedLoaderData<typeof questTracker>();
   const revalidator = useRevalidator();
 
   return (

--- a/tests/behavior-setting-view.spec.tsx
+++ b/tests/behavior-setting-view.spec.tsx
@@ -1,18 +1,13 @@
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 
 import { BehaviorSettingView } from "../src/page/components/options/BehaviorSettingView";
 import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
-// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineDefaults = structuredClone(BehaviorConfig.default);
-
-beforeEach(() => {
-  BehaviorConfig.default = structuredClone(pristineDefaults);
-});
+restoreDefaultsBeforeEach(BehaviorConfig);
 
 async function renderView() {
   const config = await BehaviorConfig.user();

--- a/tests/dashboard-setting-view.spec.tsx
+++ b/tests/dashboard-setting-view.spec.tsx
@@ -1,0 +1,61 @@
+import { expect, describe, it, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+
+import { DashboardSettingView } from "../src/page/components/options/DashboardSettingView";
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
+// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
+const pristineDefaults = structuredClone(DashboardConfig.default);
+
+beforeEach(() => {
+  DashboardConfig.default = structuredClone(pristineDefaults);
+});
+
+async function renderView() {
+  const config = await DashboardConfig.user();
+  // FoldableSection は ?open=<id> が付いていると開いた状態で描画される
+  const router = createMemoryRouter(
+    [{ path: "/", element: <DashboardSettingView config={config} /> }],
+    { initialEntries: ["/?open=dashboard"] },
+  );
+  render(<RouterProvider router={router} />);
+}
+
+// 横幅・縦幅・左位置・上位置の入力欄を空にしたときの回帰テスト。
+// 以前は parseInt(e.target.value, 10) の戻り値を無ガードで保存しており、
+// 入力欄を空にした瞬間 NaN が chrome.storage に保存されるバグがあった（0px窓になり得る）。
+describe("DashboardSettingView 数値欄のNaN保存バグ回帰", () => {
+  it("横幅入力を空にしても DashboardConfig.width は NaN にならず既定値(600)が保存される", async () => {
+    await renderView();
+    const input = screen.getByPlaceholderText("600");
+    await userEvent.clear(input);
+
+    const reloaded = await DashboardConfig.user();
+    expect(reloaded.width).not.toBeNaN();
+    expect(reloaded.width).toBe(600);
+    // 入力欄の表示にも既定値が即座に反映される
+    expect(input).toHaveValue(600);
+  });
+
+  it("縦幅入力を空にしても DashboardConfig.height は NaN にならず既定値(400)が保存される", async () => {
+    await renderView();
+    const input = screen.getByPlaceholderText("400");
+    await userEvent.clear(input);
+
+    const reloaded = await DashboardConfig.user();
+    expect(reloaded.height).not.toBeNaN();
+    expect(reloaded.height).toBe(400);
+  });
+
+  it("数値を入力すればその値がそのまま保存される", async () => {
+    await renderView();
+    const input = screen.getByPlaceholderText("600");
+    fireEvent.change(input, { target: { value: "800" } });
+
+    const reloaded = await DashboardConfig.user();
+    expect(reloaded.width).toBe(800);
+  });
+});

--- a/tests/dashboard-setting-view.spec.tsx
+++ b/tests/dashboard-setting-view.spec.tsx
@@ -1,18 +1,13 @@
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 
 import { DashboardSettingView } from "../src/page/components/options/DashboardSettingView";
 import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
-// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineDefaults = structuredClone(DashboardConfig.default);
-
-beforeEach(() => {
-  DashboardConfig.default = structuredClone(pristineDefaults);
-});
+restoreDefaultsBeforeEach(DashboardConfig);
 
 async function renderView() {
   const config = await DashboardConfig.user();

--- a/tests/fleet-capture-options.spec.tsx
+++ b/tests/fleet-capture-options.spec.tsx
@@ -1,4 +1,4 @@
-import { expect, describe, it, vi, beforeEach } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
@@ -22,14 +22,9 @@ vi.mock("../src/services/Launcher", () => ({
 import { FleetCaptureSettingView } from "../src/page/components/options/FleetCaptureSettingView";
 import { CapturePreset } from "../src/models/CapturePreset";
 import { FleetCaptureConfig, TransparentBackground } from "../src/models/configs/FleetCaptureConfig";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
-// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineConfigDefaults = structuredClone(FleetCaptureConfig.default);
-
-beforeEach(() => {
-  FleetCaptureConfig.default = structuredClone(pristineConfigDefaults);
-});
+restoreDefaultsBeforeEach(FleetCaptureConfig);
 
 async function renderView() {
   const presets = await CapturePreset.list();

--- a/tests/fleet-capture-page.spec.tsx
+++ b/tests/fleet-capture-page.spec.tsx
@@ -47,6 +47,7 @@ vi.mock("../src/services/Launcher", () => ({
 import { FleetCapturePage } from "../src/page/fleet-capture/FleetCapturePage";
 import { fleetcapture } from "../src/page/loader";
 import { CapturePreset } from "../src/models/CapturePreset";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
 function renderPage() {
   const router = createMemoryRouter([
@@ -60,13 +61,10 @@ async function openAdjustMode() {
   await userEvent.click(screen.getByRole("button", { name: "切り抜き範囲を調整する" }));
 }
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、create() は
-// そのオブジェクトへ新規エントリを書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineDefaults = structuredClone(CapturePreset.default);
+restoreDefaultsBeforeEach(CapturePreset);
 
 beforeEach(() => {
   vi.unstubAllGlobals();
-  CapturePreset.default = structuredClone(pristineDefaults);
 });
 
 describe("FleetCapturePage", () => {

--- a/tests/helpers/jstorm-defaults.ts
+++ b/tests/helpers/jstorm-defaults.ts
@@ -1,0 +1,21 @@
+import { beforeEach } from "vitest";
+
+// static default を持つ jstorm Model クラスの静的側
+interface ModelClassWithDefault {
+  default: Record<string, unknown>;
+}
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、save()/update() は
+// そのオブジェクトへ直接書き込む。同一ファイル内のテスト間で default の汚染が波及しないよう、
+// 呼び出し時点（モジュール読み込み時）のスナップショットを各テスト前に復元する。
+// 注意: tests/setup.ts へは移さないこと。NotificationConfig など default 初期化子で
+// chrome.runtime.getURL を呼ぶモデルがあり、setup.ts は各 spec の chrome スタブ
+// （vi.hoisted）より前に実行されるため、モデルの import 自体が失敗する。
+export function restoreDefaultsBeforeEach(...models: ModelClassWithDefault[]): void {
+  const snapshots = models.map((model) => structuredClone(model.default));
+  beforeEach(() => {
+    models.forEach((model, i) => {
+      model.default = structuredClone(snapshots[i]);
+    });
+  });
+}

--- a/tests/logbook-retention.spec.ts
+++ b/tests/logbook-retention.spec.ts
@@ -1,17 +1,12 @@
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it } from "vitest";
 
 import { Logbook, SortieContext } from "../src/models/Logbook";
 import { BehaviorConfig } from "../src/models/configs/BehaviorConfig";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
-// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineBehaviorDefaults = structuredClone(BehaviorConfig.default);
-
-beforeEach(() => {
-  BehaviorConfig.default = structuredClone(pristineBehaviorDefaults);
-});
+restoreDefaultsBeforeEach(BehaviorConfig);
 
 async function saveSortieAt(id: string, started: number): Promise<void> {
   const ctx = new SortieContext();

--- a/tests/notification-config-default.spec.ts
+++ b/tests/notification-config-default.spec.ts
@@ -10,6 +10,9 @@ vi.hoisted(() => {
 });
 
 import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
+
+restoreDefaultsBeforeEach(NotificationConfig);
 
 // static default のキー集合は jstorm の find() フォールバックの根拠となる。1文字でも欠けると
 // 保存済み設定が読めなくなるため、直積生成の結果を固定キー集合として検証する。

--- a/tests/notification-config-getters.spec.ts
+++ b/tests/notification-config-getters.spec.ts
@@ -22,9 +22,9 @@ describe("NotificationConfig の type / trigger getter", () => {
     expect(config.trigger).toBe(TriggerType.START);
   });
 
-  it("EntryType 外の type セグメント（quest-alert）もそのまま返す", () => {
+  it("EntryType 外の type セグメント（quest-alert）は UNKNOWN に縮退する", () => {
     const config = NotificationConfig.new({}, "/quest-alert/start");
-    expect(config.type).toBe("quest-alert");
+    expect(config.type).toBe(EntryType.UNKNOWN);
     expect(config.trigger).toBe(TriggerType.START);
   });
 

--- a/tests/quest-action-tracking.spec.ts
+++ b/tests/quest-action-tracking.spec.ts
@@ -10,6 +10,9 @@ vi.hoisted(() => {
 
 import { onQuestStart, onQuestStop, onQuestComplete } from "../src/controllers/WebRequest/quest";
 import { QuestProgress, QuestStatus } from "../src/models/QuestProgress";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
+
+restoreDefaultsBeforeEach(QuestProgress);
 
 // api_req_quest/{start,stop,clearitemget} の formData から任務IDを取り出し、
 // QuestProgress へ反映できているかを検証する（連鎖解放そのものは quest-progress.spec.ts 側で検証済み）。

--- a/tests/quest-alert-notification.spec.ts
+++ b/tests/quest-alert-notification.spec.ts
@@ -20,9 +20,12 @@ vi.hoisted(() => {
 import { onPracticePrepare, onSortiePrepare } from "../src/controllers/WebRequest/quest";
 import { NotificationConfig, QUEST_ALERT_NOTIFICATION_ID } from "../src/models/configs/NotificationConfig";
 import { QuestProgress } from "../src/models/QuestProgress";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
 const create = chrome.notifications.create as unknown as ReturnType<typeof vi.fn>;
 const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
+
+restoreDefaultsBeforeEach(NotificationConfig, QuestProgress);
 
 // 消去方式(stay)が既定のfalse(自動)だと10秒後に自動でclearされる。fake timerで固定し、
 // 実時間の待ちタイマーをテストプロセスに残さないようにする。
@@ -53,26 +56,15 @@ describe("onPracticePrepare", () => {
   it("演習任務に着手済みなら通知を出さない", async () => {
     const progress = await QuestProgress.user();
     await progress.start(303);
-    try {
-      await onPracticePrepare();
-      expect(create).not.toHaveBeenCalled();
-    } finally {
-      // QuestProgress も default が書き換わる同種の問題があるため、着手状態を戻しておく
-      await progress.stop(303);
-    }
+    await onPracticePrepare();
+    expect(create).not.toHaveBeenCalled();
   });
 
   it("設定が無効なら通知を出さない", async () => {
     const config = (await NotificationConfig.find(QUEST_ALERT_NOTIFICATION_ID))!;
     await config.update({ enabled: false });
-    try {
-      await onPracticePrepare();
-      expect(create).not.toHaveBeenCalled();
-    } finally {
-      // jstorm は保存先が空のとき static default をその場で書き換えるため、
-      // ここで false のまま残すと他テストの既定値に波及する。明示的に戻す
-      await config.update({ enabled: true });
-    }
+    await onPracticePrepare();
+    expect(create).not.toHaveBeenCalled();
   });
 
   it("消去方式が既定(自動)なら10秒後に自動でclearされる", async () => {
@@ -85,13 +77,9 @@ describe("onPracticePrepare", () => {
   it("消去方式を手動にすると自動では消えない", async () => {
     const config = (await NotificationConfig.find(QUEST_ALERT_NOTIFICATION_ID))!;
     await config.update({ stay: true });
-    try {
-      await onPracticePrepare();
-      vi.advanceTimersByTime(10_000);
-      expect(clear).toHaveBeenCalledTimes(1); // 発火直前のclearのみ
-    } finally {
-      await config.update({ stay: false });
-    }
+    await onPracticePrepare();
+    vi.advanceTimersByTime(10_000);
+    expect(clear).toHaveBeenCalledTimes(1); // 発火直前のclearのみ
   });
 });
 
@@ -108,11 +96,7 @@ describe("onSortiePrepare", () => {
   it("出撃任務に着手済みなら通知を出さない", async () => {
     const progress = await QuestProgress.user();
     await progress.start(201);
-    try {
-      await onSortiePrepare();
-      expect(create).not.toHaveBeenCalled();
-    } finally {
-      await progress.stop(201);
-    }
+    await onSortiePrepare();
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/tests/quest-progress.spec.ts
+++ b/tests/quest-progress.spec.ts
@@ -3,6 +3,9 @@ import { expect, describe, it, vi } from "vitest";
 import { QuestProgress, QuestStatus } from "../src/models/QuestProgress";
 import { quests } from "../src/catalog";
 import { KCWDate } from "../src/utils";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
+
+restoreDefaultsBeforeEach(QuestProgress);
 
 describe("QuestProgress 初期状態", () => {
   it.each([303, 201])("前提任務のない任務(id=%i)はOPENで始まる", async (id) => {

--- a/tests/quest-tracker-list.spec.tsx
+++ b/tests/quest-tracker-list.spec.tsx
@@ -12,14 +12,12 @@ vi.hoisted(() => {
 
 import { QuestTrackerList } from "../src/page/components/quest-tracker/QuestTrackerList";
 import { QuestProgress, QuestStatus } from "../src/models/QuestProgress";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
 const addListener = chrome.storage.onChanged.addListener as unknown as ReturnType<typeof vi.fn>;
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() はそのオブジェクトへ
-// 書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineDefaults = structuredClone(QuestProgress.default);
+restoreDefaultsBeforeEach(QuestProgress);
 beforeEach(() => {
-  QuestProgress.default = structuredClone(pristineDefaults);
   addListener.mockClear();
 });
 

--- a/tests/quest-tracker-page.spec.tsx
+++ b/tests/quest-tracker-page.spec.tsx
@@ -1,4 +1,4 @@
-import { expect, describe, it, vi, beforeEach } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 
@@ -12,13 +12,9 @@ vi.hoisted(() => {
 
 import { QuestTrackerPage } from "../src/page/quest-tracker/QuestTrackerPage";
 import { QuestProgress } from "../src/models/QuestProgress";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
 
-// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() はそのオブジェクトへ
-// 書き込む。テスト間の汚染を防ぐため毎回復元する。
-const pristineDefaults = structuredClone(QuestProgress.default);
-beforeEach(() => {
-  QuestProgress.default = structuredClone(pristineDefaults);
-});
+restoreDefaultsBeforeEach(QuestProgress);
 
 // QuestTrackerPage を loader データ付きで単体レンダリングする。
 // loader の非同期初期化を待たずに済むよう、hydrationData で初期データを与える。

--- a/tests/use-config-field.spec.tsx
+++ b/tests/use-config-field.spec.tsx
@@ -1,0 +1,69 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useConfigField } from "../src/page/components/options/useConfigField";
+import { FleetCaptureConfig } from "../src/models/configs/FleetCaptureConfig";
+import { DashboardConfig } from "../src/models/configs/DashboardConfig";
+
+// jstorm はストレージが空の間 static default オブジェクトをそのまま返し、update() は
+// そのオブジェクトへ書き込む。テスト間の汚染を防ぐため毎回復元する。
+const pristineFleetCaptureDefaults = structuredClone(FleetCaptureConfig.default);
+const pristineDashboardDefaults = structuredClone(DashboardConfig.default);
+
+beforeEach(() => {
+  FleetCaptureConfig.default = structuredClone(pristineFleetCaptureDefaults);
+  DashboardConfig.default = structuredClone(pristineDashboardDefaults);
+});
+
+describe("useConfigField", () => {
+  // (a) save() がストレージへ永続化し、別途 Model.find で再取得しても値が反映されていることを確認する
+  it("save() が chrome.storage(メモリ) へ永続化し、Model.find で再取得できる", async () => {
+    const config = await FleetCaptureConfig.user();
+    const { result } = renderHook(() => useConfigField(config, "background", config.background));
+
+    await act(async () => {
+      await result.current[1]("#123456");
+    });
+
+    expect(result.current[0]).toBe("#123456");
+    const reloaded = await FleetCaptureConfig.user();
+    expect(reloaded.background).toBe("#123456");
+  });
+
+  // (b) normalize の結果が state（表示値）と保存値の両方に反映されることを確認する
+  it("normalize が保存値・表示値の両方に適用される", async () => {
+    const config = await DashboardConfig.user();
+    const { result } = renderHook(() =>
+      useConfigField(config, "width", config.width, {
+        normalize: (v: number) => (Number.isFinite(v) ? Math.trunc(v) : 600),
+      }),
+    );
+
+    // 小数は trunc され、表示値(state)にも保存値にも同じ整数が反映される
+    await act(async () => {
+      await result.current[1](150.7);
+    });
+    expect(result.current[0]).toBe(150);
+    expect((await DashboardConfig.user()).width).toBe(150);
+
+    // NaN は既定値へフォールバックする
+    await act(async () => {
+      await result.current[1](NaN);
+    });
+    expect(result.current[0]).toBe(600);
+    expect((await DashboardConfig.user()).width).toBe(600);
+  });
+
+  // (c) config.update が失敗したとき、setState に到達せず state が保存前の値のまま保たれることを確認する
+  it("config.update が reject したとき state が変わらない", async () => {
+    const config = await FleetCaptureConfig.user();
+    const { result } = renderHook(() => useConfigField(config, "background", config.background));
+    vi.spyOn(config, "update").mockRejectedValue(new Error("update failed"));
+
+    await act(async () => {
+      await expect(result.current[1]("#000000")).rejects.toThrow("update failed");
+    });
+
+    expect(result.current[0]).toBe("#ffffff");
+  });
+});

--- a/tests/use-typed-loader-data.spec.tsx
+++ b/tests/use-typed-loader-data.spec.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { useTypedLoaderData } from "../src/page/loader/useTypedLoaderData";
+
+// ダミー loader。実データ形状に依存しない最小のオブジェクトを返す
+async function dummyLoader() {
+  return { value: "hello" };
+}
+
+function DummyComponent() {
+  const { value } = useTypedLoaderData<typeof dummyLoader>();
+  return <div>{value}</div>;
+}
+
+// DummyComponent を loader データ付きで単体レンダリングする。
+// loader の非同期初期化を待たずに済むよう、hydrationData で初期データを与える。
+function renderDummy(value: string) {
+  const router = createMemoryRouter(
+    [{ id: "dummy", path: "/", element: <DummyComponent />, loader: dummyLoader }],
+    { hydrationData: { loaderData: { dummy: { value } } } },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe("useTypedLoaderData", () => {
+  it("loader の返り値をそのままコンポーネントへ素通しする", async () => {
+    renderDummy("hello");
+    expect(await screen.findByText("hello")).toBeInTheDocument();
+  });
+
+  it("戻り値の型が loader の Awaited<ReturnType> と一致する", () => {
+    type Result = ReturnType<typeof useTypedLoaderData<typeof dummyLoader>>;
+    expectTypeOf<Result>().toEqualTypeOf<Awaited<ReturnType<typeof dummyLoader>>>();
+  });
+});


### PR DESCRIPTION
リファクタリング4本の3本目です（監査の背景は #1840 参照）。React 層の定型コピーと型の二重管理を解消します。

## 全体構成とマージ順

- **PR-1**: background 層の規約・定型集約（#1840）
- **PR-2**: configs の既定値一元化と UserConfig 基底（#1841）
- **PR-3（本PR）**: UI 層の定型統一（**#1840 に依存**。ベースブランチを #1840 のブランチにしています。#1840 マージ後に main へ retarget して ready 化します）
- **PR-4**: サービス層・メッセージング集約（#1843。本PRに依存）

## マージ前提

以下のマージ後に rebase して ready 化します。それまで draft です。

- [ ] #1838
- [ ] #1839
- [ ] #1840

## 変更点

1. **useConfigField フック**: 設定ビュー20箇所超の「値取り出し→config.update→setState」定型と `useState(_config)` の参照固定イディオムを統一
2. **useTypedLoaderData**: 6ページの `useLoaderData() as {...}` 手書きキャストを廃止し、loader 関数の戻り値型を真実源に一元化
3. **テストの default 復元ヘルパー**: jstorm static default のテスト間汚染対策が3系統（同文5行コピー×6・try/finally×1・無防備×2）に割れていたのを `restoreDefaultsBeforeEach()` に一本化
4. **通知設定キーの消費側整理**: loader のキーリテラル12箇所を #1840 の NotificationId 経由に置換、NotificationSettingView の `_id.split()` 独自デコードを getter 化

## 挙動への影響

原則挙動不変。例外として以下を意図的に修正しています:

- ダッシュボード設定の窓サイズ・位置欄を空にした瞬間 NaN が chrome.storage に保存されるバグ（空にすると既定値に戻る挙動になります）
- 手書き型と loader 実体の乖離2件（Dashboard の window が実際は undefined になり得る／entries に実在しない TEST_DEFAULT キー）の型是正
- テスト2ファイルの実行順序依存の解消（--sequence.shuffle 通過）

## テスト

typecheck / lint / vitest 639件 全パス。実機で設定画面の総なめ（変更→リロード保持、数値欄の空入力、一括トグルとの連動）と全ページの描画を検証済みです。
