### PR TITLE
通知表示前に回収した遠征・建造の完了通知が残り続ける問題を修正 (#1844)

### DIFF
--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -67,14 +67,20 @@ async function clearNotificationsOf(type: EntryType, target: string) {
   }
 }
 
-// 遠征結果を回収したとき、その艦隊の遠征通知（開始・完了）を消す。
-// 完了通知の表示前（Queue 未発火のタイミング）に回収した場合は、Queue を消さないと
-// 後から回収済み遠征の完了通知が出て、手動消去設定では残り続けてしまう（#1844）。
-// 通知表示後の回収では QueueWatcher が削除済みなので deleteSlot は何もしない。
+// スロット（艦隊/ドック）のタイマーの生涯を終える: 未発火の Queue と表示中の通知を両方消す。
+// 回収・即完了などスロットの用事が済んだハンドラは必ずこれを呼ぶこと。片方だけ消すと、
+// 通知表示前の回収では後から完了通知が出て残り続け（#1844）、即完了経路（QueueWatcher を
+// 通らず完了通知が出ない）では開始通知に自動で消える機会がなくなる。
+// 通知表示後の回収では QueueWatcher が Queue を削除済みなので、通知の掃除だけが効く。
+async function retireSlot(type: EntryType, slot: string) {
+  await Queue.deleteSlot(type, slot);
+  await clearNotificationsOf(type, slot);
+}
+
+// 遠征結果を回収したとき、その艦隊の遠征タイマー（Queue・通知）を終える（#1844）
 export async function onMissionResult([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const { api_deck_id: [deck] } = details.requestBody?.formData as unknown as MissionResultFormData;
-  await Queue.deleteSlot(EntryType.MISSION, deck);
-  await clearNotificationsOf(EntryType.MISSION, deck);
+  await retireSlot(EntryType.MISSION, deck);
 }
 
 export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
@@ -98,12 +104,10 @@ export async function onRecoveryStart([details]: chrome.webRequest.OnBeforeReque
   });
 }
 
-// 修復中に高速修復剤を使って完了させたとき、そのドックの修復Queueと表示中の修復通知を消す。
-// この経路では完了通知が出ない（QueueWatcherを通らない）ため、開始通知の掃除もここで行う。
+// 修復中に高速修復剤を使って完了させたとき、そのドックの修復タイマー（Queue・通知）を終える
 export async function onRecoveryHighspeed([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const { api_ndock_id: [dock] } = details.requestBody?.formData as unknown as RecoverySpeedchangeFormData;
-  await Queue.deleteSlot(EntryType.RECOVERY, dock);
-  await clearNotificationsOf(EntryType.RECOVERY, dock);
+  await retireSlot(EntryType.RECOVERY, dock);
 }
 
 // 出撃開始時
@@ -187,12 +191,10 @@ export async function onBattleResulted([details]: chrome.webRequest.OnBeforeRequ
   Logbook.sortie.battle.result();
 }
 
-// 建造した艦を受け取ったとき、そのドックの建造通知（開始・完了）を消す。
-// 遠征の回収と同様、完了通知の表示前に受け取った場合に備えて Queue も消す（#1844）。
+// 建造した艦を受け取ったとき、そのドックの建造タイマー（Queue・通知）を終える（#1844）
 export async function onGetShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as GetShipFormData;
-  await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
-  await clearNotificationsOf(EntryType.SHIPBUILD, dock);
+  await retireSlot(EntryType.SHIPBUILD, dock);
 }
 
 export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
@@ -217,8 +219,9 @@ export async function onCreateShip([details]: chrome.webRequest.OnBeforeRequestD
   });
 }
 
-// 建造中に高速建造材を使って完了させたとき、そのドックの建造Queueを削除する
+// 建造中に高速建造材を使って完了させたとき、そのドックの建造タイマー（Queue・通知）を終える。
+// 従来は Queue 削除のみで、修復側（onRecoveryHighspeed）と非対称に開始通知が残り得た
 export async function onShipbuildHighspeed([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as ShipbuildSpeedchangeFormData;
-  await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
+  await retireSlot(EntryType.SHIPBUILD, dock);
 }

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -67,9 +67,13 @@ async function clearNotificationsOf(type: EntryType, target: string) {
   }
 }
 
