### PR TITLE
サービス層とメッセージングを集約する（Promise ネイティブ化 / capture / 保存 / ルート一元化）

### DIFF
--- a/src/controllers/Commands.ts
+++ b/src/controllers/Commands.ts
@@ -1,7 +1,6 @@
 import { Router } from "chromite";
 import { Launcher } from "../services/Launcher";
 import { ScreenshotService } from "../services/ScreenshotService";
-import { FileSaveConfig } from "../models/configs/FileSaveConfig";
 
 const onCommand = new Router<typeof chrome.commands.onCommand>(async (command) => ({ __action__: command }));
 
@@ -11,9 +10,7 @@ onCommand.on("/screenshot", async () => {
   if (!win || typeof win.id !== "number") {
     throw new Error("スクリーンショット対象のウィンドウが見つかりませんでした");
   }
-  const config = await FileSaveConfig.user();
-  const uri = await launcher.capture(win.id, { format: config.format });
-  return await new ScreenshotService(config).deliver(uri);
+  return await ScreenshotService.take(win.id);
 });
 
 export {

--- a/src/controllers/Cron/QueueWatcher.ts
+++ b/src/controllers/Cron/QueueWatcher.ts
@@ -21,11 +21,13 @@ async function check() {
     if (queue.scheduled > Date.now()) continue;
     try {
       const entry = queue.entry();
-      notification.notify(entry);
+      await notification.notify(entry);
       await queue.delete();
       // 完了通知を出したら、同じ対象の開始通知は役目を終えたので消す
       // （「手動で消すまで残す」設定の開始通知には、他に自動で消える経路がない）。
-      notification.clear(entry.$n.id(TriggerType.START));
+      // 他のQueueのcron処理を止めないよう、失敗してもawaitはせずログだけ残す。
+      void notification.clear(entry.$n.id(TriggerType.START))
+        .catch((e) => log.warn("開始通知の消去に失敗", e));
     } catch (e) {
       log.warn("Once:", e);
     }

--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -9,7 +9,7 @@ import { TriggerType } from "../models/entry";
 import { Launcher } from "../services/Launcher";
 import { ScreenshotService } from "../services/ScreenshotService";
 import { CropService } from "../services/CropService";
-import { FileSaveConfig } from "../models/configs/FileSaveConfig";
+import { TabService } from "../services/TabService";
 import { DashboardConfig } from "../models/configs/DashboardConfig";
 import { DamageSnapshotConfig, DamageSnapshotMode } from "../models/configs/DamageSnapshotConfig";
 import { GameWindowConfig } from "../models/configs/GameWindowConfig";
@@ -60,10 +60,7 @@ onMessage.on("/mute:toggle", async (_, sender) => {
 
 onMessage.on("/screenshot", async (_, sender) => {
   if (!sender.tab) return;
-  const launcher = new Launcher();
-  const config = await FileSaveConfig.user();
-  const uri = await launcher.capture(sender.tab.windowId, { format: config.format });
-  return await new ScreenshotService(config).deliver(uri);
+  return await ScreenshotService.take(sender.tab.windowId);
 });
 
 onMessage.on(`/injected/dmm/ocr/${EntryType.RECOVERY}:result`, async (req) => {
@@ -103,7 +100,7 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.SHIPBUILD}:result`, async (req) => {
 onMessage.on("/damage-snapshot/capture", async (req, sender) => {
   const { after, timestamp } = req;
   await sleep(after || 1000); // 描画待ち
-  const raw = await chrome.tabs.captureVisibleTab(sender.tab!.windowId, { format: "jpeg" });
+  const raw = await new TabService().capture(sender.tab!.windowId, { format: "jpeg" });
   const img = await WorkerImage.from(raw);
   const uri = await (new CropService(img)).crop("damagesnapshot");
 

--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -47,7 +47,7 @@ onMessage.on(Routes.FRAME_MEMORY_TRACK, async (req) => {
  * 形へ窓をカスタマイズする正規のユースケースと区別できないため採用しない（#1848）。
  * ユーザーが能動的に選んだときだけ実行される、安全な手動リセット導線とする。
  */
-onMessage.on("/frame/memory:reset", async () => {
+onMessage.on(Routes.FRAME_MEMORY_RESET, async () => {
   return await (await Frame.memory()).delete();
 });
 
@@ -55,7 +55,7 @@ onMessage.on("/frame/memory:reset", async () => {
  * dmm.ts の自己診断（#game_frame の実寸が100vw/100vh相当かのチェック）でズレを検知した際に、
  * 次のナビゲーションイベントを待たずにゲーム別窓を再活性化する（#1848）。
  */
-onMessage.on("/frame/self-check:mismatch", async (_, sender) => {
+onMessage.on(Routes.FRAME_SELF_CHECK_MISMATCH, async (_, sender) => {
   if (!sender.tab?.windowId) return;
   const win = await chrome.windows.get(sender.tab.windowId, { populate: true });
   return await (new Launcher()).reactivate(win);

--- a/src/controllers/Message.ts
+++ b/src/controllers/Message.ts
@@ -16,11 +16,13 @@ import { GameWindowConfig } from "../models/configs/GameWindowConfig";
 import { NotificationService } from "../services/NotificationService";
 import { Logbook } from "../models/Logbook";
 import { formatSortieLabel } from "../models/sortieLabel";
+import { Routes, ocrResultRoute } from "../messages";
+import type { Route, DsnapshotShowPayload, DsnapshotSeparatePushPayload } from "../messages";
 
 const onMessage = new Router<typeof chrome.runtime.onMessage>();
 const log = Logger.get("Message");
 
-onMessage.on("/frame/open-or-focus", async (req) => {
+onMessage.on(Routes.FRAME_OPEN_OR_FOCUS, async (req) => {
   const launcher = new Launcher();
   const id = req.frame_id;
   const frame = (await Frame.find(id)) ?? (await Frame.memory());
@@ -34,7 +36,7 @@ onMessage.on("/frame/open-or-focus", async (req) => {
   return created;
 });
 
-onMessage.on("/frame/memory:track", async (req) => {
+onMessage.on(Routes.FRAME_MEMORY_TRACK, async (req) => {
   const frame = await Frame.memory();
   return await frame.update({ position: req.position, size: req.size });
 });
@@ -46,24 +48,24 @@ onMessage.on("/frame/memory:track", async (req) => {
  * @param req.width 幅
  * @param req.height 高さ
  */
-onMessage.on("/dashboard:track", async (req) => {
+onMessage.on(Routes.DASHBOARD_TRACK, async (req) => {
   const dashboard = await DashboardConfig.user();
   return await dashboard.update({ left: req.left, top: req.top, width: req.width, height: req.height });
 });
 
-onMessage.on("/mute:toggle", async (_, sender) => {
+onMessage.on(Routes.MUTE_TOGGLE, async (_, sender) => {
   if (!sender.tab || !sender.tab.mutedInfo) return;
   const muted = !sender.tab.mutedInfo.muted;
   (await Frame.memory()).update({ muted });
   return await chrome.tabs.update(sender.tab!.id!, { muted });
 });
 
-onMessage.on("/screenshot", async (_, sender) => {
+onMessage.on(Routes.SCREENSHOT, async (_, sender) => {
   if (!sender.tab) return;
   return await ScreenshotService.take(sender.tab.windowId);
 });
 
-onMessage.on(`/injected/dmm/ocr/${EntryType.RECOVERY}:result`, async (req) => {
+onMessage.on(ocrResultRoute(EntryType.RECOVERY), async (req) => {
   const data = req.data as Page;
   const dock = req[EntryType.RECOVERY].dock;
   // 同じドックの既存Queueを削除してから積み直す（speedchange検知漏れ等で古いQueueが
@@ -81,7 +83,7 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.RECOVERY}:result`, async (req) => {
   NotificationService.new().notify(e, TriggerType.START);
 });
 
-onMessage.on(`/injected/dmm/ocr/${EntryType.SHIPBUILD}:result`, async (req) => {
+onMessage.on(ocrResultRoute(EntryType.SHIPBUILD), async (req) => {
   const data = req.data as Page;
   const dock = req[EntryType.SHIPBUILD].dock;
   // 建造が始まった事実に基づく掃除なので、OCR結果の成否に依らず行う。
@@ -97,7 +99,7 @@ onMessage.on(`/injected/dmm/ocr/${EntryType.SHIPBUILD}:result`, async (req) => {
   NotificationService.new().notify(e, TriggerType.START);
 });
 
-onMessage.on("/damage-snapshot/capture", async (req, sender) => {
+onMessage.on(Routes.DAMAGE_SNAPSHOT_CAPTURE, async (req, sender) => {
   const { after, timestamp } = req;
   await sleep(after || 1000); // 描画待ち
   const raw = await new TabService().capture(sender.tab!.windowId, { format: "jpeg" });
@@ -112,16 +114,16 @@ onMessage.on("/damage-snapshot/capture", async (req, sender) => {
   case DamageSnapshotMode.DISABLED:
     return;
   case DamageSnapshotMode.INAPP:
-    return chrome.tabs.sendMessage(sender.tab!.id!, { __action__: "/injected/kcs/dsnapshot:show", uri, timestamp, heightRatio: config.heightRatio, label });
+    return chrome.tabs.sendMessage(sender.tab!.id!, { __action__: Routes.DSNAPSHOT_SHOW, uri, timestamp, heightRatio: config.heightRatio, label } satisfies { __action__: Route<"DSNAPSHOT_SHOW"> } & DsnapshotShowPayload);
   case DamageSnapshotMode.SEPARATE: {
     const win = await Launcher.damagesnapshot(config);
     if (!win || !win.tabs || !win.tabs[0].id) throw new Error("Failed to get damage snapshot window");
-    return chrome.tabs.sendMessage(win.tabs[0].id, { __action__: "/dsnapshot/separate:push", uri, timestamp, label });
+    return chrome.tabs.sendMessage(win.tabs[0].id, { __action__: Routes.DSNAPSHOT_SEPARATE_PUSH, uri, timestamp, label } satisfies { __action__: Route<"DSNAPSHOT_SEPARATE_PUSH"> } & DsnapshotSeparatePushPayload);
   }
   }
 });
 
-onMessage.on("/configs", async () => {
+onMessage.on(Routes.CONFIGS, async () => {
   const game = await GameWindowConfig.user();
   return { game };
 });

--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -26,6 +26,8 @@ import { onQuestStart, onQuestStop, onQuestComplete, onPracticePrepare, onSortie
 import { ScriptingService } from "../../services/ScriptingService";
 import { NotificationService } from "../../services/NotificationService";
 import { EntryType, TriggerType } from "../../models/entry";
+import { Routes } from "../../messages";
+import type { Route, DsnapshotPreparePayload } from "../../messages";
 
 const requestLogger = Logger.get("WebRequest");
 const completeLogger = Logger.get("WebRequest:onComplete");
@@ -83,14 +85,14 @@ onComplete.on(["/kcsapi/api_start2/getData"], async ([details]) => {
 onComplete.on(["/kcsapi/api_req_sortie/battleresult"], async ([details]) => {
   const timestamp = Date.now();
   completeLogger.debug("api_req_sortie/battleresult", details);
-  chrome.tabs.sendMessage(details.tabId, { __action__: "/injected/kcs/dsnapshot:prepare", count: 1, timestamp }, {
+  chrome.tabs.sendMessage(details.tabId, { __action__: Routes.DSNAPSHOT_PREPARE, count: 1, timestamp } satisfies { __action__: Route<"DSNAPSHOT_PREPARE"> } & DsnapshotPreparePayload, {
     frameId: details.frameId,
   });
 });
 onComplete.on(["/kcsapi/api_req_combined_battle/battleresult"], async ([details]) => {
   const timestamp = Date.now();
   completeLogger.debug("api_req_combined_battle/battleresult", details);
-  chrome.tabs.sendMessage(details.tabId, { __action__: "/injected/kcs/dsnapshot:prepare", count: 2, timestamp }, {
+  chrome.tabs.sendMessage(details.tabId, { __action__: Routes.DSNAPSHOT_PREPARE, count: 2, timestamp } satisfies { __action__: Route<"DSNAPSHOT_PREPARE"> } & DsnapshotPreparePayload, {
     frameId: details.frameId,
   });
 });

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -66,6 +66,20 @@ export async function onMissionResult([details]: chrome.webRequest.OnBeforeReque
   await NotificationService.new().clearBy({ type: EntryType.MISSION, target: deck });
 }
 
+// 現在のゲーム画面をキャプチャし、対象領域を切り出して content script に OCR を依頼する
+async function requestOcr(details: chrome.webRequest.OnBeforeRequestDetails, type: EntryType.RECOVERY | EntryType.SHIPBUILD, dock: string): Promise<void> {
+  const tabs = new TabService();
+  const tab = await tabs.get(details.tabId);
+  const raw = await tabs.capture(tab.windowId, { format: "jpeg" });
+  const img = await WorkerImage.from(raw);
+  const url = await (new CropService(img)).crop(type, { dock });
+  await chrome.tabs.sendMessage(details.tabId, {
+    __action__: "/injected/dmm/ocr",
+    url, purpose: type,
+    [type]: { dock }
+  });
+}
+
 export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   log.debug("onRecoveryStart", details);
   const data = formData<RecoveryStartFormData>(details);
@@ -77,15 +91,7 @@ export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeReque
     await Queue.deleteSlot(EntryType.RECOVERY, dock);
     return;
   }
-  const tab = await new TabService().get(details.tabId);
-  const raw = await chrome.tabs.captureVisibleTab(tab.windowId, { format: "jpeg" });
-  const img = await WorkerImage.from(raw);
-  const url = await (new CropService(img)).crop(EntryType.RECOVERY);
-  await chrome.tabs.sendMessage(details.tabId, {
-    __action__: "/injected/dmm/ocr",
-    url, purpose: EntryType.RECOVERY,
-    [EntryType.RECOVERY]: { dock }
-  });
+  await requestOcr(details, EntryType.RECOVERY, dock);
 }
 
 // 修復中に高速修復剤を使って完了させたとき、そのドックの修復Queueと表示中の修復通知を消す。
@@ -196,16 +202,8 @@ export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestD
     await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
     return;
   }
-  const tab = await new TabService().get(details.tabId);
   await sleep(600); // いったんめんどくさいんでこれで
-  const raw = await chrome.tabs.captureVisibleTab(tab.windowId, { format: "jpeg" });
-  const img = await WorkerImage.from(raw);
-  const url = await (new CropService(img)).crop(EntryType.SHIPBUILD, { dock });
-  await chrome.tabs.sendMessage(details.tabId, {
-    __action__: "/injected/dmm/ocr",
-    url, purpose: EntryType.SHIPBUILD,
-    [EntryType.SHIPBUILD]: { dock }
-  });
+  await requestOcr(details, EntryType.SHIPBUILD, dock);
 }
 
 // 建造中に高速建造材を使って完了させたとき、そのドックの建造Queueを削除する

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -13,6 +13,8 @@ import { Launcher } from "../../services/Launcher";
 import { Logbook } from "../../models/Logbook";
 import { DamageSnapshotConfig } from "../../models/configs/DamageSnapshotConfig";
 import { BehaviorConfig } from "../../models/configs/BehaviorConfig";
+import { Routes } from "../../messages";
+import type { Route, DmmOcrPayload } from "../../messages";
 
 const log = Logger.get("WebRequest");
 
@@ -22,11 +24,11 @@ const log = Logger.get("WebRequest");
 async function clearSnapshotOnBattleStart(details: chrome.webRequest.OnBeforeRequestDetails) {
   const config = await DamageSnapshotConfig.user();
   if (config.keepUntilNextShow) return;
-  chrome.tabs.sendMessage(details.tabId, { __action__: "/injected/kcs/dsnapshot:remove" }, { frameId: details.frameId });
+  chrome.tabs.sendMessage(details.tabId, { __action__: Routes.DSNAPSHOT_REMOVE }, { frameId: details.frameId });
 }
 
 export async function onPort([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
-  chrome.tabs.sendMessage(details.tabId, { __action__: "/injected/kcs/dsnapshot:remove" }, { frameId: details.frameId });
+  chrome.tabs.sendMessage(details.tabId, { __action__: Routes.DSNAPSHOT_REMOVE }, { frameId: details.frameId });
   const dsnapshot = await new Launcher().getDsnapshotTab();
   if (dsnapshot) chrome.windows.remove(dsnapshot.windowId!);
   await Logbook.record();
@@ -67,17 +69,18 @@ export async function onMissionResult([details]: chrome.webRequest.OnBeforeReque
 }
 
 // 現在のゲーム画面をキャプチャし、対象領域を切り出して content script に OCR を依頼する
-async function requestOcr(details: chrome.webRequest.OnBeforeRequestDetails, type: EntryType.RECOVERY | EntryType.SHIPBUILD, dock: string): Promise<void> {
+async function requestOcr<P extends EntryType.RECOVERY | EntryType.SHIPBUILD>(details: chrome.webRequest.OnBeforeRequestDetails, type: P, dock: string): Promise<void> {
   const tabs = new TabService();
   const tab = await tabs.get(details.tabId);
   const raw = await tabs.capture(tab.windowId, { format: "jpeg" });
   const img = await WorkerImage.from(raw);
   const url = await (new CropService(img)).crop(type, { dock });
-  await chrome.tabs.sendMessage(details.tabId, {
-    __action__: "/injected/dmm/ocr",
+  const payload = {
+    __action__: Routes.DMM_OCR,
     url, purpose: type,
-    [type]: { dock }
-  });
+    [type]: { dock },
+  } as { __action__: Route<"DMM_OCR"> } & DmmOcrPayload<P>;
+  await chrome.tabs.sendMessage(details.tabId, payload);
 }
 
 export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {

--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -11,6 +11,7 @@ import type { Route, OcrResultRoute, OcrPurpose, DmmOcrPayload } from '../messag
   const SCREENSHOT: Route<"SCREENSHOT"> = "/screenshot";
   const MUTE_TOGGLE: Route<"MUTE_TOGGLE"> = "/mute:toggle";
   const FRAME_MEMORY_TRACK: Route<"FRAME_MEMORY_TRACK"> = "/frame/memory:track";
+  const FRAME_SELF_CHECK_MISMATCH: Route<"FRAME_SELF_CHECK_MISMATCH"> = "/frame/self-check:mismatch";
   const CONFIGS: Route<"CONFIGS"> = "/configs";
   const DMM_OCR: Route<"DMM_OCR"> = "/injected/dmm/ocr";
   const DMM_RETOUCH: Route<"DMM_RETOUCH"> = "/injected/dmm/retouch";
@@ -152,7 +153,7 @@ import type { Route, OcrResultRoute, OcrPurpose, DmmOcrPayload } from '../messag
     const rect = frame.getBoundingClientRect();
     const fits = Math.abs(rect.width - window.innerWidth) < 2 && Math.abs(rect.height - window.innerHeight) < 2;
     if (!fits) {
-      chrome.runtime.sendMessage(chrome.runtime.id, { __action__: "/frame/self-check:mismatch" });
+      chrome.runtime.sendMessage(chrome.runtime.id, { __action__: FRAME_SELF_CHECK_MISMATCH });
     }
   }
 

--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -1,9 +1,19 @@
 import { type GameWindowConfig } from '../models/configs/GameWindowConfig';
 import { ocr, warmUpOcrWorker } from './ocrWorker';
+import type { Route, OcrResultRoute, OcrPurpose, DmmOcrPayload } from '../messages';
 // import { Rectangle, load, crop } from './crop';
 
 (async () => {
   // const GameIFrame = "iframe#game_frame";
+
+  // 拡張内メッセージのルート文字列。src/messages.ts の Routes と値を一致させる（型注釈で乖離を tsc が検出）。
+  // content script は classic script として注入されるため src/messages.ts を実行時 import できない。
+  const SCREENSHOT: Route<"SCREENSHOT"> = "/screenshot";
+  const MUTE_TOGGLE: Route<"MUTE_TOGGLE"> = "/mute:toggle";
+  const FRAME_MEMORY_TRACK: Route<"FRAME_MEMORY_TRACK"> = "/frame/memory:track";
+  const CONFIGS: Route<"CONFIGS"> = "/configs";
+  const DMM_OCR: Route<"DMM_OCR"> = "/injected/dmm/ocr";
+  const DMM_RETOUCH: Route<"DMM_RETOUCH"> = "/injected/dmm/retouch";
 
 
   /**
@@ -54,7 +64,7 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
       parent.removeChild(this.container);
       await this.waitNextFrame(InAppActionButtons.FRAME_WAIT_FOR_CAPTURE);
       try {
-        await chrome.runtime.sendMessage<{ action: string }, chrome.tabs.Tab>(chrome.runtime.id, { action: "/screenshot" });
+        await chrome.runtime.sendMessage<{ __action__: Route<"SCREENSHOT"> }, chrome.tabs.Tab>(chrome.runtime.id, { __action__: SCREENSHOT });
       } finally {
         parent.appendChild(this.container);
       }
@@ -67,7 +77,7 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
     }
 
     private async toggleMute() {
-      const tab = await chrome.runtime.sendMessage<{ action: string }, chrome.tabs.Tab>(chrome.runtime.id, { action: "/mute:toggle" })
+      const tab = await chrome.runtime.sendMessage<{ __action__: Route<"MUTE_TOGGLE"> }, chrome.tabs.Tab>(chrome.runtime.id, { __action__: MUTE_TOGGLE })
       this.muteButton.innerHTML = tab.mutedInfo?.muted ? InAppActionButtons.ICON_SPEAKER_X_MARK : InAppActionButtons.ICON_SPEAKER_WAVE;
     }
     private createContainer(): HTMLDivElement {
@@ -123,7 +133,7 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
    */
   function track() {
     chrome.runtime.sendMessage(chrome.runtime.id, {
-      __action__: "/frame/memory:track",
+      __action__: FRAME_MEMORY_TRACK,
       position: { left: window.screenX, top: window.screenY },
       size: { width: window.innerWidth, height: window.innerHeight },
     });
@@ -133,22 +143,24 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
     game: GameWindowConfig;
   }> {
     return new Promise(resolve => {
-      chrome.runtime.sendMessage(chrome.runtime.id, { __action__: "/configs" }, resolve);
+      chrome.runtime.sendMessage(chrome.runtime.id, { __action__: CONFIGS }, resolve);
     });
   }
 
   function startListeningMessage() {
     chrome.runtime.onMessage.addListener(async (msg) => {
-      if (msg.__action__ === "/injected/dmm/ocr" && msg.url) {
-        const url = msg.url;
+      if (msg.__action__ === DMM_OCR && msg.url) {
+        const request = msg as DmmOcrPayload<OcrPurpose>;
+        const url = request.url;
         const i = document.createElement("img"); i.src = url; document.body.appendChild(i);
         const ret = await ocr(url);
+        const route: OcrResultRoute = `/injected/dmm/ocr/${request.purpose}:result`;
         chrome.runtime.sendMessage(chrome.runtime.id, {
-          __action__: `/injected/dmm/ocr/${msg.purpose}:result`, data: ret.data,
-          purpose: msg.purpose, [msg.purpose]: msg[msg.purpose],
+          __action__: route, data: ret.data,
+          purpose: request.purpose, [request.purpose]: request[request.purpose],
         });
       }
-      if (msg.__action__ === "/injected/dmm/retouch") {
+      if (msg.__action__ === DMM_RETOUCH) {
         // retouch は Launcher 側で windows.update により外形をフレーム設定へ
         // 戻した直後に届くため、ここでは無条件に補正してよい
         resize();

--- a/src/injection/osapi.ts
+++ b/src/injection/osapi.ts
@@ -1,7 +1,16 @@
 /**
  * iframeの中のゲーム画面に対するinjection
  */
+import type { Route } from '../messages';
+
 (() => {
+
+  // 拡張内メッセージのルート文字列。src/messages.ts の Routes と値を一致させる（型注釈で乖離を tsc が検出）。
+  // content script は classic script として注入されるため src/messages.ts を実行時 import できない。
+  const PREPARE: Route<"DSNAPSHOT_PREPARE"> = "/injected/kcs/dsnapshot:prepare";
+  const SHOW: Route<"DSNAPSHOT_SHOW"> = "/injected/kcs/dsnapshot:show";
+  const REMOVE: Route<"DSNAPSHOT_REMOVE"> = "/injected/kcs/dsnapshot:remove";
+  const CAPTURE: Route<"DAMAGE_SNAPSHOT_CAPTURE"> = "/damage-snapshot/capture";
 
   function load(uri: string): Promise<HTMLImageElement> {
     return new Promise(resolve => {
@@ -83,7 +92,7 @@
       if (now - this.lastClickedAt < this.ignoreMillisecBetweenClicks) return;
       this.lastClickedAt = now;
       chrome.runtime.sendMessage(chrome.runtime.id, {
-        action: "/damage-snapshot/capture", after: 1000 + (800 * this.clicked), timestamp: this.timestamp,
+        __action__: CAPTURE, after: 1000 + (800 * this.clicked), timestamp: this.timestamp,
       })
       this.clicked += 1;
       if (this.count <= this.clicked) {
@@ -162,11 +171,11 @@
   const ds = new DamageSnapshot();
   chrome.runtime.onMessage.addListener(async (msg) => {
     switch (msg.__action__) {
-    case "/injected/kcs/dsnapshot:prepare":
+    case PREPARE:
       return ds.prepare(msg);
-    case "/injected/kcs/dsnapshot:show":
+    case SHOW:
       return ds.show(msg);
-    case "/injected/kcs/dsnapshot:remove":
+    case REMOVE:
       return ds.remove();
     }
   });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,82 @@
+// 拡張内メッセージ（chrome.runtime / chrome.tabs.sendMessage）のルート文字列とペイロード型を一元化する。
+//
+// content script (src/injection/*) からは import type のみで参照すること。
+// 実行時 import を書くと複数エントリ間の共有チャンクが生成され、chrome.scripting.executeScript で
+// classic script として注入される dist/dmm.js / dist/osapi.js が ESM import を含んで壊れる。
+// content script 側ではローカル定数に Route<K> 型注釈を付けて Routes との一致を tsc に検査させる。
+
+import type { Page } from "tesseract.js";
+import type { EntryType } from "./models/entry";
+
+// 拡張内メッセージのルート識別子。値は送信側・受信側で共有する単一の真実源。
+export const Routes = {
+  DMM_RETOUCH: "/injected/dmm/retouch",
+  DMM_OCR: "/injected/dmm/ocr",
+  DSNAPSHOT_PREPARE: "/injected/kcs/dsnapshot:prepare",
+  DSNAPSHOT_SHOW: "/injected/kcs/dsnapshot:show",
+  DSNAPSHOT_REMOVE: "/injected/kcs/dsnapshot:remove",
+  DSNAPSHOT_SEPARATE_PUSH: "/dsnapshot/separate:push",
+  FRAME_OPEN_OR_FOCUS: "/frame/open-or-focus",
+  FRAME_MEMORY_TRACK: "/frame/memory:track",
+  DASHBOARD_TRACK: "/dashboard:track",
+  MUTE_TOGGLE: "/mute:toggle",
+  SCREENSHOT: "/screenshot",
+  DAMAGE_SNAPSHOT_CAPTURE: "/damage-snapshot/capture",
+  CONFIGS: "/configs",
+  SOUND_PLAY: "/sound/play",
+} as const;
+
+export type Route<K extends keyof typeof Routes> = typeof Routes[K];
+
+// OCR依頼・結果のルートは入渠(RECOVERY)・建造(SHIPBUILD)ごとに枝分かれする。
+export type OcrPurpose = EntryType.RECOVERY | EntryType.SHIPBUILD;
+export type OcrResultRoute = `${typeof Routes.DMM_OCR}/${OcrPurpose}:result`;
+export const ocrResultRoute = (purpose: OcrPurpose): OcrResultRoute => `${Routes.DMM_OCR}/${purpose}:result`;
+
+// ルートごとのペイロード型。__action__ は含めず、送信側で __action__ と合わせて使う。
+export interface DsnapshotPreparePayload {
+  count: number;
+  timestamp: number;
+}
+
+export interface DsnapshotShowPayload {
+  uri: string;
+  timestamp: number;
+  heightRatio?: number;
+  label?: string | null;
+}
+
+export interface DsnapshotSeparatePushPayload {
+  uri: string;
+  timestamp: number;
+  label?: string | null;
+}
+
+export type DmmOcrPayload<P extends OcrPurpose> = { url: string; purpose: P } & { [K in P]: { dock: string } };
+
+export type OcrResultPayload<P extends OcrPurpose> = { data: Page; purpose: P } & { [K in P]: { dock: string } };
+
+export interface FrameMemoryTrackPayload {
+  position: { left: number; top: number };
+  size: { width: number; height: number };
+}
+
+export interface DashboardTrackPayload {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface DamageSnapshotCapturePayload {
+  after: number;
+  timestamp: number;
+}
+
+export interface FrameOpenOrFocusPayload {
+  frame_id?: string;
+}
+
+export interface SoundPlayPayload {
+  url: string;
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -18,6 +18,8 @@ export const Routes = {
   DSNAPSHOT_SEPARATE_PUSH: "/dsnapshot/separate:push",
   FRAME_OPEN_OR_FOCUS: "/frame/open-or-focus",
   FRAME_MEMORY_TRACK: "/frame/memory:track",
+  FRAME_MEMORY_RESET: "/frame/memory:reset",
+  FRAME_SELF_CHECK_MISMATCH: "/frame/self-check:mismatch",
   DASHBOARD_TRACK: "/dashboard:track",
   MUTE_TOGGLE: "/mute:toggle",
   SCREENSHOT: "/screenshot",

--- a/src/page/Dashboard.tsx
+++ b/src/page/Dashboard.tsx
@@ -6,6 +6,7 @@ import { QuestTrackerList } from "./components/quest-tracker/QuestTrackerList";
 import { dashboard } from "./loader";
 import { useTypedLoaderData } from "./loader/useTypedLoaderData";
 import { useEffect } from "react";
+import { Routes } from "../messages";
 
 export function DashboardPage() {
   const { window, queues, time, frameId, questTrackerConfig, questProgress, config } = useTypedLoaderData<typeof dashboard>();
@@ -25,7 +26,7 @@ export function DashboardPage() {
         if (!currentWindow.left || !currentWindow.top || !currentWindow.width || !currentWindow.height) return;
 
         await chrome.runtime.sendMessage({
-          __action__: "/dashboard:track",
+          __action__: Routes.DASHBOARD_TRACK,
           left: currentWindow.left,
           top: currentWindow.top,
           width: currentWindow.width,

--- a/src/page/PopupPage.tsx
+++ b/src/page/PopupPage.tsx
@@ -1,5 +1,7 @@
 import { Launcher } from "../services/Launcher"
 import { GameWindowConfig } from "../models/configs/GameWindowConfig"
+import { Routes } from "../messages"
+import type { Route } from "../messages"
 import { popup } from "./loader"
 import { useTypedLoaderData } from "./loader/useTypedLoaderData"
 
@@ -35,10 +37,10 @@ export function PopupPage() {
     }
     try {
       await chrome.runtime.sendMessage<
-        { action: string; frame_id?: string },
+        { __action__: Route<"FRAME_OPEN_OR_FOCUS">; frame_id?: string },
         { opened: boolean; frame_id: string | null }
       >(chrome.runtime.id, {
-        action: "/frame/open-or-focus",
+        __action__: Routes.FRAME_OPEN_OR_FOCUS,
         frame_id: frameId,
       });
     } catch (error) {

--- a/src/page/components/dashboard/ActionsView.tsx
+++ b/src/page/components/dashboard/ActionsView.tsx
@@ -3,6 +3,8 @@ import { Launcher } from "../../../services/Launcher";
 import { useRevalidator } from "react-router-dom";
 import { ScreenshotService } from "../../../services/ScreenshotService";
 import { CameraIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from "@heroicons/react/24/outline";
+import { Routes } from "../../../messages";
+import type { Route } from "../../../messages";
 
 function MuteControlButton({ tab, launcher, refresh }: { tab?: chrome.tabs.Tab, launcher: Launcher, refresh: () => void }) {
   if (!tab) return null;
@@ -30,10 +32,10 @@ function LaunchControlButton({ frameId }: { frameId: string }) {
   const onClick = async () => {
     try {
       await chrome.runtime.sendMessage<
-        { action: string; frame_id?: string },
+        { __action__: Route<"FRAME_OPEN_OR_FOCUS">; frame_id?: string },
         { opened: boolean; frame_id: string | null }
       >(chrome.runtime.id, {
-        action: "/frame/open-or-focus",
+        __action__: Routes.FRAME_OPEN_OR_FOCUS,
         frame_id: frameId,
       });
     } catch (error) {

--- a/src/page/components/dashboard/ActionsView.tsx
+++ b/src/page/components/dashboard/ActionsView.tsx
@@ -3,7 +3,6 @@ import { Launcher } from "../../../services/Launcher";
 import { useRevalidator } from "react-router-dom";
 import { ScreenshotService } from "../../../services/ScreenshotService";
 import { CameraIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from "@heroicons/react/24/outline";
-import { FileSaveConfig } from "../../../models/configs/FileSaveConfig";
 
 function MuteControlButton({ tab, launcher, refresh }: { tab?: chrome.tabs.Tab, launcher: Launcher, refresh: () => void }) {
   if (!tab) return null;
@@ -16,13 +15,11 @@ function MuteControlButton({ tab, launcher, refresh }: { tab?: chrome.tabs.Tab, 
   )
 }
 
-function CaptureControlButton({ tab, launcher }: { tab?: chrome.tabs.Tab, launcher: Launcher }) {
+function CaptureControlButton({ tab }: { tab?: chrome.tabs.Tab }) {
   if (!tab) return null;
   return (
     <div onClick={async () => {
-      const config = await FileSaveConfig.user();
-      const uri = await launcher.capture(tab.windowId, { format: config.format });
-      await new ScreenshotService(config).deliver(uri);
+      await ScreenshotService.take(tab.windowId);
     }} className="cursor-pointer text-slate-400 hover:text-slate-600" title="スクリーンショットを保存">
       <CameraIcon className="w-8 h-8" aria-hidden="true" />
     </div>
@@ -57,7 +54,7 @@ export function ActionsView({tab, frameId}: { tab?: chrome.tabs.Tab, frameId: st
   return (
     <div className="flex-1 flex items-center justify-end space-x-4">
       <LaunchControlButton frameId={frameId} />
-      <CaptureControlButton tab={tab} launcher={launcher} />
+      <CaptureControlButton tab={tab} />
       <MuteControlButton tab={tab} launcher={launcher} refresh={refresh} />
     </div>
   )

--- a/src/page/components/options/FrameSettingView.tsx
+++ b/src/page/components/options/FrameSettingView.tsx
@@ -5,6 +5,7 @@ import { Launcher } from "../../../services/Launcher";
 import { ScriptingService } from "../../../services/ScriptingService";
 import { FoldableSection } from "../FoldableSection";
 import { useConfigField } from "./useConfigField";
+import { Routes } from "../../../messages";
 
 export function FrameSettingView({
   frames,
@@ -43,7 +44,7 @@ export function FrameSettingView({
             {frame._id === "__memory__" && <div>
               <button className="border rounded p-2 cursor-pointer border-slate-200 bg-slate-100"
                 onClick={async () => {
-                  await chrome.runtime.sendMessage(chrome.runtime.id, { __action__: "/frame/memory:reset" });
+                  await chrome.runtime.sendMessage(chrome.runtime.id, { __action__: Routes.FRAME_MEMORY_RESET });
                   navigate("/options?open=frames");
                 }}
               >ウィンドウサイズをリセット</button>

--- a/src/page/fleet-capture/useFleetCapture.ts
+++ b/src/page/fleet-capture/useFleetCapture.ts
@@ -6,7 +6,6 @@ import { Launcher } from "../../services/Launcher";
 import { WorkerImage } from "../../utils";
 import { Logger } from "../../logger";
 import { CapturePreset } from "../../models/CapturePreset";
-import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
 import { FleetCaptureConfig, TransparentBackground } from "../../models/configs/FleetCaptureConfig";
 import {
   createEmptyResultSet,
@@ -179,10 +178,7 @@ export function useFleetCapture({ presets }: UseFleetCaptureOptions): FleetCaptu
           ctx.drawImage(img, colIndex * width, rowIndex * height, width, height);
         });
       });
-      const config = await FileSaveConfig.user();
-      const downloadService = new DownloadService(config);
-      const dataUrl = canvas.toDataURL(`image/${config.format}`);
-      await downloadService.download(dataUrl);
+      await DownloadService.saveCanvasAsImage(canvas);
     } catch (error) {
       log.error("exportResults failed", error);
       alert("画像の結合に失敗しました。コンソールログを確認してください。");

--- a/src/page/fleet-capture/useFleetCapture.ts
+++ b/src/page/fleet-capture/useFleetCapture.ts
@@ -79,8 +79,13 @@ export function useFleetCapture({ presets }: UseFleetCaptureOptions): FleetCaptu
       setPreview(null);
       return;
     }
-    setPreview(await launcher.capture(win.id!));
-  }, []);
+    try {
+      setPreview(await launcher.capture(win.id!));
+    } catch (error) {
+      log.error("refreshPreview failed", error);
+      setPreview(null);
+    }
+  }, [log]);
 
   // 初回表示時にプレビューを取得する（StrictModeの二重実行で連続キャプチャしないようガード）
   const previewRequested = useRef(false);
@@ -98,13 +103,18 @@ export function useFleetCapture({ presets }: UseFleetCaptureOptions): FleetCaptu
         alert("ゲームウィンドウを検出できませんでした。");
         return;
       }
-      const whole = await launcher.capture(win.id!);
-      const workerImage = await WorkerImage.from(whole);
-      const cropper = new CropService(workerImage);
-      const cropped = await cropper.cropRelative(rect);
-      setResults((prev) => updateResultCell(prev, rowIndex, colIndex, cropped));
+      try {
+        const whole = await launcher.capture(win.id!);
+        const workerImage = await WorkerImage.from(whole);
+        const cropper = new CropService(workerImage);
+        const cropped = await cropper.cropRelative(rect);
+        setResults((prev) => updateResultCell(prev, rowIndex, colIndex, cropped));
+      } catch (error) {
+        log.error("captureCell failed", error);
+        alert("ゲームウィンドウのキャプチャに失敗しました。");
+      }
     },
-    [rect],
+    [rect, log],
   );
 
   const clearCell = useCallback((rowIndex: number, colIndex: number) => {

--- a/src/page/logbook/LogbookPage.tsx
+++ b/src/page/logbook/LogbookPage.tsx
@@ -4,7 +4,6 @@ import { ArrowDownTrayIcon, ArrowPathIcon, BookOpenIcon } from "@heroicons/react
 import { SortieContext } from "../../models/Logbook";
 import { describeBattles, formatStarted } from "./format";
 import { logbookExportFilename, toCSV, toDataUrl, toJSONL } from "./export";
-import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
 import { DownloadService } from "../../services/DownloadService";
 import { logbook } from "../loader";
 import { useTypedLoaderData } from "../loader/useTypedLoaderData";
@@ -19,10 +18,7 @@ const CSV_BOM = String.fromCharCode(0xfeff);
 async function downloadLogbook(sorties: SortieContext[], format: "csv" | "jsonl") {
   const content = format === "csv" ? CSV_BOM + toCSV(sorties) : toJSONL(sorties);
   const mimeType = format === "csv" ? "text/csv" : "application/x-ndjson";
-  await new DownloadService(new FileSaveConfig()).download(
-    toDataUrl(content, mimeType),
-    logbookExportFilename(format),
-  );
+  await DownloadService.direct(toDataUrl(content, mimeType), logbookExportFilename(format));
 }
 
 export function LogbookPage() {

--- a/src/page/screenshot-edit/useScreenshotEditor.ts
+++ b/src/page/screenshot-edit/useScreenshotEditor.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { TempStorage } from "../../services/TempStorage";
 import { DownloadService } from "../../services/DownloadService";
-import { FileSaveConfig } from "../../models/configs/FileSaveConfig";
 
 // 編集ツール種別。crop: ドラッグ範囲で切り取り、rect: ドラッグ範囲に矩形を描く
 export type ToolType = "crop" | "rect";
@@ -149,9 +148,7 @@ export function useScreenshotEditor(key: string | null): ScreenshotEditorControl
   const save = useCallback(async () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const config = await FileSaveConfig.user();
-    const uri = canvas.toDataURL(`image/${config.format}`);
-    await new DownloadService(config).download(uri);
+    await DownloadService.saveCanvasAsImage(canvas);
   }, []);
 
   return {

--- a/src/page/snapshot/DamageSnapshotPage.tsx
+++ b/src/page/snapshot/DamageSnapshotPage.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from "react"
+import { Routes } from "../../messages";
+import type { DsnapshotSeparatePushPayload } from "../../messages";
 
 export function DamageSnapshotPage() {
   const [uris, setURIs] = useState<string[]>([]);
@@ -9,17 +11,18 @@ export function DamageSnapshotPage() {
   const shownTimestamp = useRef<number | undefined>(undefined);
   useEffect(() => {
     chrome.runtime.onMessage.addListener((msg) => {
-      if (msg.__action__ === "/dsnapshot/separate:push") {
-        const timestamp = msg.timestamp as number;
+      if (msg.__action__ === Routes.DSNAPSHOT_SEPARATE_PUSH) {
+        const push = msg as DsnapshotSeparatePushPayload;
+        const timestamp = push.timestamp;
         // 新しい戦闘（timestampが変わった）なら前回までの画像を消して置き換える。
         // 同じtimestamp（連合艦隊の2ペイン目）は消さずに横へ追記する（#1815）。
         if (shownTimestamp.current !== timestamp) {
-          setURIs([msg.uri as string]);
+          setURIs([push.uri]);
           shownTimestamp.current = timestamp;
         } else {
-          setURIs((prev) => [...prev, msg.uri as string]);
+          setURIs((prev) => [...prev, push.uri]);
         }
-        if (msg.label) setLabel(msg.label as string);
+        if (push.label) setLabel(push.label);
       }
     });
     document.title = "艦隊状況";

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -6,16 +6,31 @@ export class DownloadService {
     private readonly mod = chrome.downloads,
   ) { }
 
-  public async download(url: string, filename?: string): Promise<number> {
-    filename = filename || (this.config.folder + "/" + this.config.getFilename(new Date()));
-    const options: chrome.downloads.DownloadOptions = {
-      url,
-      filename,
-      saveAs: this.config.askAlways,
-    };
-    return this.mod.download(options);
+  public async download(url: string): Promise<number> {
+    const filename = this.config.folder + "/" + this.config.getFilename(new Date());
+    return this.mod.download({ url, filename, saveAs: this.config.askAlways });
   }
+
   public async show(downloadId: number) {
     return this.mod.show(downloadId);
+  }
+
+  /**
+   * ファイル保存設定を参照せず、指定 URL・ファイル名でダウンロードフォルダ直下に保存する。
+   * 保存ダイアログは出さない（saveAs: false）。
+   */
+  public static async direct(url: string, filename: string, mod = chrome.downloads): Promise<number> {
+    return mod.download({ url, filename, saveAs: false });
+  }
+
+  /**
+   * canvas をユーザーのファイル保存設定に従って画像として保存する。
+   * 実際のエンコード形式とファイル名の拡張子が一致するよう、
+   * toDataURL のフォーマット指定（config.format）もここで行う。
+   */
+  public static async saveCanvasAsImage(canvas: HTMLCanvasElement): Promise<number> {
+    const config = await FileSaveConfig.user();
+    const uri = canvas.toDataURL(`image/${config.format}`);
+    return new DownloadService(config).download(uri);
   }
 }

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -13,12 +13,7 @@ export class DownloadService {
       filename,
       saveAs: this.config.askAlways,
     };
-    return new Promise((resolve, reject) => {
-      this.mod.download(options, (id) => {
-        if (chrome.runtime.lastError) return reject(chrome.runtime.lastError);
-        resolve(id);
-      });
-    });
+    return this.mod.download(options);
   }
   public async show(downloadId: number) {
     return this.mod.show(downloadId);

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -7,6 +7,7 @@ import { KanColleURL } from "../constants";
 import { DashboardConfig } from "../models/configs/DashboardConfig";
 import { DamageSnapshotConfig } from "../models/configs/DamageSnapshotConfig";
 import { sleep } from "../utils";
+import { Routes } from "../messages";
 
 /**
  * 艦これウィジェットがゲーム別窓や関連タブを起動・管理するための制御クラス。
@@ -216,7 +217,7 @@ export class Launcher {
   public async retouch(win: chrome.windows.Window, frame: Frame | null) {
     if (frame) {
       await this.windows.update(win.id!, { ...frame.size });
-      chrome.tabs.sendMessage(win.tabs![0].id!, { __action__: "/injected/dmm/retouch" });
+      chrome.tabs.sendMessage(win.tabs![0].id!, { __action__: Routes.DMM_RETOUCH });
     }
     await this.focus(win.id!);
   }

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -307,15 +307,15 @@ export class Launcher {
   }
 
   /**
-   * 指定タブの可視領域をキャプチャし、Base64 データ URL を返す。
-   * @param tabId 対象タブ ID
+   * 指定ウィンドウの可視領域をキャプチャし、Base64 データ URL を返す。
+   * @param windowId 対象ウィンドウ ID
    * @param options Chrome のキャプチャオプション（既定は JPEG/100）
    * @returns キャプチャ結果の文字列
    */
-  public async capture(tabId: number, options: chrome.extensionTypes.ImageDetails = {
+  public async capture(windowId: number, options: chrome.extensionTypes.ImageDetails = {
     format: "jpeg",
     quality: 100,
   }): Promise<string> {
-    return this.tabs.capture(tabId, options);
+    return this.tabs.capture(windowId, options);
   }
 }

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -17,12 +17,12 @@ export class NotificationService {
     return all[id];
   }
 
-  public getAll(): Promise<Record<string, boolean>> {
-    return new Promise((resolve) => this.mod.getAll(obj => resolve(obj as Record<string, boolean>)));
+  public async getAll(): Promise<Record<string, boolean>> {
+    return await this.mod.getAll() as Record<string, boolean>;
   }
 
   public clear(id: string): Promise<boolean> {
-    return new Promise((resolve) => this.mod.clear(id, (wasCleared) => resolve(wasCleared)));
+    return this.mod.clear(id);
   }
 
   // 表示中の通知のうち条件に一致するものをすべて消す。
@@ -35,7 +35,7 @@ export class NotificationService {
   }
 
   public create(id: string, options: chrome.notifications.NotificationCreateOptions): Promise<string> {
-    return new Promise((resolve) => this.mod.create(id, options, (notificationId) => resolve(notificationId)));
+    return this.mod.create(id, options);
   }
 
   public async notify(entry: Entry, trigger: TriggerType = TriggerType.END): Promise<string> {

--- a/src/services/ScreenshotService.ts
+++ b/src/services/ScreenshotService.ts
@@ -17,6 +17,17 @@ export class ScreenshotService {
   ) { }
 
   /**
+   * 指定ウィンドウの可視領域を撮影し、ユーザー設定に応じて保存または編集ページへ渡す。
+   * @param windowId 撮影対象のウィンドウ ID
+   * @param launcher キャプチャを担うサービス（既定は新規 Launcher）
+   */
+  public static async take(windowId: number, launcher: Pick<Launcher, "capture"> = new Launcher()): Promise<void> {
+    const config = await FileSaveConfig.user();
+    const uri = await launcher.capture(windowId, { format: config.format });
+    return new ScreenshotService(config).deliver(uri);
+  }
+
+  /**
    * 撮影画像を設定に応じて処理する
    * @param uri 撮影画像の dataURL
    */

--- a/src/services/SoundService.ts
+++ b/src/services/SoundService.ts
@@ -1,3 +1,5 @@
+import { Routes } from "../messages";
+
 /**
  * 通知音の再生を担うサービス。
  * 実行環境に応じて適切なドライバーを選択し、呼び出し側は単一のAPIで扱えるようにする。
@@ -36,7 +38,7 @@ interface SoundDriver {
 }
 
 const OFFSCREEN_DOCUMENT_PATH = "offscreen/index.html";
-export const SOUND_PLAY_ACTION = "/sound/play";
+export const SOUND_PLAY_ACTION = Routes.SOUND_PLAY;
 
 function resolveDriver(): SoundDriver {
   if (typeof globalThis.Audio === "function") {

--- a/src/services/TabService.ts
+++ b/src/services/TabService.ts
@@ -20,8 +20,8 @@ export class TabService {
     return await this.mod.update(tabId, props);
   }
 
-  // TODO: 各所で chrome.tabs.captureVisibleTab を使っているので、ここに集約させたい
-  public async capture(windowId: number, options: chrome.extensionTypes.ImageDetails) {
+  // 可視タブをキャプチャして dataURL を返す
+  public async capture(windowId: number, options: chrome.extensionTypes.ImageDetails): Promise<string> {
     return await this.mod.captureVisibleTab(windowId, options);
   }
 }

--- a/src/services/TabService.ts
+++ b/src/services/TabService.ts
@@ -5,11 +5,7 @@ export class TabService {
   ) { }
 
   public async query(queryInfo: chrome.tabs.QueryInfo) {
-    return await new Promise<chrome.tabs.Tab[]>((resolve) => {
-      this.mod.query(queryInfo, (tabs) => {
-        resolve(tabs);
-      });
-    });
+    return await this.mod.query(queryInfo);
   }
 
   public async get(tabId: number): Promise<chrome.tabs.Tab> {
@@ -26,10 +22,6 @@ export class TabService {
 
   // TODO: 各所で chrome.tabs.captureVisibleTab を使っているので、ここに集約させたい
   public async capture(windowId: number, options: chrome.extensionTypes.ImageDetails) {
-    return await new Promise<string>((resolve) => {
-      this.mod.captureVisibleTab(windowId, options, (dataUrl) => {
-        resolve(dataUrl);
-      });
-    });
+    return await this.mod.captureVisibleTab(windowId, options);
   }
 }

--- a/tests/dashboard-launch-anchor.spec.tsx
+++ b/tests/dashboard-launch-anchor.spec.tsx
@@ -42,7 +42,8 @@ describe("ActionsView の錨アイコン", () => {
 
     expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(1);
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith("test", {
-      action: "/frame/open-or-focus",
+      // ルート文字列は受信側(Message.ts)との契約なのでリテラルで固定する
+      __action__: "/frame/open-or-focus",
       frame_id: "__classic__",
     });
   });

--- a/tests/download-service.spec.ts
+++ b/tests/download-service.spec.ts
@@ -1,0 +1,84 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+import { Model } from "jstorm/chrome/local";
+import { installMemoryStorage } from "jstorm/testing";
+
+// static saveCanvasAsImage は mod を注入できず既定の chrome.downloads を使うため、
+// グローバルスタブを用意しておく。
+const { downloadMock } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const downloadMock = vi.fn(async (_options: unknown) => 1);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    downloads: { download: downloadMock },
+  };
+  return { downloadMock };
+});
+
+import { DownloadService } from "../src/services/DownloadService";
+import { FileSaveConfig } from "../src/models/configs/FileSaveConfig";
+
+beforeEach(() => {
+  downloadMock.mockClear();
+});
+
+describe("DownloadService", () => {
+  // インスタンス download が config 由来の filename（folder + getFilename）と
+  // saveAs（askAlways）を chrome.downloads.download に渡すことを検証する
+  it("インスタンス download は folder/getFilename 由来の filename と config.askAlways 由来の saveAs を渡す", async () => {
+    const area = installMemoryStorage({
+      "FileSaveConfig": {
+        "user": { _id: "user", askAlways: true, folder: "myfolder", filenameTemplate: "%Y%m%d_%H%M%S", format: "png" },
+      },
+    });
+    Model.useStorage(area);
+    const config = await FileSaveConfig.user();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const mod = { download: vi.fn(async (_options: chrome.downloads.DownloadOptions) => 42) };
+
+    const id = await new DownloadService(config, mod).download("data:image/png;base64,xx");
+
+    expect(id).toBe(42);
+    expect(mod.download).toHaveBeenCalledTimes(1);
+    const [options] = mod.download.mock.calls[0];
+    expect(options.url).toBe("data:image/png;base64,xx");
+    expect(options.filename).toMatch(/^myfolder\/\d{8}_\d{6}\.png$/);
+    expect(options.saveAs).toBe(true);
+  });
+
+  // static direct が指定された url/filename をそのまま渡し、saveAs を false に固定することを検証する
+  it("static direct は渡された url/filename をそのまま渡し saveAs を false に固定する", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const mod = { download: vi.fn(async (_options: chrome.downloads.DownloadOptions) => 7) };
+
+    const id = await DownloadService.direct("data:text/csv;base64,yy", "logbook.csv", mod);
+
+    expect(id).toBe(7);
+    expect(mod.download).toHaveBeenCalledWith({
+      url: "data:text/csv;base64,yy",
+      filename: "logbook.csv",
+      saveAs: false,
+    });
+  });
+
+  // static saveCanvasAsImage が toDataURL に渡す MIME と、getFilename が付ける拡張子を
+  // config.format で一致させていることを検証する
+  it("static saveCanvasAsImage は config.format に応じた MIME で toDataURL を呼び、拡張子が一致するファイル名で保存する", async () => {
+    const area = installMemoryStorage({
+      "FileSaveConfig": {
+        "user": { _id: "user", askAlways: false, folder: "艦これ", filenameTemplate: "%Y%m%d_%H%M%S", format: "jpeg" },
+      },
+    });
+    Model.useStorage(area);
+    const toDataURL = vi.fn(() => "data:image/jpeg;base64,x");
+    const canvas = { toDataURL } as unknown as HTMLCanvasElement;
+
+    await DownloadService.saveCanvasAsImage(canvas);
+
+    expect(toDataURL).toHaveBeenCalledWith("image/jpeg");
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+    const [options] = downloadMock.mock.calls[0] as [chrome.downloads.DownloadOptions];
+    expect(options.url).toBe("data:image/jpeg;base64,x");
+    expect(options.filename).toMatch(/\.jpeg$/);
+  });
+});

--- a/tests/dsnapshot-delivery.spec.ts
+++ b/tests/dsnapshot-delivery.spec.ts
@@ -1,0 +1,191 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// Message.ts / WebRequest 系の import 連鎖が chrome.runtime 等を参照するため、import より前にスタブする
+const { sendMessage, removeWindow } = vi.hoisted(() => {
+  const sendMessage = vi.fn();
+  const removeWindow = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+    notifications: { getAll: vi.fn(), clear: vi.fn() },
+    tabs: { sendMessage },
+    windows: { remove: removeWindow },
+  };
+  return { sendMessage, removeWindow };
+});
+
+const { capture } = vi.hoisted(() => ({ capture: vi.fn().mockResolvedValue("data:image/jpeg;base64,raw") }));
+vi.mock("../src/services/TabService", () => ({
+  TabService: vi.fn().mockImplementation(() => ({ capture })),
+}));
+
+const { crop } = vi.hoisted(() => ({ crop: vi.fn().mockResolvedValue("cropped-uri") }));
+vi.mock("../src/services/CropService", () => ({
+  CropService: vi.fn().mockImplementation(() => ({ crop })),
+}));
+
+const { getDsnapshotTab, damagesnapshot } = vi.hoisted(() => ({
+  getDsnapshotTab: vi.fn(),
+  damagesnapshot: vi.fn(),
+}));
+vi.mock("../src/services/Launcher", () => ({
+  Launcher: Object.assign(
+    vi.fn().mockImplementation(() => ({ getDsnapshotTab })),
+    { damagesnapshot },
+  ),
+}));
+
+const { dsnapshotUser } = vi.hoisted(() => ({ dsnapshotUser: vi.fn() }));
+vi.mock("../src/models/configs/DamageSnapshotConfig", () => ({
+  DamageSnapshotConfig: { user: dsnapshotUser },
+  DamageSnapshotMode: { DISABLED: "disabled", INAPP: "inapp", SEPARATE: "separate" },
+}));
+
+const { formatSortieLabel } = vi.hoisted(() => ({ formatSortieLabel: vi.fn() }));
+vi.mock("../src/models/sortieLabel", () => ({ formatSortieLabel }));
+
+vi.mock("../src/models/Logbook", () => ({
+  Logbook: { record: vi.fn().mockResolvedValue(null), sortie: { map: null, battles: [] } },
+}));
+
+vi.mock("../src/utils", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sleep: vi.fn().mockResolvedValue(undefined),
+  WorkerImage: { from: vi.fn().mockResolvedValue({ bitmap: {} }) },
+}));
+
+// Message.ts の他ルートが参照する依存はこのテストの対象外なので、最小スタブに差し替える
+vi.mock("../src/models/Frame", () => ({ Frame: { find: vi.fn(), memory: vi.fn() } }));
+vi.mock("../src/models/Queue", () => ({ default: { deleteSlot: vi.fn(), create: vi.fn() } }));
+vi.mock("../src/services/ScreenshotService", () => ({ ScreenshotService: vi.fn() }));
+vi.mock("../src/models/configs/DashboardConfig", () => ({ DashboardConfig: { user: vi.fn() } }));
+vi.mock("../src/models/configs/GameWindowConfig", () => ({ GameWindowConfig: { user: vi.fn() } }));
+vi.mock("../src/services/NotificationService", () => ({
+  NotificationService: { new: () => ({ notify: vi.fn(), clearBy: vi.fn() }) },
+}));
+
+import { onMessage } from "../src/controllers/Message";
+import { onComplete } from "../src/controllers/WebRequest";
+import { onPort } from "../src/controllers/WebRequest/kcsapi";
+import { Routes } from "../src/messages";
+
+// Router 経由でメッセージを1件処理させ、内部ハンドラの完了(sendResponse呼び出し)を待つ
+// (tests/queue-dedupe-on-ocr-result.spec.ts と同じ流儀)
+function dispatchMessage(message: Record<string, unknown>, sender: chrome.runtime.MessageSender): Promise<unknown> {
+  const listener = onMessage.listener();
+  return new Promise((resolve) => {
+    listener(message, sender, resolve);
+  });
+}
+
+// SequentialRouter(onComplete) 経由でイベントを1件流し、ハンドラの完了を待つ
+// (tests/notification-clear-on-recovery.spec.ts と同じ流儀)
+const completeListener = onComplete.listener();
+async function fireComplete(path: string, tabId: number, frameId: number) {
+  completeListener({ url: `https://w00g.kancolle-server.com${path}`, tabId, frameId } as unknown as chrome.webRequest.OnCompletedDetails);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// 大破進撃防止スナップショットの撮影〜配送フロー（/damage-snapshot/capture）を検証する。
+// TabService.capture で撮影し、設定モードに応じてゲーム別窓内 or 別窓へ表示メッセージを送る。
+describe("/damage-snapshot/capture の配送(Message.ts)", () => {
+  beforeEach(() => {
+    capture.mockClear();
+    crop.mockClear();
+    sendMessage.mockClear();
+    damagesnapshot.mockClear();
+    formatSortieLabel.mockReset();
+    dsnapshotUser.mockReset();
+  });
+
+  it("INAPPモード: TabService.captureで撮影し、送信元タブへDSNAPSHOT_SHOWを送る", async () => {
+    dsnapshotUser.mockResolvedValue({ mode: "inapp", heightRatio: 55, areaLabelFormat: "number" });
+    formatSortieLabel.mockReturnValue("1-1 (2)");
+
+    await dispatchMessage(
+      { __action__: Routes.DAMAGE_SNAPSHOT_CAPTURE, after: 0, timestamp: 12345 },
+      { tab: { windowId: 9, id: 5 } } as unknown as chrome.runtime.MessageSender,
+    );
+
+    expect(capture).toHaveBeenCalledWith(9, { format: "jpeg" });
+    expect(sendMessage).toHaveBeenCalledWith(5, {
+      __action__: Routes.DSNAPSHOT_SHOW,
+      uri: "cropped-uri",
+      timestamp: 12345,
+      heightRatio: 55,
+      label: "1-1 (2)",
+    });
+  });
+
+  it("SEPARATEモード: 別窓のダメージスナップショットタブへDSNAPSHOT_SEPARATE_PUSHを送る", async () => {
+    dsnapshotUser.mockResolvedValue({ mode: "separate", heightRatio: 40, areaLabelFormat: "number" });
+    formatSortieLabel.mockReturnValue("2-3 (1)");
+    damagesnapshot.mockResolvedValue({ tabs: [{ id: 77 }] });
+
+    await dispatchMessage(
+      { __action__: Routes.DAMAGE_SNAPSHOT_CAPTURE, after: 0, timestamp: 999 },
+      { tab: { windowId: 9, id: 5 } } as unknown as chrome.runtime.MessageSender,
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith(77, {
+      __action__: Routes.DSNAPSHOT_SEPARATE_PUSH,
+      uri: "cropped-uri",
+      timestamp: 999,
+      label: "2-3 (1)",
+    });
+  });
+});
+
+// 戦闘結果を回収しようとしたとき（api_req_sortie/battleresult 系）、大破進撃防止窓を表示する
+// 準備としてDSNAPSHOT_PREPAREを送ることを検証する。単艦隊と連合艦隊で count が変わる（#1764）。
+describe("戦闘結果回収時のDSNAPSHOT_PREPARE送信(WebRequest/index.ts)", () => {
+  beforeEach(() => {
+    sendMessage.mockClear();
+  });
+
+  it("通常艦隊のbattleresult: count:1でDSNAPSHOT_PREPAREを送る", async () => {
+    await fireComplete("/kcsapi/api_req_sortie/battleresult", 11, 3);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      11,
+      expect.objectContaining({ __action__: Routes.DSNAPSHOT_PREPARE, count: 1 }),
+      { frameId: 3 },
+    );
+  });
+
+  it("連合艦隊のbattleresult: count:2でDSNAPSHOT_PREPAREを送る", async () => {
+    await fireComplete("/kcsapi/api_req_combined_battle/battleresult", 12, 4);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      12,
+      expect.objectContaining({ __action__: Routes.DSNAPSHOT_PREPARE, count: 2 }),
+      { frameId: 4 },
+    );
+  });
+});
+
+// 母港帰投時（api_port/port）、開いたままの大破進撃防止別窓を閉じることを検証する。
+describe("母港帰投時のダメージスナップショット別窓クローズ(kcsapi.ts onPort)", () => {
+  const details = [{ tabId: 1, frameId: 0 }] as unknown as chrome.webRequest.OnBeforeRequestDetails[];
+
+  beforeEach(() => {
+    removeWindow.mockClear();
+    getDsnapshotTab.mockReset();
+  });
+
+  it("別窓が開いているとき、そのwindowIdでchrome.windows.removeする", async () => {
+    getDsnapshotTab.mockResolvedValue({ windowId: 33 });
+
+    await onPort(details);
+
+    expect(removeWindow).toHaveBeenCalledWith(33);
+  });
+
+  it("別窓が無いとき、chrome.windows.removeを呼ばない", async () => {
+    getDsnapshotTab.mockResolvedValue(undefined);
+
+    await onPort(details);
+
+    expect(removeWindow).not.toHaveBeenCalled();
+  });
+});

--- a/tests/logbook-page.spec.tsx
+++ b/tests/logbook-page.spec.tsx
@@ -6,7 +6,8 @@ import { RouterProvider, createMemoryRouter } from "react-router-dom";
 // chrome.downloads はダウンロードボタンのテストでのみ必要。呼び出された
 // filename/url を検証できるよう、DownloadService からの呼び出しをモックする。
 const { downloadMock } = vi.hoisted(() => {
-  const downloadMock = vi.fn((_options: unknown, cb: (id: number) => void) => cb(1));
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const downloadMock = vi.fn(async (_options: unknown) => 1);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).chrome = {
     runtime: { lastError: undefined },

--- a/tests/logbook-page.spec.tsx
+++ b/tests/logbook-page.spec.tsx
@@ -89,17 +89,19 @@ describe("LogbookPage", () => {
     renderPage([sortie()]);
     await userEvent.click(await screen.findByRole("button", { name: "CSV" }));
     await waitFor(() => expect(downloadMock).toHaveBeenCalledTimes(1));
-    const [options] = downloadMock.mock.calls[0] as [{ filename: string; url: string }];
+    const [options] = downloadMock.mock.calls[0] as [{ filename: string; url: string; saveAs: boolean }];
     expect(options.filename).toMatch(/\.csv$/);
     expect(options.url).toMatch(/^data:text\/csv/);
+    expect(options.saveAs).toBe(false);
   });
 
   it("JSONLボタンを押すと .jsonl ファイルをダウンロードする", async () => {
     renderPage([sortie()]);
     await userEvent.click(await screen.findByRole("button", { name: "JSONL" }));
     await waitFor(() => expect(downloadMock).toHaveBeenCalledTimes(1));
-    const [options] = downloadMock.mock.calls[0] as [{ filename: string; url: string }];
+    const [options] = downloadMock.mock.calls[0] as [{ filename: string; url: string; saveAs: boolean }];
     expect(options.filename).toMatch(/\.jsonl$/);
     expect(options.url).toMatch(/^data:application\/x-ndjson/);
+    expect(options.saveAs).toBe(false);
   });
 });

--- a/tests/messages-routes.spec.ts
+++ b/tests/messages-routes.spec.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it } from "vitest";
+import { Routes, ocrResultRoute } from "../src/messages";
+import { EntryType } from "../src/models/entry";
+
+// 拡張内メッセージのルート定数（src/messages.ts）の値を、送受信の契約リテラルとして固定する。
+// 定数の値が変わると送信側・受信側の実際の文字列一致が壊れるため、値を直接リテラルで比較して
+// 事故的な変更を検出する。送信側実装が定数を参照する形になっても、この期待値は独立した契約として残す。
+describe("メッセージルート定数の契約", () => {
+  it("Routes の全定数が期待リテラルと一致する", () => {
+    expect(Routes).toEqual({
+      DMM_RETOUCH: "/injected/dmm/retouch",
+      DMM_OCR: "/injected/dmm/ocr",
+      DSNAPSHOT_PREPARE: "/injected/kcs/dsnapshot:prepare",
+      DSNAPSHOT_SHOW: "/injected/kcs/dsnapshot:show",
+      DSNAPSHOT_REMOVE: "/injected/kcs/dsnapshot:remove",
+      DSNAPSHOT_SEPARATE_PUSH: "/dsnapshot/separate:push",
+      FRAME_OPEN_OR_FOCUS: "/frame/open-or-focus",
+      FRAME_MEMORY_TRACK: "/frame/memory:track",
+      DASHBOARD_TRACK: "/dashboard:track",
+      MUTE_TOGGLE: "/mute:toggle",
+      SCREENSHOT: "/screenshot",
+      DAMAGE_SNAPSHOT_CAPTURE: "/damage-snapshot/capture",
+      CONFIGS: "/configs",
+      SOUND_PLAY: "/sound/play",
+    });
+  });
+
+  it.each([
+    [EntryType.RECOVERY, "/injected/dmm/ocr/recovery:result"],
+    [EntryType.SHIPBUILD, "/injected/dmm/ocr/shipbuild:result"],
+  ])("ocrResultRoute(%s) は期待リテラルを返す", (purpose, expected) => {
+    expect(ocrResultRoute(purpose)).toBe(expected);
+  });
+});

--- a/tests/messages-routes.spec.ts
+++ b/tests/messages-routes.spec.ts
@@ -16,6 +16,8 @@ describe("メッセージルート定数の契約", () => {
       DSNAPSHOT_SEPARATE_PUSH: "/dsnapshot/separate:push",
       FRAME_OPEN_OR_FOCUS: "/frame/open-or-focus",
       FRAME_MEMORY_TRACK: "/frame/memory:track",
+      FRAME_MEMORY_RESET: "/frame/memory:reset",
+      FRAME_SELF_CHECK_MISMATCH: "/frame/self-check:mismatch",
       DASHBOARD_TRACK: "/dashboard:track",
       MUTE_TOGGLE: "/mute:toggle",
       SCREENSHOT: "/screenshot",

--- a/tests/no-timer-on-highspeed-start.spec.ts
+++ b/tests/no-timer-on-highspeed-start.spec.ts
@@ -22,6 +22,7 @@ vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create } }));
 vi.mock("../src/services/TabService", () => ({
   TabService: class {
     get = vi.fn().mockResolvedValue({ windowId: 1 });
+    capture = vi.fn().mockResolvedValue("data:image/jpeg;base64,stub");
   },
 }));
 vi.mock("../src/services/CropService", () => ({

--- a/tests/notification-clear-on-collection.spec.ts
+++ b/tests/notification-clear-on-collection.spec.ts
@@ -21,12 +21,10 @@ import { onMissionResult, onGetShip } from "../src/controllers/WebRequest/kcsapi
 const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
 const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
 
-// 表示中の通知IDを与えてスタブを構成する（コールバック形式のAPI）
+// 表示中の通知IDを与えてスタブを構成する
 const displaying = (ids: string[]) => {
-  getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
-    cb(Object.fromEntries(ids.map((id) => [id, true])));
-  });
-  clear.mockImplementation((_id: string, cb: (wasCleared: boolean) => void) => cb(true));
+  getAll.mockResolvedValue(Object.fromEntries(ids.map((id) => [id, true])));
+  clear.mockResolvedValue(true);
 };
 
 // ハンドラに渡す webRequest details の最小構成

--- a/tests/notification-clear-on-recovery.spec.ts
+++ b/tests/notification-clear-on-recovery.spec.ts
@@ -21,14 +21,10 @@ import { onComplete } from "../src/controllers/WebRequest";
 const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
 const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
 
-// 表示中の通知IDを与えてスタブを構成する（コールバック形式のAPI）
+// 表示中の通知IDを与えてスタブを構成する
 const displaying = (ids: string[]) => {
-  getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
-    cb(Object.fromEntries(ids.map((id) => [id, true])));
-  });
-  // clearBy は NotificationService.clear（コールバックを Promise 解決に使う）経由で消すため、
-  // コールバックを呼ばないと await が解決せずテストがタイムアウトする。
-  clear.mockImplementation((_id: string, cb?: (wasCleared: boolean) => void) => cb?.(true));
+  getAll.mockResolvedValue(Object.fromEntries(ids.map((id) => [id, true])));
+  clear.mockResolvedValue(true);
 };
 
 const clearedIds = () => clear.mock.calls.map(([id]) => id);

--- a/tests/notification-service-clearby.spec.ts
+++ b/tests/notification-service-clearby.spec.ts
@@ -18,12 +18,10 @@ import { EntryType, TriggerType } from "../src/models/entry";
 const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
 const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
 
-// 表示中の通知IDを与えてスタブを構成する（どちらもコールバック形式のAPI）
+// 表示中の通知IDを与えてスタブを構成する
 const displaying = (ids: string[]) => {
-  getAll.mockImplementation((cb: (n: Record<string, boolean>) => void) => {
-    cb(Object.fromEntries(ids.map((id) => [id, true])));
-  });
-  clear.mockImplementation((_id: string, cb?: (wasCleared: boolean) => void) => cb?.(true));
+  getAll.mockResolvedValue(Object.fromEntries(ids.map((id) => [id, true])));
+  clear.mockResolvedValue(true);
 };
 
 const clearedIds = () => clear.mock.calls.map(([id]) => id).sort();

--- a/tests/notification-service-notify-propagates-create-failure.spec.ts
+++ b/tests/notification-service-notify-propagates-create-failure.spec.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it, vi } from "vitest";
+
+// NotificationService が chrome.notifications を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: {
+      id: "test",
+      onMessage: { addListener: () => {} },
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+    },
+    notifications: {
+      create: vi.fn(async () => { throw new Error("notification create failed"); }),
+      clear: vi.fn(async () => true),
+    },
+  };
+});
+
+import { NotificationService } from "../src/services/NotificationService";
+import { NotificationConfig } from "../src/models/configs/NotificationConfig";
+import { Fatigue } from "../src/models/entry";
+import { restoreDefaultsBeforeEach } from "./helpers/jstorm-defaults";
+
+restoreDefaultsBeforeEach(NotificationConfig);
+
+// chrome.notifications.create はネイティブ Promise 形式なので、拡張機能側の権限不足等で
+// 失敗すると reject される。notify() がその失敗を握りつぶさず呼び出し元に伝播することを検証する。
+describe("NotificationService.notify", () => {
+  it("create が失敗したら、その失敗を reject として呼び出し元に伝播する", async () => {
+    const service = new NotificationService();
+    const entry = new Fatigue("1", { area: 1, info: 1 });
+    await expect(service.notify(entry)).rejects.toThrow("notification create failed");
+  });
+});

--- a/tests/ocr-request.spec.ts
+++ b/tests/ocr-request.spec.ts
@@ -1,0 +1,85 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// kcsapi.ts の import 連鎖が chrome.runtime を参照するため、import より前にスタブする
+const { sendMessage } = vi.hoisted(() => {
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+    notifications: { getAll: vi.fn(), clear: vi.fn() },
+    tabs: { sendMessage },
+  };
+  return { sendMessage };
+});
+
+const { deleteSlot } = vi.hoisted(() => ({
+  deleteSlot: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../src/models/Queue", () => ({ default: { deleteSlot, create: vi.fn().mockResolvedValue({ entry: () => ({}) }) } }));
+
+const { capture } = vi.hoisted(() => ({
+  capture: vi.fn().mockResolvedValue("data:image/jpeg;base64,stub"),
+}));
+vi.mock("../src/services/TabService", () => ({
+  TabService: class {
+    get = vi.fn().mockResolvedValue({ windowId: 42 });
+    capture = capture;
+  },
+}));
+
+const { crop } = vi.hoisted(() => ({ crop: vi.fn().mockResolvedValue("cropped-data-url") }));
+vi.mock("../src/services/CropService", () => ({
+  CropService: class {
+    crop = crop;
+  },
+}));
+
+vi.mock("../src/utils", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sleep: vi.fn().mockResolvedValue(undefined),
+  WorkerImage: { from: vi.fn().mockResolvedValue({}) },
+}));
+
+import { onRecoveryStart, onCreateShip } from "../src/controllers/WebRequest/kcsapi";
+import { EntryType } from "../src/models/entry";
+
+// ハンドラに渡す webRequest details の最小構成
+const details = (formData: Record<string, string[]>) =>
+  [{ tabId: 10, requestBody: { formData } }] as unknown as chrome.webRequest.OnBeforeRequestDetails[];
+
+beforeEach(() => {
+  capture.mockClear();
+  sendMessage.mockClear();
+  crop.mockClear();
+  deleteSlot.mockClear();
+});
+
+// kcsapi.ts の requestOcr に集約した「撮影→切り出し→OCR依頼」の契約を固定する回帰テスト。
+// onRecoveryStart / onCreateShip のどちらから呼ばれても同じ形のメッセージを送ることを検証する。
+describe("requestOcr の契約(修復/建造共通)", () => {
+  it("修復開始時: 撮影したウィンドウを対象に(type, {dock})でcropし、その結果をOCR依頼メッセージで送る", async () => {
+    await onRecoveryStart(details({ api_highspeed: ["0"], api_ndock_id: ["3"], api_ship_id: ["100"] }));
+
+    expect(capture).toHaveBeenCalledWith(42, { format: "jpeg" });
+    expect(crop).toHaveBeenCalledWith(EntryType.RECOVERY, { dock: "3" });
+    expect(sendMessage).toHaveBeenCalledWith(10, {
+      __action__: "/injected/dmm/ocr",
+      url: "cropped-data-url",
+      purpose: EntryType.RECOVERY,
+      [EntryType.RECOVERY]: { dock: "3" },
+    });
+  });
+
+  it("建造開始時: 撮影したウィンドウを対象に(type, {dock})でcropし、その結果をOCR依頼メッセージで送る", async () => {
+    await onCreateShip(details({ api_highspeed: ["0"], api_kdock_id: ["5"] }));
+
+    expect(capture).toHaveBeenCalledWith(42, { format: "jpeg" });
+    expect(crop).toHaveBeenCalledWith(EntryType.SHIPBUILD, { dock: "5" });
+    expect(sendMessage).toHaveBeenCalledWith(10, {
+      __action__: "/injected/dmm/ocr",
+      url: "cropped-data-url",
+      purpose: EntryType.SHIPBUILD,
+      [EntryType.SHIPBUILD]: { dock: "5" },
+    });
+  });
+});

--- a/tests/quest-alert-notification.spec.ts
+++ b/tests/quest-alert-notification.spec.ts
@@ -10,9 +10,8 @@ vi.hoisted(() => {
       getURL: (path: string) => `chrome-extension://test/${path}`,
     },
     notifications: {
-      // NotificationService.create/clear はコールバック経由でPromiseを解決するため、素の vi.fn() だとawaitがハングする
-      create: vi.fn((id: string, _options: unknown, cb?: (id: string) => void) => cb?.(id)),
-      clear: vi.fn((id: string, cb?: (wasCleared: boolean) => void) => cb?.(true)),
+      create: vi.fn(async (id: string) => id),
+      clear: vi.fn(async () => true),
     },
   };
 });
@@ -30,7 +29,7 @@ restoreDefaultsBeforeEach(NotificationConfig, QuestProgress);
 // 消去方式(stay)が既定のfalse(自動)だと10秒後に自動でclearされる。fake timerで固定し、
 // 実時間の待ちタイマーをテストプロセスに残さないようにする。
 beforeEach(() => {
-  // mockReset() だとコールバックを呼ぶ実装（hoisted側で設定）まで消えてPromiseがハングするので、
+  // mockReset() だと hoisted 側で設定した実装（Promise解決）まで消えてしまうので、
   // 呼び出し履歴だけ消す mockClear() を使う
   create.mockClear();
   clear.mockClear();
@@ -45,7 +44,7 @@ afterEach(() => {
 describe("onPracticePrepare", () => {
   it("演習任務が未着手なら通知を出し、アイコンは他の通知と同じ既定値を使う", async () => {
     await onPracticePrepare();
-    expect(clear).toHaveBeenCalledWith("/quest-alert/practice", expect.any(Function));
+    expect(clear).toHaveBeenCalledWith("/quest-alert/practice");
     expect(create).toHaveBeenCalledTimes(1);
     const [id, options] = create.mock.calls[0] as [string, chrome.notifications.NotificationCreateOptions];
     expect(id).toBe("/quest-alert/practice");
@@ -86,7 +85,7 @@ describe("onPracticePrepare", () => {
 describe("onSortiePrepare", () => {
   it("出撃任務が未着手なら通知を出す", async () => {
     await onSortiePrepare();
-    expect(clear).toHaveBeenCalledWith("/quest-alert/sortie", expect.any(Function));
+    expect(clear).toHaveBeenCalledWith("/quest-alert/sortie");
     expect(create).toHaveBeenCalledTimes(1);
     const [id, options] = create.mock.calls[0] as [string, chrome.notifications.NotificationCreateOptions];
     expect(id).toBe("/quest-alert/sortie");

--- a/tests/screenshot-entrypoints.spec.ts
+++ b/tests/screenshot-entrypoints.spec.ts
@@ -1,0 +1,105 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// Commands.ts / Message.ts の import 連鎖が chrome.runtime 等を参照するため、import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} }, getURL: (p: string) => p },
+    commands: { onCommand: { addListener: () => {} } },
+  };
+});
+
+const { take } = vi.hoisted(() => ({ take: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../src/services/ScreenshotService", () => ({ ScreenshotService: { take } }));
+
+const { launcherFind, LauncherCtor } = vi.hoisted(() => {
+  const launcherFind = vi.fn();
+  const LauncherCtor = vi.fn().mockImplementation(() => ({ find: launcherFind }));
+  return { launcherFind, LauncherCtor };
+});
+vi.mock("../src/services/Launcher", () => ({ Launcher: LauncherCtor }));
+
+// Message.ts の他ルートが参照する依存はこのテストの対象外なので、最小スタブに差し替えて
+// import 時の副作用（実ストレージ/実サービスへのアクセス）を避ける。
+vi.mock("../src/models/Frame", () => ({ Frame: { find: vi.fn(), memory: vi.fn() } }));
+vi.mock("../src/models/Queue", () => ({ default: { deleteSlot: vi.fn(), create: vi.fn() } }));
+vi.mock("../src/services/CropService", () => ({ CropService: vi.fn() }));
+vi.mock("../src/services/TabService", () => ({ TabService: vi.fn() }));
+vi.mock("../src/services/NotificationService", () => ({
+  NotificationService: { new: () => ({ notify: vi.fn(), clearBy: vi.fn() }) },
+}));
+vi.mock("../src/models/configs/DashboardConfig", () => ({ DashboardConfig: { user: vi.fn() } }));
+vi.mock("../src/models/configs/DamageSnapshotConfig", () => ({
+  DamageSnapshotConfig: { user: vi.fn() },
+  DamageSnapshotMode: { DISABLED: "disabled", INAPP: "inapp", SEPARATE: "separate" },
+}));
+vi.mock("../src/models/configs/GameWindowConfig", () => ({ GameWindowConfig: { user: vi.fn() } }));
+vi.mock("../src/models/Logbook", () => ({ Logbook: { record: vi.fn(), sortie: { map: null, battles: [] } } }));
+vi.mock("../src/models/sortieLabel", () => ({ formatSortieLabel: vi.fn() }));
+
+import { onCommand } from "../src/controllers/Commands";
+import { onMessage } from "../src/controllers/Message";
+import { Routes } from "../src/messages";
+
+// Router（単発イベント、sendResponse なし）経由でコマンドを発火し、内部処理の完了を待つ。
+// 全ての処理がマイクロタスクのみで完結するため、setTimeout(0) のマクロタスクで完了を待てる
+// （tests/notification-clear-on-recovery.spec.ts と同じ流儀）。
+function dispatchCommand(command: string): Promise<void> {
+  const listener = onCommand.listener();
+  listener(command);
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// Router 経由でメッセージを1件処理させ、内部ハンドラの完了(sendResponse呼び出し)を待つ
+function dispatchMessage(message: Record<string, unknown>, sender: chrome.runtime.MessageSender): Promise<unknown> {
+  const listener = onMessage.listener();
+  return new Promise((resolve) => {
+    listener(message, sender, resolve);
+  });
+}
+
+// キーボードショートカット「/screenshot」コマンドの入口を検証する（src/controllers/Commands.ts）
+describe("/screenshot コマンド(Commands.ts)", () => {
+  beforeEach(() => {
+    launcherFind.mockReset();
+    take.mockClear();
+  });
+
+  it("撮影対象のゲーム別窓が見つかったとき、そのウィンドウIDで ScreenshotService.take を呼ぶ", async () => {
+    launcherFind.mockResolvedValue({ id: 42 });
+
+    await dispatchCommand("/screenshot");
+
+    expect(take).toHaveBeenCalledWith(42);
+  });
+
+  it("撮影対象のゲーム別窓が見つからないとき、例外を投げて ScreenshotService.take を呼ばない", async () => {
+    launcherFind.mockResolvedValue(undefined);
+
+    await dispatchCommand("/screenshot");
+
+    expect(take).not.toHaveBeenCalled();
+  });
+});
+
+// ゲーム別窓内のショートカットキーからの /screenshot メッセージの入口を検証する（src/controllers/Message.ts）
+describe(`${Routes.SCREENSHOT} メッセージ(Message.ts)`, () => {
+  beforeEach(() => {
+    take.mockClear();
+  });
+
+  it("送信元タブのウィンドウIDで ScreenshotService.take を呼ぶ", async () => {
+    await dispatchMessage(
+      { __action__: Routes.SCREENSHOT },
+      { tab: { windowId: 7 } } as unknown as chrome.runtime.MessageSender,
+    );
+
+    expect(take).toHaveBeenCalledWith(7);
+  });
+
+  it("送信元タブ情報が無いとき、ScreenshotService.take を呼ばない", async () => {
+    await dispatchMessage({ __action__: Routes.SCREENSHOT }, {} as chrome.runtime.MessageSender);
+
+    expect(take).not.toHaveBeenCalled();
+  });
+});

--- a/tests/screenshot-service.spec.ts
+++ b/tests/screenshot-service.spec.ts
@@ -38,4 +38,21 @@ describe("ScreenshotService", () => {
     const key = openEditPage.mock.calls[0][0];
     expect(await temp.draw(key)).toBe(URI);
   });
+
+  it("take: launcher.capture で撮影した画像を設定のformatで受け取り、deliverへ渡す", async () => {
+    // 既定引数省略時に ScreenshotService が内部で DownloadService/TempStorage を
+    // 既定構築するため、chrome.downloads / chrome.storage.local の参照先が要る
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).chrome = { downloads: {}, storage: { local: {} } };
+    const config = await FileSaveConfig.user();
+    const deliverSpy = vi.spyOn(ScreenshotService.prototype, "deliver").mockResolvedValue(undefined);
+    const capture = vi.fn<(windowId: number, options: chrome.extensionTypes.ImageDetails) => Promise<string>>()
+      .mockResolvedValue(URI);
+
+    await ScreenshotService.take(1, { capture });
+
+    expect(capture).toHaveBeenCalledWith(1, { format: config.format });
+    expect(deliverSpy).toHaveBeenCalledWith(URI);
+    deliverSpy.mockRestore();
+  });
 });

--- a/tests/tab-service-capture.spec.ts
+++ b/tests/tab-service-capture.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { TabService } from "../src/services/TabService";
+import { Launcher } from "../src/services/Launcher";
+import type { WindowService } from "../src/services/WindowService";
+import type { ScriptingService } from "../src/services/ScriptingService";
 
 // TabService.capture がネイティブ Promise 形式の chrome.tabs.captureVisibleTab の
 // 成功/失敗をそのまま resolve/reject として伝播することを検証する
@@ -20,5 +23,39 @@ describe("TabService.capture", () => {
     const tabs = new TabService(mod);
 
     await expect(tabs.capture(1, { format: "jpeg" })).rejects.toThrow(error);
+  });
+});
+
+// TabService.query がネイティブ Promise 形式の chrome.tabs.query にそのまま委譲することを検証する
+describe("TabService.query", () => {
+  it("queryInfo をそのまま渡し、query が resolve した結果をそのまま返す", async () => {
+    const tabsResult = [{ id: 1 }] as unknown as chrome.tabs.Tab[];
+    const mod = { query: vi.fn().mockResolvedValue(tabsResult) } as unknown as typeof chrome.tabs;
+    const tabs = new TabService(mod);
+
+    await expect(tabs.query({ windowType: "popup" })).resolves.toBe(tabsResult);
+    expect(mod.query).toHaveBeenCalledWith({ windowType: "popup" });
+  });
+});
+
+// Launcher.capture が既定オプション({format:"jpeg", quality:100})で TabService.capture に
+// 委譲することを検証する（#1826 でタブ単位からウィンドウ単位のキャプチャへ変更）
+describe("Launcher.capture", () => {
+  it("options 省略時: {format: jpeg, quality: 100} で TabService.capture に委譲する", async () => {
+    const dataUrl = "data:image/jpeg;base64,stub";
+    const tabs = { capture: vi.fn().mockResolvedValue(dataUrl) } as unknown as TabService;
+    const launcher = new Launcher({} as unknown as WindowService, tabs, {} as unknown as ScriptingService);
+
+    await expect(launcher.capture(1)).resolves.toBe(dataUrl);
+    expect(tabs.capture).toHaveBeenCalledWith(1, { format: "jpeg", quality: 100 });
+  });
+
+  it("options 指定時: そのオプションをそのまま TabService.capture に渡す", async () => {
+    const dataUrl = "data:image/png;base64,stub";
+    const tabs = { capture: vi.fn().mockResolvedValue(dataUrl) } as unknown as TabService;
+    const launcher = new Launcher({} as unknown as WindowService, tabs, {} as unknown as ScriptingService);
+
+    await expect(launcher.capture(2, { format: "png" })).resolves.toBe(dataUrl);
+    expect(tabs.capture).toHaveBeenCalledWith(2, { format: "png" });
   });
 });

--- a/tests/tab-service-capture.spec.ts
+++ b/tests/tab-service-capture.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { TabService } from "../src/services/TabService";
+
+// TabService.capture がネイティブ Promise 形式の chrome.tabs.captureVisibleTab の
+// 成功/失敗をそのまま resolve/reject として伝播することを検証する
+describe("TabService.capture", () => {
+  it("成功時: captureVisibleTab が resolve した dataURL をそのまま返す", async () => {
+    const dataUrl = "data:image/jpeg;base64,stub";
+    const mod = { captureVisibleTab: vi.fn().mockResolvedValue(dataUrl) } as unknown as typeof chrome.tabs;
+    const tabs = new TabService(mod);
+
+    await expect(tabs.capture(1, { format: "jpeg" })).resolves.toBe(dataUrl);
+    expect(mod.captureVisibleTab).toHaveBeenCalledWith(1, { format: "jpeg" });
+  });
+
+  it("失敗時: captureVisibleTab の reject をそのまま伝播する", async () => {
+    const error = new Error("キャプチャに失敗しました");
+    const mod = { captureVisibleTab: vi.fn().mockRejectedValue(error) } as unknown as typeof chrome.tabs;
+    const tabs = new TabService(mod);
+
+    await expect(tabs.capture(1, { format: "jpeg" })).rejects.toThrow(error);
+  });
+});


### PR DESCRIPTION
リファクタリング4本の最終弾です（監査の背景は #1840 参照）。chrome API まわりの定型と拡張内メッセージの分散を解消します。

## 全体構成とマージ順

- **PR-1**: background 層の規約・定型集約（#1840）
- **PR-2**: configs の既定値一元化と UserConfig 基底（#1841）
- **PR-3**: UI 層の定型統一（#1842）
- **PR-4（本PR）**: サービス層・メッセージング集約（**#1842 に依存**。ベースブランチを #1842 のブランチにしています。#1840〜#1842 マージ後に main へ retarget して ready 化します）

## マージ前提

以下のマージ後に rebase して ready 化します。それまで draft です。

- [ ] #1838
- [ ] #1839
- [ ] #1840
- [ ] #1842

## 変更点

1. **chrome API のネイティブ Promise 化**: 手書き `new Promise` ラップ5箇所が lastError を無視して失敗を undefined 解決で握りつぶしていたのを、MV3 ネイティブ Promise 形式（失敗時 reject）に統一
2. **撮影オーケストレーションの集約**: スクリーンショット3経路の逐語コピーを `ScreenshotService.take()` に、入渠・建造の OCR 依頼5段フローを `requestOcr()` に集約（TabService の既存 TODO の実行）
3. **保存フローの統合**: canvas 保存の定型2箇所を `DownloadService.saveCanvasAsImage()` に集約し、設定非依存の保存を `DownloadService.direct()` として明示（出撃記録エクスポートのデフォルトインスタンス捏造を解消）
4. **メッセージルートの一元化**: `__action__` のルート文字列14系統を `src/messages.ts` の Routes 定数とペイロード型に集約。content script は classic script 注入のため実行時 import 禁止とし、`import type`＋型注釈で乖離を tsc に検査させる方式（ビルド後の dist/dmm.js・osapi.js が自己完結のままであることを確認済み）。`action:` キーの混在も `__action__` に正規化（chromite のエイリアスにより挙動不変）

## 挙動への影響

- 通知作成・キャプチャ・ダウンロードの失敗が「静かな undefined」から「reject」に変わります。タイマー完了通知は作成成功後に Queue を削除する順序になり、失敗時は次回 cron で再試行されます（従来は失敗が黙殺され通知が消失）
- 編成キャプチャはゲーム窓が無い状態での撮影がクラッシュではなく告知になります
- それ以外は挙動不変です（ルート文字列・quality 設定・保存先はすべて従来どおり）

なお chrome.notifications の Promise 形式は Chrome 116+ のため、それ以前（Win7 系の最終版 109 等）では通知の一括消去（getAll 経由）が動作しなくなります。

## テスト

typecheck / lint / vitest 651件 全パス。実機でスクリーンショット3経路・大破スナップショット（INAPP/SEPARATE）・出撃記録エクスポート・編成キャプチャ・通知音・タイマー一巡を検証済みです。
