### PR TITLE
fix(damage-snapshot): 大破進撃防止窓の交戦回数に航空戦・空襲戦マスを含める

### DIFF
--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -21,6 +21,7 @@ import {
   onMidnightBattleStarted,
   onSpMidnightBattleStarted,
   onCombinedSpMidnightBattleStarted,
+  onAirBattleStarted,
 } from "./kcsapi";
 import { onQuestStart, onQuestStop, onQuestComplete, onPracticePrepare, onSortiePrepare } from "./quest";
 import { ScriptingService } from "../../services/ScriptingService";
@@ -52,6 +53,10 @@ onBeforeRequest.on(["/kcsapi/api_req_battle_midnight/battle"], onMidnightBattleS
 onBeforeRequest.on(["/kcsapi/api_req_battle_midnight/sp_midnight"], onSpMidnightBattleStarted); // 開幕夜戦マスの戦闘が開始されたとき(#1764)
 // 連合艦隊の開幕夜戦。パス未観測のため予防的登録（実機確認まで挙動は未保証）(#1764)
 onBeforeRequest.on(["/kcsapi/api_req_combined_battle/sp_midnight"], onCombinedSpMidnightBattleStarted);
+onBeforeRequest.on(["/kcsapi/api_req_sortie/airbattle"], onAirBattleStarted); // 航空戦マスの戦闘が開始されたとき(#1854)
+onBeforeRequest.on(["/kcsapi/api_req_sortie/ld_airbattle"], onAirBattleStarted); // 空襲戦マス（通常艦隊）の戦闘が開始されたとき(#1854)
+onBeforeRequest.on(["/kcsapi/api_req_combined_battle/ld_airbattle"], onAirBattleStarted); // 空襲戦マス（連合艦隊）の戦闘が開始されたとき(#1854)
+onBeforeRequest.on(["/kcsapi/api_req_map/start_air_base"], onAirBattleStarted); // イベント海域の基地航空戦が開始されたとき(#1854)
 
 onBeforeRequest.on([
   '/kcsapi/api_req_kousyou/createship',

--- a/src/controllers/WebRequest/index.ts
+++ b/src/controllers/WebRequest/index.ts
@@ -56,7 +56,6 @@ onBeforeRequest.on(["/kcsapi/api_req_combined_battle/sp_midnight"], onCombinedSp
 onBeforeRequest.on(["/kcsapi/api_req_sortie/airbattle"], onAirBattleStarted); // 航空戦マスの戦闘が開始されたとき(#1854)
 onBeforeRequest.on(["/kcsapi/api_req_sortie/ld_airbattle"], onAirBattleStarted); // 空襲戦マス（通常艦隊）の戦闘が開始されたとき(#1854)
 onBeforeRequest.on(["/kcsapi/api_req_combined_battle/ld_airbattle"], onAirBattleStarted); // 空襲戦マス（連合艦隊）の戦闘が開始されたとき(#1854)
-onBeforeRequest.on(["/kcsapi/api_req_map/start_air_base"], onAirBattleStarted); // イベント海域の基地航空戦が開始されたとき(#1854)
 
 onBeforeRequest.on([
   '/kcsapi/api_req_kousyou/createship',

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -189,11 +189,8 @@ export async function onCombinedSpMidnightBattleStarted([details]: chrome.webReq
 }
 
 // 航空戦マス（1-6等）・空襲戦マス（7-5・5-2・E1等）・イベント海域の基地航空戦の戦闘開始時。
-// 昼戦と同じく連戦数に算入する。夜戦に継続するマスではないため midnight は立てない（#1854）。
-// 通常艦隊の航空戦・空襲戦（api_req_sortie/airbattle・ld_airbattle）は kcsapi Recorder の実データで
-// 裏取り済み：どちらも1回のみ発火し api_formation を持ち、結果は api_req_sortie/battleresult に乗る。
-// 連合艦隊の空襲戦（api_req_combined_battle/ld_airbattle）とイベント基地航空戦（api_req_map/start_air_base）
-// は実データ未観測（v3実装のパス名を踏襲した防御的登録）。実機で観測できたら本コメントを更新すること。
+// 昼戦と同じく連戦数に算入する。夜戦に継続するマスではないため midnight は立てない。結果は他の
+// 戦闘同様 api_req_sortie/battleresult で返るため専用の result ハンドラは不要（#1854）。
 export async function onAirBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   await startBattle(details);
 }

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -188,9 +188,9 @@ export async function onCombinedSpMidnightBattleStarted([details]: chrome.webReq
   await startBattle(details, { midnight: true });
 }
 
-// 航空戦マス（1-6等）・空襲戦マス（7-5・5-2・E1等）・イベント海域の基地航空戦の戦闘開始時。
-// 昼戦と同じく連戦数に算入する。夜戦に継続するマスではないため midnight は立てない。結果は他の
-// 戦闘同様 api_req_sortie/battleresult で返るため専用の result ハンドラは不要（#1854）。
+// 航空戦マス（1-6等）・空襲戦マス（7-5・5-2等）の戦闘開始時。昼戦と同じく連戦数に算入する。
+// 夜戦に継続するマスではないため midnight は立てない。結果は他の戦闘同様 api_req_sortie/battleresult
+// で返るため専用の result ハンドラは不要（#1854）。
 export async function onAirBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   await startBattle(details);
 }

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -188,8 +188,12 @@ export async function onCombinedSpMidnightBattleStarted([details]: chrome.webReq
   await startBattle(details, { midnight: true });
 }
 
-// 航空戦マス（1-6等）・空襲戦マス（通常/連合艦隊、7-5・5-2・E1等）・イベント海域の基地航空戦の
-// 戦闘開始時。昼戦と同じく連戦数に算入する。夜戦に継続するマスではないため midnight は立てない（#1854）。
+// 航空戦マス（1-6等）・空襲戦マス（7-5・5-2・E1等）・イベント海域の基地航空戦の戦闘開始時。
+// 昼戦と同じく連戦数に算入する。夜戦に継続するマスではないため midnight は立てない（#1854）。
+// 通常艦隊の航空戦・空襲戦（api_req_sortie/airbattle・ld_airbattle）は kcsapi Recorder の実データで
+// 裏取り済み：どちらも1回のみ発火し api_formation を持ち、結果は api_req_sortie/battleresult に乗る。
+// 連合艦隊の空襲戦（api_req_combined_battle/ld_airbattle）とイベント基地航空戦（api_req_map/start_air_base）
+// は実データ未観測（v3実装のパス名を踏襲した防御的登録）。実機で観測できたら本コメントを更新すること。
 export async function onAirBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   await startBattle(details);
 }

--- a/src/controllers/WebRequest/kcsapi.ts
+++ b/src/controllers/WebRequest/kcsapi.ts
@@ -188,6 +188,12 @@ export async function onCombinedSpMidnightBattleStarted([details]: chrome.webReq
   await startBattle(details, { midnight: true });
 }
 
+// 航空戦マス（1-6等）・空襲戦マス（通常/連合艦隊、7-5・5-2・E1等）・イベント海域の基地航空戦の
+// 戦闘開始時。昼戦と同じく連戦数に算入する。夜戦に継続するマスではないため midnight は立てない（#1854）。
+export async function onAirBattleStarted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
+  await startBattle(details);
+}
+
 // 戦闘終了時
 export async function onBattleResulted([details]: chrome.webRequest.OnBeforeRequestDetails[]) {
   log.debug("onBattleResulted", details);

--- a/tests/battle-start-handlers.spec.ts
+++ b/tests/battle-start-handlers.spec.ts
@@ -22,6 +22,7 @@ import {
   onBattleStarted,
   onCombinedBattleStarted,
   onSpMidnightBattleStarted,
+  onAirBattleStarted,
   onMapNext,
 } from "../src/controllers/WebRequest/kcsapi";
 
@@ -63,6 +64,17 @@ describe("戦闘開始系ハンドラ", () => {
     damageSnapshotUser.mockResolvedValue({ keepUntilNextShow: true });
     await onBattleStarted(details({ api_formation: ["1"] }));
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("onAirBattleStarted: 航空戦・空襲戦マスでも通常戦闘と同様にLogbookへ戦闘開始を記録する", async () => {
+    await onAirBattleStarted(details({ api_formation: ["1"] }));
+    expect(start).toHaveBeenCalledWith("1");
+    expect(midnight).not.toHaveBeenCalled();
+  });
+
+  it("onAirBattleStarted: formData欠落時は空文字でstartを呼び、例外にならない", async () => {
+    await expect(onAirBattleStarted(details())).resolves.not.toThrow();
+    expect(start).toHaveBeenCalledWith("");
   });
 });
 

--- a/tests/battle-start-handlers.spec.ts
+++ b/tests/battle-start-handlers.spec.ts
@@ -66,9 +66,17 @@ describe("戦闘開始系ハンドラ", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("onAirBattleStarted: 航空戦・空襲戦マスでも通常戦闘と同様にLogbookへ戦闘開始を記録する", async () => {
-    await onAirBattleStarted(details({ api_formation: ["1"] }));
-    expect(start).toHaveBeenCalledWith("1");
+  // formation値は kcsapi Recorder で実際に観測した航空戦(1-6)のformDataを反映（#1854）
+  it("onAirBattleStarted: 航空戦マスでも通常戦闘と同様にLogbookへ戦闘開始を記録する", async () => {
+    await onAirBattleStarted(details({ api_formation: ["3"], api_recovery_type: ["0"] }));
+    expect(start).toHaveBeenCalledWith("3");
+    expect(midnight).not.toHaveBeenCalled();
+  });
+
+  // formation値は kcsapi Recorder で実際に観測した空襲戦(5-2)のformDataを反映（#1854）
+  it("onAirBattleStarted: 空襲戦マスでも通常戦闘と同様にLogbookへ戦闘開始を記録する", async () => {
+    await onAirBattleStarted(details({ api_formation: ["6"], api_recovery_type: ["0"] }));
+    expect(start).toHaveBeenCalledWith("6");
     expect(midnight).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

大破進撃防止機能の交戦回数（連戦数）が、航空戦マス（1-6等）・空襲戦マス
（7-5・5-2等）を素通りしてカウントされていなかった問題を修正する。

## Changes

- `onAirBattleStarted` を追加し、以下3エンドポイントで通常戦闘と同じ連戦数
  カウント処理（`startBattle`）を行うようにした。
  - `api_req_sortie/airbattle`（航空戦）
  - `api_req_sortie/ld_airbattle`（空襲戦・通常艦隊）
  - `api_req_combined_battle/ld_airbattle`（空襲戦・連合艦隊）

## Verification

- 航空戦（1-6）・空襲戦（5-2、通常艦隊）の2つは kcsapi Recorder で実出撃を
  録って裏取り済み。両方とも単発発火・`api_formation` あり・結果は既存の
  `api_req_sortie/battleresult` で返ることを確認した。修正前ビルドで実際に
  交戦数カウント漏れ（3戦→2戦、0戦のまま）が再現することも確認済み。
- 連合艦隊の空襲戦（`api_req_combined_battle/ld_airbattle`）は実データでの
  裏取りはできていない（v3実装のパス名をそのまま踏襲、未検証）。
- `api_req_map/start_air_base`（基地航空隊出撃）は当初 v3 のパス名を踏襲して
  同様に実装したが、6-5 での実出撃検証で「同じマスの本来の戦闘開始APIに
  `api_req_map/next` を挟まず先行して発火する」ことが分かった。両方をカウント
  すると1戦が2戦に水増しされるため、今回の対象から除外した。
- typecheck / lint / vitest（該当spec 10件）はいずれもpass。

Closes #1854