-// 遠征結果を回収したとき、その艦隊の遠征通知（開始・完了）を消す
+// 遠征結果を回収したとき、その艦隊の遠征通知（開始・完了）を消す。
+// 完了通知の表示前（Queue 未発火のタイミング）に回収した場合は、Queue を消さないと
+// 後から回収済み遠征の完了通知が出て、手動消去設定では残り続けてしまう（#1844）。
+// 通知表示後の回収では QueueWatcher が削除済みなので deleteSlot は何もしない。
 export async function onMissionResult([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const { api_deck_id: [deck] } = details.requestBody?.formData as unknown as MissionResultFormData;
+  await Queue.deleteSlot(EntryType.MISSION, deck);
   await clearNotificationsOf(EntryType.MISSION, deck);
 }
 
@@ -183,9 +187,11 @@ export async function onBattleResulted([details]: chrome.webRequest.OnBeforeRequ
   Logbook.sortie.battle.result();
 }
 
-// 建造した艦を受け取ったとき、そのドックの建造通知（開始・完了）を消す
+// 建造した艦を受け取ったとき、そのドックの建造通知（開始・完了）を消す。
+// 遠征の回収と同様、完了通知の表示前に受け取った場合に備えて Queue も消す（#1844）。
 export async function onGetShip([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   const { api_kdock_id: [dock] } = details.requestBody?.formData as unknown as GetShipFormData;
+  await Queue.deleteSlot(EntryType.SHIPBUILD, dock);
   await clearNotificationsOf(EntryType.SHIPBUILD, dock);
 }
 

--- a/tests/notification-clear-on-collection.spec.ts
+++ b/tests/notification-clear-on-collection.spec.ts
@@ -17,6 +17,8 @@ vi.hoisted(() => {
 });
 
 import { onMissionResult, onGetShip } from "../src/controllers/WebRequest/kcsapi";
+import Queue from "../src/models/Queue";
+import { EntryType } from "../src/models/entry";
 
 const getAll = chrome.notifications.getAll as unknown as ReturnType<typeof vi.fn>;
 const clear = chrome.notifications.clear as unknown as ReturnType<typeof vi.fn>;
@@ -35,12 +37,16 @@ const details = (formData: Record<string, string[]>) =>
 
 const clearedIds = () => clear.mock.calls.map(([id]) => id);
 
-// 回収操作（遠征結果回収・建造艦受取）で、対象の艦隊/ドックの通知だけが消えることを検証する。
+// 回収操作（遠征結果回収・建造艦受取）で、対象の艦隊/ドックの通知だけが消えることと、
+// 未発火の Queue も削除されること（#1844: 通知表示前に回収すると後から完了通知が出て
+// 残り続ける問題の再発防止）を検証する。
 // 通知IDは /{type}/{trigger}/{deck|dock} 形式（tests/notification-id.spec.ts 参照）。
 describe("onMissionResult", () => {
+  let deleteSlot: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     getAll.mockReset();
     clear.mockReset();
+    deleteSlot = vi.spyOn(Queue, "deleteSlot").mockResolvedValue(undefined);
   });
 
   it("回収した艦隊の遠征通知（開始・完了）を消す", async () => {
@@ -55,12 +61,20 @@ describe("onMissionResult", () => {
     await onMissionResult(details({ api_deck_id: ["2"] }));
     expect(clearedIds()).toEqual(["/mission/end/2"]);
   });
+
+  it("回収した艦隊の未発火Queueを削除する（#1844: 通知表示前の回収）", async () => {
+    displaying([]);
+    await onMissionResult(details({ api_deck_id: ["2"] }));
+    expect(deleteSlot).toHaveBeenCalledWith(EntryType.MISSION, "2");
+  });
 });
 
 describe("onGetShip", () => {
+  let deleteSlot: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     getAll.mockReset();
     clear.mockReset();
+    deleteSlot = vi.spyOn(Queue, "deleteSlot").mockResolvedValue(undefined);
   });
 
   it("受け取ったドックの建造通知（開始・完了）を消す", async () => {
@@ -74,5 +88,11 @@ describe("onGetShip", () => {
     displaying(["/shipbuild/end/3", "/shipbuild/end/1", "/recovery/end/3"]);
     await onGetShip(details({ api_kdock_id: ["3"] }));
     expect(clearedIds()).toEqual(["/shipbuild/end/3"]);
+  });
+
+  it("受け取ったドックの未発火Queueを削除する（#1844）", async () => {
+    displaying([]);
+    await onGetShip(details({ api_kdock_id: ["3"] }));
+    expect(deleteSlot).toHaveBeenCalledWith(EntryType.SHIPBUILD, "3");
   });
 });

--- a/tests/notification-clear-on-collection.spec.ts
+++ b/tests/notification-clear-on-collection.spec.ts
@@ -38,8 +38,8 @@ const details = (formData: Record<string, string[]>) =>
 const clearedIds = () => clear.mock.calls.map(([id]) => id);
 
 // 回収操作（遠征結果回収・建造艦受取）で、対象の艦隊/ドックの通知だけが消えることと、
-// 未発火の Queue も削除されること（#1844: 通知表示前に回収すると後から完了通知が出て
-// 残り続ける問題の再発防止）を検証する。
+// 未発火の Queue も削除されることを検証する（#1844 の再発防止。機構は kcsapi.ts の
+// retireSlot のコメント参照）。
 // 通知IDは /{type}/{trigger}/{deck|dock} 形式（tests/notification-id.spec.ts 参照）。
 describe("onMissionResult", () => {
   let deleteSlot: ReturnType<typeof vi.spyOn>;

--- a/tests/queue-dedupe-on-speedchange-and-start.spec.ts
+++ b/tests/queue-dedupe-on-speedchange-and-start.spec.ts
@@ -70,6 +70,17 @@ describe("修復・建造の高速化剤使用(speedchange)検知", () => {
     expect(deleteSlot).toHaveBeenCalledWith("shipbuild", "3");
     expect(deleteSlot).toHaveBeenCalledTimes(1);
   });
+
+  // 修復側と同様、この経路も完了通知が出ないため通知の掃除まで担う（従来は非対称に漏れていた）
+  it("onShipbuildHighspeed: 対象ドックの表示中の建造通知を消し、他は消さない", async () => {
+    getAll.mockResolvedValueOnce({
+      "/shipbuild/start/3": true,
+      "/shipbuild/start/1": true,
+      "/recovery/start/3": true,
+    });
+    await onShipbuildHighspeed(details({ api_kdock_id: ["3"] }));
+    expect(clear.mock.calls.map(([id]) => id)).toEqual(["/shipbuild/start/3"]);
+  });
 });
 
 describe("遠征開始時の重複排除", () => {


### PR DESCRIPTION
Fixes #1844

## 問題

遠征完了通知が表示される前に遠征を回収すると、後から表示される完了通知が自動では消去されず、手動消去設定では残り続ける。

## 原因

遠征結果の回収（`onMissionResult`）と建造艦の受取（`onGetShip`）は**表示中の通知を消すだけ**で、未発火の Queue を削除していなかった。

遠征の完了通知は #1811 対応で「終了1分前」（`Mission.EARLY_RETURN_MARGIN`）にスケジュールされ、cron alarm は30秒粒度のため、完了通知の表示前にユーザーが回収できるタイミングが存在する。そこで回収すると Queue が残り、後から alarm 経由で回収済み遠征の完了通知が発行されていた（報告の再現率100%とも整合）。

## 修正

「スロットの用事が済んだら未発火 Queue と表示中の通知を両方消す」操作を `retireSlot` ヘルパーとして定義し、回収・即完了系ハンドラから呼ぶ。

- `onMissionResult`（遠征回収）・`onGetShip`（建造艦受取）: Queue 削除が漏れていたのを修正（#1844 の本丸）。通知表示後の通常の回収では QueueWatcher が Queue を削除済みのため no-op で、挙動は変わらない
- `onRecoveryHighspeed`（高速修復）: 従来から両方消していたので `retireSlot` 呼び出しに置換のみ（挙動不変）
- `onShipbuildHighspeed`（高速建造）: 従来 Queue 削除のみで、修復側と非対称に建造の開始通知が残り得たため、あわせて通知掃除も行うようにした（この経路は完了通知が出ないため、開始通知には他に自動で消える機会がない）

#1844 自体が「Queue 削除と通知掃除の片方だけ呼ぶ」という不変条件の破れだったので、定義を1箇所に集約して再発しにくくしている。

## テスト

- `notification-clear-on-collection.spec.ts`: 回収/受取時に未発火 Queue が削除される検証を2件追加
- `queue-dedupe-on-speedchange-and-start.spec.ts`: 高速建造時に建造通知が掃除される検証を追加（修復側と対称）

typecheck / lint / テスト306件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dzowSExdMuy1rAATGZYWe