### PR TITLE
拡張アイコンに完了が最も近いタイマーの残り時間をバッジ表示する

### DIFF
--- a/src/controllers/Cron/QueueWatcher.ts
+++ b/src/controllers/Cron/QueueWatcher.ts
@@ -2,6 +2,7 @@ import { Logger } from "../../logger";
 import Queue from "../../models/Queue";
 import { TriggerType } from "../../models/entry";
 import { NotificationService } from "../../services/NotificationService";
+import { BadgeService } from "../../services/BadgeService";
 
 // Once の実行を直列化するための Promise チェーン。
 // 多重起動で同一 Queue を並行チェックすると二重通知の恐れがあるため、前回の実行完了を待ってから次を実行する。
@@ -31,5 +32,12 @@ async function check() {
     } catch (e) {
       log.warn("Once:", e);
     }
+  }
+  // 完了処理を終えた残りのQueueをバッジ表示に反映する。
+  // バッジ更新の失敗が通知処理の結果を壊さないよう、ここで握ってログだけ残す。
+  try {
+    await new BadgeService().update(queues);
+  } catch (e) {
+    log.warn("バッジ更新に失敗", e);
   }
 }

--- a/src/services/BadgeService.ts
+++ b/src/services/BadgeService.ts
@@ -1,0 +1,37 @@
+import Queue from "../models/Queue";
+import { EntryType } from "../models/entry";
+
+// 種別ごとのバッジ背景色。任務トラッカー（QuestTrackerList.tsx の CATEGORY_COLORS）と
+// 意図的に同じ配色（v3 dashboard.scss 準拠）を使っている。
+const BADGE_COLORS: Partial<Record<EntryType, string>> = {
+  [EntryType.MISSION]: "#5755d9",
+  [EntryType.RECOVERY]: "#56c2c1",
+  [EntryType.SHIPBUILD]: "#fa9836",
+};
+const DEFAULT_BADGE_COLOR = "gray";
+
+/**
+ * 拡張機能アイコンのバッジ表示を担うサービス。
+ * 完了が最も近いQueueの残り時間を、種別ごとの背景色でバッジに表示する。
+ */
+export class BadgeService {
+  /**
+   * Queueの一覧からバッジ表示を更新する。
+   * 期限前のQueueが無ければバッジを消す。
+   */
+  public async update(queues: Queue[]): Promise<void> {
+    const nearest = queues
+      .filter((queue) => queue.scheduled > Date.now())
+      .sort((prev, next) => prev.scheduled - next.scheduled)[0];
+    if (!nearest) {
+      await chrome.action.setBadgeText({ text: "" });
+      return;
+    }
+    const { hours, minutes } = nearest.remain();
+    const text = hours > 0 ? `${hours}h` : `${minutes}m`;
+    await chrome.action.setBadgeText({ text });
+    await chrome.action.setBadgeBackgroundColor({
+      color: BADGE_COLORS[nearest.type] ?? DEFAULT_BADGE_COLOR,
+    });
+  }
+}

--- a/tests/badge-service.spec.ts
+++ b/tests/badge-service.spec.ts
@@ -1,0 +1,74 @@
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+
+// jstorm の Model が chrome.runtime を参照するため、import より前にスタブする
+const { setBadgeText, setBadgeBackgroundColor } = vi.hoisted(() => {
+  const setBadgeText = vi.fn().mockResolvedValue(undefined);
+  const setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = {
+    runtime: { getURL: (p: string) => p },
+    action: { setBadgeText, setBadgeBackgroundColor },
+  };
+  return { setBadgeText, setBadgeBackgroundColor };
+});
+
+import Queue from "../src/models/Queue";
+import { EntryType } from "../src/models/entry";
+import { BadgeService } from "../src/services/BadgeService";
+
+const H = 60 * 60 * 1000;
+const M = 60 * 1000;
+
+const fakeQueue = (type: EntryType, scheduled: number) => Queue.new({ type, scheduled });
+
+// バッジは「完了が最も近いQueueの残り時間＋種別色」を表示する契約であることを検証する。
+describe("BadgeService.update", () => {
+  beforeEach(() => {
+    setBadgeText.mockClear();
+    setBadgeBackgroundColor.mockClear();
+    // 残り時間の文字列を決定的にするため、現在時刻を固定する
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("期限前のQueueが無ければバッジを消す", async () => {
+    await new BadgeService().update([fakeQueue(EntryType.MISSION, -1000)]);
+    expect(setBadgeText).toHaveBeenCalledWith({ text: "" });
+    expect(setBadgeBackgroundColor).not.toHaveBeenCalled();
+  });
+
+  it("残り1時間以上は時間単位で表示する", async () => {
+    await new BadgeService().update([fakeQueue(EntryType.MISSION, 2 * H + 30 * M)]);
+    expect(setBadgeText).toHaveBeenCalledWith({ text: "2h" });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: "#5755d9" });
+  });
+
+  it("残り1時間未満は分単位で表示する", async () => {
+    await new BadgeService().update([fakeQueue(EntryType.RECOVERY, 35 * M)]);
+    expect(setBadgeText).toHaveBeenCalledWith({ text: "35m" });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: "#56c2c1" });
+  });
+
+  it("複数のQueueがあれば完了が最も近いものを表示する", async () => {
+    await new BadgeService().update([
+      fakeQueue(EntryType.MISSION, 3 * H),
+      fakeQueue(EntryType.SHIPBUILD, 40 * M),
+      fakeQueue(EntryType.RECOVERY, 2 * H),
+    ]);
+    expect(setBadgeText).toHaveBeenCalledWith({ text: "40m" });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: "#fa9836" });
+  });
+
+  it("期限を過ぎたQueueは表示対象から除外する", async () => {
+    await new BadgeService().update([
+      fakeQueue(EntryType.MISSION, -1000),
+      fakeQueue(EntryType.FATIGUE, 10 * M),
+    ]);
+    expect(setBadgeText).toHaveBeenCalledWith({ text: "10m" });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: "gray" });
+  });
+});

