### PR TITLE
リロード時の窓サイズ累積と再注入の取りこぼしを修正 (#1813, #1845)

### DIFF
--- a/knowledge/decisions/0002-idempotent-injection-and-resize.md
+++ b/knowledge/decisions/0002-idempotent-injection-and-resize.md
@@ -1,0 +1,79 @@
+# 注入とサイズ補正の冪等化に関する設計判断記録
+
+- ステータス: 採用
+- 日付: 2026-07-12
+- 関連 Issue: [#1813](https://github.com/KanCraft/kanColleWidget/issues/1813)（F5 リロードで上下に黒帯が入り累積する）、[#1845](https://github.com/KanCraft/kanColleWidget/issues/1845)（休止復帰後のブラウザ主導リロードで位置ずれ・スクロールバー）
+- 関連する過去の判断: [0001](./0001-game-window-resize-on-reload.md)（#1784 のリロード再注入）、#1810/#1812（通知クリックの黒帯累積）
+- 関連コード: `src/injection/dmm.ts`, `src/services/Launcher.ts`, `src/controllers/WebNavigation.ts`
+
+## 問題
+
+ADR 0001 で導入した「リロード検知 → dmm.js 一式を再注入」（#1784 対応）には、2 つの穴があった。
+
+### 1. `resize()` が非冪等（#1813）
+
+`dmm.ts` の `resize()` は `window.resizeBy(outerWidth - innerWidth, outerHeight - innerHeight)` で、
+「外形指定で作られた窓に、ウィンドウ装飾（タイトルバー等）ぶんを足して内寸を合わせる」補正である。
+これは**外形がフレーム設定どおりに整えられた直後の 1 回に限り正しい**。
+
+ところがリロード再注入の経路（`WebNavigation → Launcher.reactivate → activate → dmm.js`）は、
+`retouch()` と違って事前に `windows.update({...frame.size})` で外形を基準へ戻さないため、
+再注入された `__main__` が呼ぶ `resize()` がリロードのたびに装飾ぶん（縦 30〜40px）を**加算**する。
+内寸が 1200:720 より縦長になり、内側 iframe の中央寄せ背景（`#222`）が上下黒帯として現れ、
+リロード回数に比例して窓が伸びる。#1810（通知クリック経路、#1812 で修正済み）と同根の
+「resize() の誤適用」が、別経路で残っていた。
+
+さらに `track()` が膨らんだ内寸を 10 秒ごとに `__memory__` へ保存するため、
+汚染が次回起動サイズにも波及していた。
+
+### 2. `transitionType === "reload"` 限定の取りこぼし（#1845）
+
+ADR 0001 は初回ロードとの二重注入を避けるため `transitionType === "reload"` のみを
+再注入対象にした。しかし PC 休止からの復帰時など、ブラウザ主導の再読み込み
+（タブ破棄からの復元等）では transitionType が `"reload"` にならないことがあり、
+再注入が発火しない。dmm.js/CSS が失われたままになり、#1784 と同型の
+「ゲームが上にずれて右下にスクロールバー」が再発していた。
+
+また `waitForInnerIframeLoaded()` に (a) resolve/reject 後も `return` せず
+ポーリングが回り続けるバグ、(b) 復帰直後の遅いネットワークには 8 秒タイムアウトが
+短すぎる問題があり、reject 時は注入自体が行われずに終わっていた。
+
+## 決定
+
+**「1 回だけ実行すべき処理」に、それぞれ適切な生存期間のガードを持たせて冪等化する。**
+イベント側（いつ発火するか）を絞るのではなく、処理側（何度呼ばれても安全）を保証する方針へ転換する。
+
+| 処理 | ガード | 生存期間 | 効果 |
+|------|--------|----------|------|
+| `resize()`（`dmm.ts __main__`） | `sessionStorage.kcw_resized` | 同一タブの生存中（**リロードを跨いで残る**） | 窓の生成後 1 回だけ補正。リロード再注入では実行されず、累積が止まる（#1813）。ユーザーの手動リサイズも保持される |
+| dmm.js/CSS 注入（`Launcher.activate()`） | `window.__kancolleWidgetActivated` を `scripting.func` で check-and-set | 同一 document の生存中（**ナビゲーションで消える**） | 同じ document への二重注入（リスナー・ボタン・track タイマーの多重化）を防ぎつつ、リロード後の新しい document には確実に再注入される |
+
+check-and-set（読み取りと書き込み）を 1 回の `executeScript` 内で行うため、
+初回起動時に `open()` と `onCommitted` ハンドラが並走しても注入は 1 回に決まる。
+
+この冪等化により `transitionType === "reload"` ガードは不要になったので、
+`WebNavigation` は**トップフレームのゲーム URL へのコミット全般**を対象に広げ、
+ブラウザ主導の再読み込みも拾う（#1845）。所有権確認（`Launcher.find()` +
+tabId 一致）は従来どおり維持し、普通のタブには波及させない。
+
+あわせて `waitForInnerIframeLoaded()` は resolve/reject 後に `return` して
+ポーリングを止め、タイムアウトを 30 秒へ延長した。
+
+なお `/injected/dmm/retouch` メッセージ経由の `resize()` は無条件のまま維持する。
+retouch は `Launcher.retouch()` が `windows.update({...frame.size})` で外形を基準へ
+戻した直後に届くため、そこでの補正は毎回必要である。
+
+## 検討した代替案
+
+| 案 | 評価 | 理由 |
+|----|------|------|
+| `resize()` を `resizeTo`（絶対指定）に変える | △ | 冪等にはなるが、目標サイズを content script に伝える配管が必要になり、ユーザーの手動リサイズをリロードで巻き戻してしまう |
+| `reactivate()` で事前に `windows.update({...frame.size})` する（retouch と同型） | △ | 累積は止まるが、同じく手動リサイズをリロードのたびに巻き戻す。また #1845（そもそも発火しない）には効かない |
+| transitionType の対象を列挙で増やす（`"auto_toplevel"` 等） | × | ブラウザ主導リロードの transitionType は環境依存で網羅できず、いたちごっこになる |
+
+## 影響と今後の課題
+
+- 既存ユーザーの `__memory__` に保存された「膨らんだサイズ」は自動では縮まないが、
+  累積が止まるため一度手動で直せば以後は安定する。
+- 所有権ヒューリスティック（ADR 0001 の課題）は未着手のまま。`chrome.storage.session` に
+  windowId を保存する堅牢化案は引き続き将来課題とする。

--- a/src/background.ts
+++ b/src/background.ts
@@ -32,7 +32,7 @@ import { onCommand } from "./controllers/Commands";
 chrome.commands.onCommand.addListener(onCommand.listener());
 
 import { onCommitted } from "./controllers/WebNavigation";
-// ゲーム画面のリロード時にコンテンツスクリプトを再注入する
+// ゲーム画面へのナビゲーション（リロード含む）時にコンテンツスクリプトを再注入する
 chrome.webNavigation.onCommitted.addListener(onCommitted.listener(), { url: [{ urlPrefix: KanColleURL }] });
 
 // import { Launcher } from "./services/Launcher";

--- a/src/controllers/WebNavigation.ts
+++ b/src/controllers/WebNavigation.ts
@@ -3,17 +3,11 @@ import { Launcher } from "../services/Launcher";
 import { KanColleURL } from "../constants";
 
 /**
- * ゲーム画面のナビゲーションを検知し、失われたコンテンツスクリプトを再注入する。
- *
- * MV3 では scripting.executeScript で注入した dmm.js はリロードで失われ、
- * 窓のサイズ調整（resize）・操作ボタン・OCR リスナーがすべて停止する（Issue #1784）。
- *
- * かつては初回ロードとの二重注入を避けるため transitionType === "reload" のみを
- * 対象にしていたが、PC 休止からの復帰などブラウザ主導の再読み込みでは
- * transitionType が "reload" にならないことがあり、再注入が発火せず
- * 窓ずれ・スクロールバーが残るケースがあった（Issue #1845）。
- * 二重注入は Launcher.activate() の check-and-set で防がれるようになったため、
- * トップフレームのゲーム URL へのコミット全般を対象にして取りこぼしを無くす。
+ * ゲーム画面のナビゲーションを検知し、リロードで失われたコンテンツスクリプトを再注入する（#1784）。
+ * ブラウザ主導の再読み込みでは transitionType が "reload" にならないことがあるため、
+ * 種別では絞らずトップフレームのゲーム URL へのコミット全般を対象にする（#1845）。
+ * 初回ロードと重なっても、二重注入は Launcher.activate() の check-and-set が防ぐ。
+ * 経緯の詳細は ADR 0002。
  */
 const onCommitted = new Router<typeof chrome.webNavigation.onCommitted>(async (details) => {
   const isGameNavigation = details.frameId === 0

--- a/src/controllers/WebNavigation.ts
+++ b/src/controllers/WebNavigation.ts
@@ -3,28 +3,36 @@ import { Launcher } from "../services/Launcher";
 import { KanColleURL } from "../constants";
 
 /**
- * ゲーム画面のリロードを検知し、失われたコンテンツスクリプトを再注入する。
+ * ゲーム画面のナビゲーションを検知し、失われたコンテンツスクリプトを再注入する。
  *
  * MV3 では scripting.executeScript で注入した dmm.js はリロードで失われ、
  * 窓のサイズ調整（resize）・操作ボタン・OCR リスナーがすべて停止する（Issue #1784）。
- * 初回ロードとの二重注入を避けるため transitionType === "reload" のみを対象にする。
+ *
+ * かつては初回ロードとの二重注入を避けるため transitionType === "reload" のみを
+ * 対象にしていたが、PC 休止からの復帰などブラウザ主導の再読み込みでは
+ * transitionType が "reload" にならないことがあり、再注入が発火せず
+ * 窓ずれ・スクロールバーが残るケースがあった（Issue #1845）。
+ * 二重注入は Launcher.activate() の check-and-set で防がれるようになったため、
+ * トップフレームのゲーム URL へのコミット全般を対象にして取りこぼしを無くす。
  */
 const onCommitted = new Router<typeof chrome.webNavigation.onCommitted>(async (details) => {
-  const isGameReload = details.frameId === 0
-    && details.transitionType === "reload"
+  const isGameNavigation = details.frameId === 0
     && details.url.startsWith(KanColleURL);
-  return { __action__: isGameReload ? "/game/reload" : "/ignore" };
+  return { __action__: isGameNavigation ? "/game/navigated" : "/ignore" };
 });
 
-onCommitted.on("/game/reload", async (details) => {
+onCommitted.on("/game/navigated", async (details) => {
   const launcher = new Launcher();
   // 拡張自身が開いた別窓（popup）かを確認し、所有権スコープ外の普通のタブには波及させない
   const win = await launcher.find();
   if (!win || win.tabs?.[0]?.id !== details.tabId) return;
-  await launcher.reactivate(win);
+  // 内側 iframe のロード待ちがタイムアウトしても Service Worker 側で握りつぶす
+  await launcher.reactivate(win).catch((err) => {
+    console.warn("[KCW] ゲーム窓の再活性化に失敗しました:", err);
+  });
 });
 
-// リロード以外のナビゲーションは無視する
+// ゲーム画面以外のナビゲーションは無視する
 onCommitted.onNotFound(async () => { /* noop */ });
 
 export {

--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -108,9 +108,10 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
 
   /**
    * BazelというかAeroというか、を考慮して、ウィンドウのリサイズを行う。
-   * 外形(outer)と内寸(inner)の差分＝ウィンドウ装飾ぶんを足す非冪等な補正なので、
-   * 「外形がフレーム設定どおりに整えられた直後」に一度だけ呼ぶこと。
-   * 既に補正済みの窓に対して再実行すると、そのたびに装飾ぶん窓が拡大する（#1810, #1813）。
+   * 外形(outer)と内寸(inner)の差分＝ウィンドウ装飾ぶんを足す非冪等な補正で、
+   * 再実行のたびに窓が装飾ぶん拡大してしまう（#1810, #1813）。呼び出してよいのは
+   * __main__（sessionStorage ガード付き）と retouch ハンドラ（Launcher.retouch が
+   * 外形を戻した直後）の2箇所だけ。詳細は ADR 0002。
    */
   function resize() {
     window.resizeBy(window.outerWidth - window.innerWidth, window.outerHeight - window.innerHeight);
@@ -168,10 +169,9 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
   }
 
   (async function __main__() {
-    // resize() は「外形と内寸の差分を足す」非冪等な補正なので、同じタブで一度だけ実行する。
-    // sessionStorage はリロードを跨いで残るため、リロード後の再注入（#1784 対応の経路）では
-    // スキップされ、リロードのたびにタイトルバー分だけ窓が縦に伸びる累積を防ぐ（#1813）。
-    // ユーザーが手動調整した窓サイズもリロードで失われない。
+    // resize は1タブにつき1回だけ。sessionStorage はリロードを跨いで残るため、
+    // リロード再注入時はスキップされ、窓サイズの累積（#1813）も手動リサイズの
+    // 巻き戻しも起きない。
     if (!sessionStorage.getItem("kcw_resized")) {
       resize();
       sessionStorage.setItem("kcw_resized", "1");

--- a/src/injection/dmm.ts
+++ b/src/injection/dmm.ts
@@ -107,10 +107,12 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
   }
 
   /**
-   * BazelというかAeroというか、を考慮して、ウィンドウのリサイズを行う
+   * BazelというかAeroというか、を考慮して、ウィンドウのリサイズを行う。
+   * 外形(outer)と内寸(inner)の差分＝ウィンドウ装飾ぶんを足す非冪等な補正なので、
+   * 「外形がフレーム設定どおりに整えられた直後」に一度だけ呼ぶこと。
+   * 既に補正済みの窓に対して再実行すると、そのたびに装飾ぶん窓が拡大する（#1810, #1813）。
    */
   function resize() {
-    // TODO: これだとなんか問題ありそう
     window.resizeBy(window.outerWidth - window.innerWidth, window.outerHeight - window.innerHeight);
   }
 
@@ -146,6 +148,8 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
         });
       }
       if (msg.__action__ === "/injected/dmm/retouch") {
+        // retouch は Launcher 側で windows.update により外形をフレーム設定へ
+        // 戻した直後に届くため、ここでは無条件に補正してよい
         resize();
       }
     });
@@ -164,7 +168,14 @@ import { ocr, warmUpOcrWorker } from './ocrWorker';
   }
 
   (async function __main__() {
-    resize();
+    // resize() は「外形と内寸の差分を足す」非冪等な補正なので、同じタブで一度だけ実行する。
+    // sessionStorage はリロードを跨いで残るため、リロード後の再注入（#1784 対応の経路）では
+    // スキップされ、リロードのたびにタイトルバー分だけ窓が縦に伸びる累積を防ぐ（#1813）。
+    // ユーザーが手動調整した窓サイズもリロードで失われない。
+    if (!sessionStorage.getItem("kcw_resized")) {
+      resize();
+      sessionStorage.setItem("kcw_resized", "1");
+    }
     setInterval(track, 10 * 1000);
     warmUpOcrWorker();
     const configs = await fetchNecessaryConfig();

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -181,13 +181,15 @@ export class Launcher {
    * @param timeout 
    * @returns 
    */
-  private async waitForInnerIframeLoaded(tabId: number, timeout: number = 8 * 1000) {
+  private async waitForInnerIframeLoaded(tabId: number, timeout: number = 30 * 1000) {
+    // タイムアウトは PC 休止からの復帰直後などネットワーク回復が遅いケース（#1845）を
+    // 考慮して 30 秒とする。決着後は return してポーリングを確実に止める。
     return new Promise<chrome.webNavigation.GetAllFrameResultDetails>((resolve, reject) => {
       const check = async (timeoutMilliseconds: number) => {
         const all_webframes = (await chrome.webNavigation.getAllFrames({ tabId }) || []);
         const found = all_webframes.find(f => f.url.includes("osapi.dmm.com/gadgets/ifr"));
-        if (found) resolve(found);
-        if (timeoutMilliseconds <= 0) reject(new Error("Timeout waiting for inner iframe loaded"));
+        if (found) return resolve(found);
+        if (timeoutMilliseconds <= 0) return reject(new Error("Timeout waiting for inner iframe loaded"));
         setTimeout(() => check(timeoutMilliseconds - 500), 500);
       };
       check(timeout);
@@ -219,11 +221,21 @@ export class Launcher {
 
   /**
    * 起動直後の別窓タブにスクリプトやスタイルを注入し、必要なら劇場モード用 CSS も適用する。
+   * window 上のフラグを check-and-set し、同じ document への二重注入
+   * （リスナー・ボタン・track タイマーの多重化）を防ぐ。フラグはナビゲーションで
+   * 消えるため、リロード後の document には改めて注入される。
    * @param win 対象ウィンドウ
    * @param frame 劇場モードなどの設定を含むフレーム情報
    */
   public async activate(win: chrome.windows.Window, innerIframe: chrome.webNavigation.GetAllFrameResultDetails) {
     const tab = win.tabs![0];
+    const results = await this.scriptings.func(tab.id!, () => {
+      const w = window as unknown as { __kancolleWidgetActivated?: boolean };
+      const activated = w.__kancolleWidgetActivated === true;
+      w.__kancolleWidgetActivated = true;
+      return activated;
+    });
+    if (results?.[0]?.result === true) return;
     this.scriptings.js(tab.id!, ["dmm.js"]);
     this.scriptings.css(tab.id!, ["assets/dmm.css"]);
     this.scriptings.css({ tabId: tab.id!, frameIds: [innerIframe.frameId] }, ["assets/osapi.css"]);

--- a/src/services/Launcher.ts
+++ b/src/services/Launcher.ts
@@ -209,6 +209,8 @@ export class Launcher {
 
   /**
    * 既存のゲーム別窓を前面に出し、サイズをフレーム設定に合わせて調整する。
+   * dmm.ts の retouch ハンドラは resize()（非冪等な装飾ぶん補正）を無条件に呼ぶため、
+   * その直前に必ず windows.update で外形をフレーム設定へ戻すこと（ADR 0002）。
    * @param win 対象ウィンドウ
    */
   public async retouch(win: chrome.windows.Window, frame: Frame | null) {
@@ -221,9 +223,9 @@ export class Launcher {
 
   /**
    * 起動直後の別窓タブにスクリプトやスタイルを注入し、必要なら劇場モード用 CSS も適用する。
-   * window 上のフラグを check-and-set し、同じ document への二重注入
-   * （リスナー・ボタン・track タイマーの多重化）を防ぐ。フラグはナビゲーションで
-   * 消えるため、リロード後の document には改めて注入される。
+   * window フラグの check-and-set で同一 document への二重注入を防ぐ（ADR 0002）。
+   * 初回起動時は open() と WebNavigation の onCommitted から並走で呼ばれうるが、
+   * このガードにより注入は1回に収束する。
    * @param win 対象ウィンドウ
    * @param frame 劇場モードなどの設定を含むフレーム情報
    */
@@ -236,9 +238,20 @@ export class Launcher {
       return activated;
     });
     if (results?.[0]?.result === true) return;
-    this.scriptings.js(tab.id!, ["dmm.js"]);
-    this.scriptings.css(tab.id!, ["assets/dmm.css"]);
-    this.scriptings.css({ tabId: tab.id!, frameIds: [innerIframe.frameId] }, ["assets/osapi.css"]);
+    try {
+      await Promise.all([
+        this.scriptings.js(tab.id!, ["dmm.js"]),
+        this.scriptings.css(tab.id!, ["assets/dmm.css"]),
+        this.scriptings.css({ tabId: tab.id!, frameIds: [innerIframe.frameId] }, ["assets/osapi.css"]),
+      ]);
+    } catch (err) {
+      // フラグが立ったまま注入だけ失敗すると、以降の再注入がすべて短絡して
+      // 自己回復できなくなるため、フラグを戻して次回の reactivate で再試行させる
+      await this.scriptings.func(tab.id!, () => {
+        (window as unknown as { __kancolleWidgetActivated?: boolean }).__kancolleWidgetActivated = false;
+      }).catch(() => { /* タブごと消えている場合は戻す必要もない */ });
+      throw err;
+    }
     // if (frame.theater.enabled) setTimeout(() => {
     //   this.scriptings.css({ tabId: tab.id!, allFrames: true }, ["assets/theater.css"]);
     // }, 5 * 1000);

--- a/tests/launcher-activate-idempotent.spec.ts
+++ b/tests/launcher-activate-idempotent.spec.ts
@@ -1,0 +1,78 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+
+// Launcher が参照するグローバル chrome を import より前にスタブする
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { id: "test", onMessage: { addListener: () => {} } },
+    tabs: { sendMessage: vi.fn() },
+    webNavigation: {
+      getAllFrames: vi.fn().mockResolvedValue([
+        { frameId: 1, url: "https://osapi.dmm.com/gadgets/ifr?game" },
+      ]),
+    },
+  };
+});
+
+import { Launcher } from "../src/services/Launcher";
+import { WindowService } from "../src/services/WindowService";
+import { TabService } from "../src/services/TabService";
+import { ScriptingService } from "../src/services/ScriptingService";
+
+const win = { id: 10, tabs: [{ id: 1 }] } as unknown as chrome.windows.Window;
+const innerIframe = { frameId: 1 } as unknown as chrome.webNavigation.GetAllFrameResultDetails;
+
+// activate() の check-and-set（scripting.func）の返り値を注入済みフラグとして表現する
+function build(funcResults: boolean[]) {
+  const scriptings = {
+    func: vi.fn(),
+    js: vi.fn(),
+    css: vi.fn(),
+  };
+  for (const activated of funcResults) {
+    scriptings.func.mockResolvedValueOnce([{ result: activated }]);
+  }
+  const launcher = new Launcher(
+    {} as unknown as WindowService,
+    {} as unknown as TabService,
+    scriptings as unknown as ScriptingService,
+  );
+  return { launcher, scriptings };
+}
+
+describe("Launcher.activate の冪等性（#1813 / #1845）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("未注入の document には dmm.js と CSS 一式を注入する", async () => {
+    const { launcher, scriptings } = build([false]);
+
+    await launcher.activate(win, innerIframe);
+
+    expect(scriptings.js).toHaveBeenCalledTimes(1);
+    expect(scriptings.js).toHaveBeenCalledWith(1, ["dmm.js"]);
+    expect(scriptings.css).toHaveBeenCalledWith(1, ["assets/dmm.css"]);
+    expect(scriptings.css).toHaveBeenCalledWith({ tabId: 1, frameIds: [1] }, ["assets/osapi.css"]);
+  });
+
+  it("同じ document への2回目の activate では何も注入しない（二重注入防止）", async () => {
+    const { launcher, scriptings } = build([false, true]);
+
+    await launcher.activate(win, innerIframe);
+    await launcher.activate(win, innerIframe);
+
+    // check-and-set は2回走るが、注入は初回の1度だけ
+    expect(scriptings.func).toHaveBeenCalledTimes(2);
+    expect(scriptings.js).toHaveBeenCalledTimes(1);
+    expect(scriptings.css).toHaveBeenCalledTimes(2);
+  });
+
+  it("reactivate は内側 iframe を待ってから activate と同じ注入を行う", async () => {
+    const { launcher, scriptings } = build([false]);
+
+    await launcher.reactivate(win);
+
+    expect(scriptings.js).toHaveBeenCalledWith(1, ["dmm.js"]);
+  });
+});

--- a/tests/launcher-activate-idempotent.spec.ts
+++ b/tests/launcher-activate-idempotent.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, vi, beforeEach } from "vitest";
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 
 // Launcher が参照するグローバル chrome を import より前にスタブする
 vi.hoisted(() => {
@@ -6,11 +6,7 @@ vi.hoisted(() => {
   (globalThis as any).chrome = {
     runtime: { id: "test", onMessage: { addListener: () => {} } },
     tabs: { sendMessage: vi.fn() },
-    webNavigation: {
-      getAllFrames: vi.fn().mockResolvedValue([
-        { frameId: 1, url: "https://osapi.dmm.com/gadgets/ifr?game" },
-      ]),
-    },
+    webNavigation: { getAllFrames: vi.fn() },
   };
 });
 
@@ -21,17 +17,18 @@ import { ScriptingService } from "../src/services/ScriptingService";
 
 const win = { id: 10, tabs: [{ id: 1 }] } as unknown as chrome.windows.Window;
 const innerIframe = { frameId: 1 } as unknown as chrome.webNavigation.GetAllFrameResultDetails;
+const osapiFrame = { frameId: 1, url: "https://osapi.dmm.com/gadgets/ifr?game" };
 
-// activate() の check-and-set（scripting.func）の返り値を注入済みフラグとして表現する
-function build(funcResults: boolean[]) {
+// scripting.func に渡されたコールバックを jsdom の window 上で実際に実行するスタブ。
+// これにより check-and-set（__kancolleWidgetActivated の読み書き）の実挙動を検証できる。
+function build() {
   const scriptings = {
-    func: vi.fn(),
-    js: vi.fn(),
-    css: vi.fn(),
+    func: vi.fn(async (_target: unknown, fn: (...args: unknown[]) => unknown, args?: unknown[]) => [
+      { result: args ? fn(...args) : fn() },
+    ]),
+    js: vi.fn().mockResolvedValue(undefined),
+    css: vi.fn().mockResolvedValue(undefined),
   };
-  for (const activated of funcResults) {
-    scriptings.func.mockResolvedValueOnce([{ result: activated }]);
-  }
   const launcher = new Launcher(
     {} as unknown as WindowService,
     {} as unknown as TabService,
@@ -43,10 +40,16 @@ function build(funcResults: boolean[]) {
 describe("Launcher.activate の冪等性（#1813 / #1845）", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(chrome.webNavigation.getAllFrames).mockResolvedValue([osapiFrame]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).__kancolleWidgetActivated;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("未注入の document には dmm.js と CSS 一式を注入する", async () => {
-    const { launcher, scriptings } = build([false]);
+    const { launcher, scriptings } = build();
 
     await launcher.activate(win, innerIframe);
 
@@ -57,7 +60,7 @@ describe("Launcher.activate の冪等性（#1813 / #1845）", () => {
   });
 
   it("同じ document への2回目の activate では何も注入しない（二重注入防止）", async () => {
-    const { launcher, scriptings } = build([false, true]);
+    const { launcher, scriptings } = build();
 
     await launcher.activate(win, innerIframe);
     await launcher.activate(win, innerIframe);
@@ -68,11 +71,38 @@ describe("Launcher.activate の冪等性（#1813 / #1845）", () => {
     expect(scriptings.css).toHaveBeenCalledTimes(2);
   });
 
+  it("注入に失敗したらフラグを戻し、次回の activate で再試行できる", async () => {
+    const { launcher, scriptings } = build();
+    scriptings.js.mockRejectedValueOnce(new Error("injection failed"));
+
+    await expect(launcher.activate(win, innerIframe)).rejects.toThrow("injection failed");
+    // フラグが戻っているので、次の activate は短絡せず再注入する
+    await launcher.activate(win, innerIframe);
+
+    expect(scriptings.js).toHaveBeenCalledTimes(2);
+  });
+
   it("reactivate は内側 iframe を待ってから activate と同じ注入を行う", async () => {
-    const { launcher, scriptings } = build([false]);
+    const { launcher, scriptings } = build();
 
     await launcher.reactivate(win);
 
     expect(scriptings.js).toHaveBeenCalledWith(1, ["dmm.js"]);
+  });
+
+  it("内側 iframe が現れない場合はタイムアウトで reject し、ポーリングも止まる", async () => {
+    vi.useFakeTimers();
+    vi.mocked(chrome.webNavigation.getAllFrames).mockResolvedValue([]);
+    const { launcher, scriptings } = build();
+
+    const rejection = expect(launcher.reactivate(win)).rejects.toThrow("Timeout");
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    await rejection;
+    expect(scriptings.js).not.toHaveBeenCalled();
+
+    // reject 後はポーリングが止まっている（決着後も回り続ける旧バグの再発防止）
+    const polled = vi.mocked(chrome.webNavigation.getAllFrames).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5 * 1000);
+    expect(vi.mocked(chrome.webNavigation.getAllFrames).mock.calls.length).toBe(polled);
   });
 });

--- a/tests/web-navigation.spec.ts
+++ b/tests/web-navigation.spec.ts
@@ -50,9 +50,15 @@ describe("WebNavigation onCommitted", () => {
     await vi.waitFor(() => expect(reactivate).toHaveBeenCalledTimes(1));
   });
 
-  it("リロード以外のナビゲーション（link）では何もしない", async () => {
+  it("リロード以外のナビゲーションでも自分の窓なら再活性化する（#1845: ブラウザ主導の再読み込みでは transitionType が reload にならないことがある）", async () => {
     find.mockResolvedValue({ id: 10, tabs: [{ id: 1 }] });
     fire({ transitionType: "link" });
+    await vi.waitFor(() => expect(reactivate).toHaveBeenCalledTimes(1));
+  });
+
+  it("ゲーム画面以外の URL では何もしない", async () => {
+    find.mockResolvedValue({ id: 10, tabs: [{ id: 1 }] });
+    fire({ url: "https://example.com/" });
     // ルーティング対象外なので find すら呼ばれない
     await new Promise((r) => setTimeout(r, 10));
     expect(find).not.toHaveBeenCalled();

--- a/tests/web-navigation.spec.ts
+++ b/tests/web-navigation.spec.ts
@@ -87,4 +87,13 @@ describe("WebNavigation onCommitted", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(reactivate).not.toHaveBeenCalled();
   });
+
+  it("reactivate の失敗（iframe 待ちタイムアウト等）は警告ログを出して握りつぶす", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    find.mockResolvedValue({ id: 10, tabs: [{ id: 1 }] });
+    reactivate.mockRejectedValue(new Error("Timeout waiting for inner iframe loaded"));
+    fire();
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
+  });
 });


### PR DESCRIPTION
resize() は外形と内寸の差分を足す非冪等な補正だが、リロード再注入経路
(#1784 対応) では外形を基準に戻さないまま再実行されるため、リロードの
たびにタイトルバー分だけ窓が縦に伸びて上下黒帯が累積していた (#1813)。
sessionStorage ガードで同一タブにつき一度だけ実行するよう冪等化する。

また transitionType === "reload" 限定の再注入検知は、PC 休止復帰時の
ブラウザ主導リロードを取りこぼし、dmm.js/CSS が失われたまま位置ずれと
スクロールバーが再発していた (#1845)。activate() に window フラグの
check-and-set による二重注入防止を入れた上で、検知対象をトップフレームの
ゲーム URL へのコミット全般に拡大する。

あわせて waitForInnerIframeLoaded() の resolve/reject 後にポーリングが
止まらないバグを修正し、休止復帰直後の遅いロードを考慮してタイムアウトを
8 秒から 30 秒に延長する。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011dzowSExdMuy1rAATGZYWe