--- a/tests/queue-watcher.spec.ts
+++ b/tests/queue-watcher.spec.ts
@@ -17,6 +17,10 @@ vi.mock("../src/models/Queue", () => ({ default: { list } }));
 vi.mock("../src/services/NotificationService", () => ({
   NotificationService: vi.fn(() => ({ notify, clear })),
 }));
+const { badgeUpdate } = vi.hoisted(() => ({ badgeUpdate: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../src/services/BadgeService", () => ({
+  BadgeService: vi.fn(() => ({ update: badgeUpdate })),
+}));
 
 import { Once } from "../src/controllers/Cron/QueueWatcher";
 
@@ -32,6 +36,8 @@ describe("QueueWatcher.Once", () => {
     list.mockReset();
     notify.mockClear();
     clear.mockClear();
+    badgeUpdate.mockClear();
+    badgeUpdate.mockResolvedValue(undefined);
   });
 
   it("期限を過ぎた Queue は通知して削除し、期限前の Queue には触らない", async () => {
@@ -51,6 +57,21 @@ describe("QueueWatcher.Once", () => {
     list.mockResolvedValueOnce([due]);
     await Once();
     expect(clear).toHaveBeenCalledWith("/mission/start/1");
+  });
+
+  it("チェックの最後に全Queueを渡してバッジ表示を更新する", async () => {
+    const due = queue(Date.now() - 1000);
+    const pending = queue(Date.now() + 60 * 1000);
+    list.mockResolvedValueOnce([due, pending]);
+    await Once();
+    expect(badgeUpdate).toHaveBeenCalledTimes(1);
+    expect(badgeUpdate).toHaveBeenCalledWith([due, pending]);
+  });
+
+  it("バッジ更新の失敗はチェック全体を失敗させない", async () => {
+    list.mockResolvedValueOnce([queue(Date.now() + 60 * 1000)]);
+    badgeUpdate.mockRejectedValueOnce(new Error("action unavailable"));
+    await expect(Once()).resolves.toBeUndefined();
   });
 
   it("実行は直列化され、前の実行が完了するまで次のチェックは始まらない", async () => {


### PR DESCRIPTION
## Summary
- 遠征・入渠・建造・疲労のQueueのうち、完了が最も近いものの残り時間を拡張機能アイコンのバッジに表示する（v3 の `updateBadge` 相当をMV3向けに再実装）
- 表示形式・配色は v3 の `Cron/index.ts`（`updateBadge`）に準拠：1時間以上は `{h}h`、それ未満は `{m}m`。遠征`#5755d9`・入渠`#56c2c1`・建造`#fa9836`・それ以外`gray`。対象のQueueが無ければバッジを消す
- `QueueWatcher.check()` の最後、通知処理後に `BadgeService.update()` を呼ぶ。バッジ更新の失敗が通知処理の結果を壊さないよう、失敗はログのみで握る

## 実装時の判断
- 同じ配色は任務トラッカー（`QuestTrackerList.tsx` の `CATEGORY_COLORS`、同じくv3 dashboard.scss準拠）にも存在する。値を共有する定数への切り出しも検討したが、Tailwindの`bg-[...]`（任意値クラス）はビルド時の静的スキャンでクラス文字列を検出する仕組みのため、動的に値を差し込むとクラス生成が壊れる。3値程度の重複解消のために任務トラッカー側の実装（Tailwindクラス→インラインstyle）まで変えるのは対価が大きいと判断し、独立した定数のまま維持した（v3自身もSCSS変数とJSのswitch文で同種の重複を許容していた前例に倣った）。`BadgeService.ts` に意図的な重複である旨のコメントを残している

## Test plan
- [x] `tsc --noEmit` 通過
- [x] `vitest run` 全件（435件）通過。追加分は `tests/badge-service.spec.ts`（5件）と `tests/queue-watcher.spec.ts` への統合2件
- [x] 実機（dogfoodビルド）で拡張アイコンをリロードし、バッジが表示されることを確認